### PR TITLE
feat(af-webpack): support opts.tsConfigFile and resolve default tsconfig.json under cwd

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "scripts": {
     "build": "node scripts/build.js",
     "changelog": "lerna-changelog",
-    "test": "./packages/umi-test/bin/umi-test.js --coverage",
-    "debug": "./packages/umi-test/bin/umi-test.js",
+    "test": "umi-test --coverage",
+    "debug": "umi-test",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "lint": "eslint --ext .js packages",
     "precommit": "lint-staged",
@@ -40,6 +40,7 @@
     "rimraf": "^2.6.2",
     "shelljs": "^0.8.1",
     "through2": "^2.0.3",
+    "umi-test": "^0.5.3",
     "vinyl-fs": "^3.0.2"
   }
 }

--- a/packages/af-webpack/src/getConfig.js
+++ b/packages/af-webpack/src/getConfig.js
@@ -436,6 +436,8 @@ export default function getConfig(opts = {}) {
             {
               loader: require.resolve('awesome-typescript-loader'),
               options: {
+                configFileName:
+                  opts.tsConfigFile || join(opts.cwd, 'tsconfig.json'),
                 transpileOnly: true,
               },
             },


### PR DESCRIPTION
Changes:

1. 如果有指定 APP_ROOT，会从 APP_ROOT 下找 tsconfig.json
2. 支持在 .webpackrc 中通过 tsConfigFile 配置 tsconfig.json 的路径
