### PR TITLE
feat(umi-build-dev): resolve local react and react-dom if specified in package.json

### DIFF
--- a/packages/umi-build-dev/src/getWebpackConfig.js
+++ b/packages/umi-build-dev/src/getWebpackConfig.js
@@ -94,6 +94,25 @@ export default function(service = {}) {
         require.resolve(join(cwd, 'node_modules/antd-mobile/package.json')),
       );
     }
+    if (preact) {
+      if (dependencies['preact-compat']) {
+        libAlias.react = libAlias['react-dom'] = dirname(
+          // eslint-disable-line
+          require.resolve(join(cwd, 'node_modules/preact-compat/package.json')),
+        );
+      }
+    } else {
+      if (dependencies.react) {
+        libAlias.react = dirname(
+          require.resolve(join(cwd, 'node_modules/react/package.json')),
+        );
+      }
+      if (dependencies['react-dom']) {
+        libAlias['react-dom'] = dirname(
+          require.resolve(join(cwd, 'node_modules/react-dom/package.json')),
+        );
+      }
+    }
   }
 
   const browserslist = webpackRCConfig.browserslist || defaultBrowsers;


### PR DESCRIPTION
Close #306 

1. 项目中有 react 和 react-dom 依赖，会取依赖的版本
2. preact 则取 preact-compat
