### PR TITLE
fix: winPath problem with dynamic routes

### DIFF
--- a/packages/umi-build-dev/src/getRouteConfig.js
+++ b/packages/umi-build-dev/src/getRouteConfig.js
@@ -75,10 +75,7 @@ function getRoutesByConfig(routesConfigFile) {
 }
 
 function variablePath(path) {
-  return path
-    .split('/')
-    .map(path => path.replace(/^\$/, ':').replace(/\$$/, '?'))
-    .join('/');
+  return winPath(path).split('/').map(path => path.replace(/^\$/, ':').replace(/\$$/, '?')).join('/')
 }
 
 function getLayoutJS(paths, fullPath) {


### PR DESCRIPTION
动态路由配置 path为 $id，Close #381