### PR TITLE
fix: import global css failed when have multiple global css files

### DIFF
--- a/packages/umi-build-dev/src/plugins/global-css.js
+++ b/packages/umi-build-dev/src/plugins/global-css.js
@@ -18,7 +18,7 @@ export default function(api) {
     if (cssImports.length) {
       return `
 ${memo}
-${cssImports.join('\\r\\n')}
+${cssImports.join('\r\n')}
       `.trim();
     } else {
       return memo;


### PR DESCRIPTION
https://github.com/umijs/umi/issues/390

在Windows下测试通过，不知道为什么要写
```js
‘\\r\\n’
```