### PR TITLE
fix(umi-plugin-dva): path-to-regexp's version is uncompatible with react-router@4

### DIFF
--- a/packages/umi-plugin-dva/package.json
+++ b/packages/umi-plugin-dva/package.json
@@ -9,7 +9,7 @@
     "globby": "^7.1.1",
     "lodash.uniq": "^4.5.0",
     "object-assign": "^4.1.1",
-    "path-to-regexp": "^2.2.0"
+    "path-to-regexp": "^1.7.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Close #378 