### PR TITLE
feat(umi-plugin-dva): config dva via dva.js

### DIFF
--- a/examples/with-dva/src/dva.js
+++ b/examples/with-dva/src/dva.js
@@ -1,0 +1,15 @@
+import { message } from 'antd';
+
+export function config() {
+  return {
+    onError(err) {
+      err.preventDefault();
+      message.error(err.message);
+    },
+    initialState: {
+      global: {
+        text: 'hi umi + dva',
+      },
+    },
+  };
+}

--- a/examples/with-dva/src/plugins/onError.js
+++ b/examples/with-dva/src/plugins/onError.js
@@ -1,8 +1,0 @@
-import { message } from 'antd';
-
-export default {
-  onError(err) {
-    err.preventDefault();
-    message.error(err.message);
-  },
-};

--- a/packages/umi-plugin-dva/template/DvaContainer.js
+++ b/packages/umi-plugin-dva/template/DvaContainer.js
@@ -2,9 +2,11 @@ import { Component } from 'react';
 import dva from 'dva';
 import createLoading from 'dva-loading';
 
-const app = dva({
+let app = dva({
   history: window.g_history,
+  <%= ExtendDvaConfig %>
 });
+<%= EnhanceApp %>
 window.g_app = app;
 app.use(createLoading());
 <%= RegisterPlugins %>


### PR DESCRIPTION
Close #261 

## 如何配置 onError、initialState 等 hook？

新建 src/dva.js，通过导出的 config 方法来返回额外配置项，比如：

```js
import { message } from 'antd';

export function config() {
  return {
    onError(err) {
      err.preventDefault();
      message.error(err.message);
    },
    initialState: {
      global: {
        text: 'hi umi + dva',
      },
    },
  };
}
```
