### PR TITLE
add help command

### DIFF
--- a/packages/umi/bin/umi.js
+++ b/packages/umi/bin/umi.js
@@ -46,8 +46,7 @@ function help(aliasedScript) {
   let usage = "\nUsage: umi <command>\n";
   let helpArea = "";
   for(var cmd in cmds) {
-    let space = 25 - cmd.length;
-    helpArea += ("  " + cmd + Array(space).join(' ') + cmds[cmd] + '\n');
+    helpArea += ("  " + cmd + Array(25 - cmd.length).join(' ') + cmds[cmd] + '\n');
   };
   console.log([usage,helpArea].join("\nCommands:\n"));
   aliasedScript !== "help" && console.log(`Unknown script ${chalk.cyan(aliasedScript)}.`);

--- a/packages/umi/bin/umi.js
+++ b/packages/umi/bin/umi.js
@@ -40,16 +40,16 @@ const cmds = {
   "dev": "start a development server",
   "help": "show help",
   "-v, --version": "show version",  
-}
+};
 
 function help(aliasedScript) {
-  let usage = "\nUsage: umi <command>\n"
+  let usage = "\nUsage: umi <command>\n";
   let helpArea = "";
   for(var cmd in cmds) {
-    let space = 25 - cmd.length
+    let space = 25 - cmd.length;
     helpArea += ("  " + cmd + Array(space).join(' ') + cmds[cmd] + '\n');
   };
-  console.log([usage,helpArea].join("\nCommands:\n"))
+  console.log([usage,helpArea].join("\nCommands:\n"));
   aliasedScript !== "help" && console.log(`Unknown script ${chalk.cyan(aliasedScript)}.`);
 }
 

--- a/packages/umi/bin/umi.js
+++ b/packages/umi/bin/umi.js
@@ -34,6 +34,26 @@ function runScript(script, args, isFork) {
   }
 }
 
+// Add help command
+const cmds = {
+  "build": "create a production build",
+  "dev": "start a development server",
+  "help": "show help",
+  "-v, --version": "show version",  
+}
+
+function help(aliasedScript) {
+  let usage = "\nUsage: umi <command>\n"
+  let helpArea = "";
+  for(var cmd in cmds) {
+    let space = 25 - cmd.length
+    helpArea += ("  " + cmd + Array(space).join(' ') + cmds[cmd] + '\n');
+  };
+  console.log([usage,helpArea].join("\nCommands:\n"))
+  aliasedScript !== "help" && console.log(`Unknown script ${chalk.cyan(aliasedScript)}.`);
+}
+
+// Script area
 const scriptAlias = {
   g: 'generate',
 };
@@ -56,6 +76,6 @@ switch (aliasedScript) {
     runScript(aliasedScript, args);
     break;
   default:
-    console.log(`Unknown script ${chalk.cyan(aliasedScript)}.`);
+    help(aliasedScript);
     break;
 }


### PR DESCRIPTION
A help command might make umi more friendly to the developers.

Comparing with the help command of [Gatsby][1] and [next][2]. In consideration, umi only own few commands now... add a simple help command temporarily.

+ `help() {}`:
```javascript
const cmds = {
    "build": "create a production build",
    "dev": "start a development server",
    "help": "show help",
    "-v, --version": "show version",
};

function help(aliasedScript) {
    let usage = "\nUsage: umi <command>\n";
    let helpArea = "";
    for(var cmd in cmds) {
        helpArea += ("  " + cmd + Array(25 - cmd.length).join(' ') + cmds[cmd] + '\n');
    };
    console.log([usage,helpArea].join("\nCommands:\n"));
    aliasedScript !== "help" && console.log(`Unknown script ${chalk.cyan(aliasedScript)}.`);
}
```
```shell
$ time ./umi.js help

real	0m0.133s
user	0m0.097s
sys	0m0.028s

```

+ `console.log()` the help field directly:  
```javascript
console.log(`                                                                                                
 Commands:                                                                                                   
   build                   create a production build                                                         
   dev                     start a development server                                                        
   help                    show help                                                                         
   -v, --version           show version                                                                      
 `)
```
```shell
$ time ./umi.js help

real	0m0.132s
user	0m0.098s
sys	0m0.026s

```

Using function just for logical.

[1]:https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-cli/src/create-cli.js#L16
[2]:https://github.com/zeit/next.js/blob/canary/bin/next#L39