### PR TITLE
feat(af-webpack): add preprocessor for config

### DIFF
--- a/packages/af-webpack/src/getUserConfig/index.js
+++ b/packages/af-webpack/src/getUserConfig/index.js
@@ -79,6 +79,7 @@ export default function getUserConfig(opts = {}) {
     cwd = process.cwd(),
     configFile = '.webpackrc',
     disabledConfigs = [],
+    preprocessor,
   } = opts;
 
   // TODO: 支持数组的形式？
@@ -103,6 +104,9 @@ export default function getUserConfig(opts = {}) {
     if (config.default) {
       config = config.default;
     }
+  }
+  if (typeof preprocessor === 'function') {
+    config = preprocessor(config);
   }
 
   // Context for validate function


### PR DESCRIPTION
支持对config在校验前做一些预处理， 方便roadhog之类的工具定制， 简化配置或者加些默认配置、自定义配置