### PR TITLE
Fixed MIME type error

### DIFF
--- a/packages/umi-plugin-dll/src/index.js
+++ b/packages/umi-plugin-dll/src/index.js
@@ -47,6 +47,7 @@ export default function(api, opts = {}) {
         const content = existsSync(dllFile)
           ? readFileSync(dllFile, 'utf-8')
           : `console.error('File pages/.umi/dll/umi.dll.js not found, please reload after it\'s ready.');`;
+        res.setHeader('Content-Type', 'text/javascript');
         res.end(content);
       } else {
         next();


### PR DESCRIPTION
Refused to execute script from 'http://localhost:55943/__umi.dll.js' because its MIME type ('') is not executable, and strict MIME type checking is enabled.