### PR TITLE
new plugin: umi-plugin-es5-imcompatible-versions

### DIFF
--- a/packages/umi-plugin-es5-imcompatible-versions/README.md
+++ b/packages/umi-plugin-es5-imcompatible-versions/README.md
@@ -1,0 +1,19 @@
+# umi-plugin-es5-imcompatible-versions
+
+## Usage
+
+Install,
+
+```bash
+$ npm i umi-plugin-es5-imcompatible-versions --save-dev
+```
+
+Edit `.umirc.js`, 
+
+```js
+export default {
+  plugins: [
+    'umi-plugin-es5-imcompatible-versions',
+  ],
+}
+```

--- a/packages/umi-plugin-es5-imcompatible-versions/package.json
+++ b/packages/umi-plugin-es5-imcompatible-versions/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "umi-plugin-es5-imcompatible-versions",
+  "version": "0.0.1",
+  "main": "./lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/umijs/umi/tree/master/packages/umi-plugin-es5-imcompatible-versions"
+  },
+  "homepage": "https://github.com/umijs/umi/tree/master/packages/umi-plugin-es5-imcompatible-versions",
+  "authors": [
+    "chencheng <sorrycc@gmail.com> (https://github.com/sorrycc)"
+  ],
+  "bugs": {
+    "url": "https://github.com/umijs/umi/issues"
+  },
+  "files": [
+    "lib",
+    "src"
+  ],
+  "dependencies": {
+    "es5-imcompatible-versions": "^0.1.1",
+    "pkg-up": "^2.0.0",
+    "semver": "^5.5.0"
+  }
+}

--- a/packages/umi-plugin-es5-imcompatible-versions/src/index.js
+++ b/packages/umi-plugin-es5-imcompatible-versions/src/index.js
@@ -1,0 +1,45 @@
+import { dirname } from 'path';
+import pkgUp from 'pkg-up';
+import { satisfies } from 'semver';
+
+const pkgPathCache = {};
+const pkgCache = {};
+const {
+  config: { 'es5-imcompatible-versions': config },
+} = require('es5-imcompatible-versions/package');
+
+function getPkgPath(filePath) {
+  const dir = dirname(filePath);
+  if (dir in pkgPathCache) return pkgPathCache[dir];
+  pkgPathCache[dir] = pkgUp.sync(filePath);
+  return pkgPathCache[dir];
+}
+
+function shouldTransform(pkgPath) {
+  if (pkgPath in pkgCache) return pkgCache[pkgPath];
+  const { name, version } = require(pkgPath); // eslint-disable-line
+  pkgCache[pkgPath] = isMatch(name, version);
+  return pkgCache[pkgPath];
+}
+
+function isMatch(name, version) {
+  if (config[name]) {
+    return Object.keys(config[name]).some(sv => satisfies(version, sv));
+  } else {
+    return false;
+  }
+}
+
+export default api => {
+  api.register('modifyAFWebpackOpts', ({ memo }) => {
+    memo.extraBabelIncludes = [
+      ...(memo.extraBabelIncludes || []),
+      a => {
+        if (a.indexOf('node_modules') === -1) return false;
+        const pkgPath = getPkgPath(a);
+        return shouldTransform(pkgPath);
+      },
+    ];
+    return memo;
+  });
+};


### PR DESCRIPTION

Related links:

* https://github.com/umijs/umi-examples/tree/master/es5-imcompatible-versions
* https://github.com/umijs/es5-imcompatible-versions
* https://github.com/sorrycc/blog/issues/68
