### PR TITLE
update cssModules config

### DIFF
--- a/packages/af-webpack/src/getConfig.js
+++ b/packages/af-webpack/src/getConfig.js
@@ -59,7 +59,7 @@ export default function getConfig(opts = {}) {
     ? {}
     : {
         modules: true,
-        localIdentName: '[local]___[hash:base64:5]',
+        localIdentName: isDev ? '[name]__[local]___[hash:base64:5]' : '[local]___[hash:base64:5]',
       };
   const lessOptions = {
     modifyVars: theme,


### PR DESCRIPTION
修改`css-modules`hash规则
在开发环境下由原来`[local]___[hash:base64:5]`修改为`[name]__[local]___[hash:base64:5]`
其他环境不变