### PR TITLE
feat(af-webpack):add progress-bar-webpack-plugin for indicating progress of build process

### DIFF
--- a/packages/af-webpack/package.json
+++ b/packages/af-webpack/package.json
@@ -43,6 +43,7 @@
     "postcss": "^6.0.11",
     "postcss-flexbugs-fixes": "^3.2.0",
     "postcss-loader": "^2.0.6",
+    "progress-bar-webpack-plugin": "^1.11.0",
     "react-dev-utils": "^5.0.0",
     "react-error-overlay": "^3.0.0",
     "requireindex": "^1.1.0",

--- a/packages/af-webpack/src/getConfig.js
+++ b/packages/af-webpack/src/getConfig.js
@@ -14,6 +14,7 @@ import deprecate from 'deprecate';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 import HTMLWebpackPlugin from 'html-webpack-plugin';
+import ProgressPlugin from 'progress-bar-webpack-plugin';
 import { sync as resolveSync } from 'resolve';
 import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import uglifyJSConfig from './defaultConfigs/uglifyJS';
@@ -554,6 +555,7 @@ export default function getConfig(opts = {}) {
           context: __dirname,
         },
       }),
+      new ProgressPlugin(),
       ...(process.env.TS_TYPECHECK ? [new ForkTsCheckerWebpackPlugin()] : []),
       ...(opts.ignoreMomentLocale
         ? [new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)]


### PR DESCRIPTION
As the title said, when using `ant-design-pro-cli` with `npm run start`, the console prints nothing but:

```
Starting the development server...

[babel-plugin-dva-hmr][INFO] got routerPath ./router

```

which is not very convenient to get the progress of build process, so how about add [progress-bar-webpack-plugin](https://www.npmjs.com/package/progress-bar-webpack-plugin) to webpack configuration?