### PR TITLE
Add some eslint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,10 +2,16 @@
   "parser": "babel-eslint",
   "extends": "airbnb",
   "env": {
+    "browser": true,
     "mocha": true
   },
   "rules": {
     "jsx-a11y/href-no-hash": [0],
+    "jsx-a11y/click-events-have-key-events": [0],
+    "jsx-a11y/anchor-is-valid": [ "error", {
+      "components": [ "Link" ],
+      "specialLink": [ "to" ]
+    }],
     "generator-star-spacing": [0],
     "consistent-return": [0],
     "react/react-in-jsx-scope": [0],
@@ -38,7 +44,8 @@
     "arrow-parens": [0],
     "space-before-function-paren": [0],
     "no-useless-escape": [0],
-    "object-curly-newline": [0]
+    "object-curly-newline": [0],
+    "no-restricted-globals": ["self"]
   },
   "parserOptions": {
     "ecmaFeatures": {


### PR DESCRIPTION
Add eslint rules to fix warnings below:
- [eslint] 'window' is  not defined. (no-undef).
- [eslint] The href attribute is required on an anchor. Provide a valid, navigable address as the href value. (jsx-a11y/anchor-is-valid).
- [eslint] Visible, non-interactive elements with click handlers must have at least one keyboard listener. (jsx-a11y/click-events-have-key-events).
- [eslint] Unexpected use of 'self'. (no-restricted-globals).