### PR TITLE
feat(umi-plugin-dva): built-in path-to-regexp and object-assign

### DIFF
--- a/packages/umi-plugin-dva/package.json
+++ b/packages/umi-plugin-dva/package.json
@@ -7,7 +7,9 @@
     "dva-immer": "^0.1.2",
     "dva-loading": "^2.0.0",
     "globby": "^7.1.1",
-    "lodash.uniq": "^4.5.0"
+    "lodash.uniq": "^4.5.0",
+    "object-assign": "^4.1.1",
+    "path-to-regexp": "^2.2.0"
   },
   "repository": {
     "type": "git",

--- a/packages/umi-plugin-dva/src/index.js
+++ b/packages/umi-plugin-dva/src/index.js
@@ -223,6 +223,8 @@ ReactDOM.render(React.createElement(
       ...memo.alias,
       dva: dirname(require.resolve('dva/package')),
       'dva-loading': require.resolve('dva-loading'),
+      'path-to-regexp': require.resolve('path-to-regexp'),
+      'object-assign': require.resolve('object-assign'),
     };
     return memo;
   });


### PR DESCRIPTION
内置常用依赖，其中使用 dva-immer 时肯定会用到 obect-assign 。