### PR TITLE
Advanced path resolution in TypeScript 2.0

### DIFF
--- a/packages/af-webpack/src/getConfig.js
+++ b/packages/af-webpack/src/getConfig.js
@@ -25,6 +25,7 @@ import { applyWebpackConfig } from './applyWebpackConfig';
 import readRc from './readRc';
 import { stripLastSlash } from './utils';
 
+const TsConfigPathsPlugin = require('awesome-typescript-loader').TsConfigPathsPlugin;
 const debug = require('debug')('af-webpack:getConfig');
 
 if (process.env.DISABLE_TSLINT) {
@@ -336,6 +337,7 @@ export default function getConfig(opts = {}) {
         '@babel/runtime': dirname(require.resolve('@babel/runtime/package')),
         ...opts.alias,
       },
+      plugins: [new TsConfigPathsPlugin()]
     },
     module: {
       rules: [


### PR DESCRIPTION
支持tsconfig.json中使用路径映射
`    "paths": {
      "ApiService": [ "src/services/service-proxies.ts" ]
    },
`