### PR TITLE
feat(af-webpack): enable babel cache, and support disable it with BABEL_CACHE=none

### DIFF
--- a/packages/af-webpack/src/getConfig.js
+++ b/packages/af-webpack/src/getConfig.js
@@ -267,8 +267,7 @@ export default function getConfig(opts = {}) {
 
   const babelOptions = {
     ...(opts.babel || babelConfig),
-    // 性能提升有限，但会带来一系列答疑的工作量，所以不开放
-    cacheDirectory: false,
+    cacheDirectory: process.env.BABEL_CACHE !== 'none',
     babelrc: !!process.env.BABELRC,
   };
   babelOptions.plugins = [


### PR DESCRIPTION
以 antd-admin 为例，

* 开 babel cache 26s
* 关 babel cache 32s
