### PR TITLE
node_modules下的tsx也运行转义

### DIFF
--- a/packages/af-webpack/src/dev.js
+++ b/packages/af-webpack/src/dev.js
@@ -68,9 +68,6 @@ export default function dev({
           'access-control-allow-origin': '*',
         },
         publicPath: webpackConfig.output.publicPath,
-        watchOptions: {
-          ignored: /node_modules/,
-        },
         historyApiFallback,
         overlay: false,
         host: HOST,

--- a/packages/af-webpack/src/getConfig.js
+++ b/packages/af-webpack/src/getConfig.js
@@ -430,7 +430,8 @@ export default function getConfig(opts = {}) {
         },
         {
           test: /\.(ts|tsx)$/,
-          include: opts.cwd,
+         // include: opts.cwd,
+          exclude: /node_modules/,
           use: [
             ...babelUse,
             {

--- a/packages/af-webpack/src/getConfig.js
+++ b/packages/af-webpack/src/getConfig.js
@@ -431,7 +431,6 @@ export default function getConfig(opts = {}) {
         {
           test: /\.(ts|tsx)$/,
           include: opts.cwd,
-          exclude: /node_modules/,
           use: [
             ...babelUse,
             {

--- a/packages/af-webpack/src/getConfig.js
+++ b/packages/af-webpack/src/getConfig.js
@@ -424,7 +424,7 @@ export default function getConfig(opts = {}) {
         },
         {
           test: /\.(js|jsx)$/,
-          include: opts.cwd,
+          include: [opts.cwd,/packages/],
           exclude: /node_modules/,
           use: babelUse,
         },


### PR DESCRIPTION
取消node_modules排除，[让 tsx 也跟less一样，可以在第三方库里面载入](https://github.com/sorrycc/blog/issues/68)