### PR TITLE
fix(af-webpack): image loader match failed when have directory named *.html

### DIFF
--- a/packages/af-webpack/src/getConfig.js
+++ b/packages/af-webpack/src/getConfig.js
@@ -410,7 +410,7 @@ export default function getConfig(opts = {}) {
             ]),
         {
           exclude: [
-            /\.html|ejs$/,
+            /\.(html|ejs)$/,
             /\.json$/,
             /\.(js|jsx|ts|tsx)$/,
             /\.(css|less|scss|sass)$/,


### PR DESCRIPTION
Close #152 