### PR TITLE
feat: support redirect via config

### DIFF
--- a/packages/umi-build-dev/package.json
+++ b/packages/umi-build-dev/package.json
@@ -21,6 +21,7 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",
+    "lodash.remove": "^4.7.0",
     "mkdirp": "^0.5.1",
     "path-is-absolute": "^1.0.1",
     "postcss-plugin-px2rem": "^0.7.0",

--- a/packages/umi-build-dev/src/routes/getRouteConfigFromConfig.js
+++ b/packages/umi-build-dev/src/routes/getRouteConfigFromConfig.js
@@ -49,8 +49,8 @@ function patchRoute(route, pagesPath, parentRoutePath) {
   if (route.path && route.path.charAt(0) !== '/') {
     route.path = join(parentRoutePath, route.path);
   }
-  if (route.redirect) {
-    route.redirect = resolveComponent(pagesPath, route.redirect);
+  if (route.redirect && route.redirect.charAt(0) !== '/') {
+    route.redirect = join(parentRoutePath, route.redirect);
   }
   if (route.routes) {
     patchRoutes(route.routes, pagesPath, route.path);

--- a/packages/umi-build-dev/src/routes/getRouteConfigFromConfig.test.js
+++ b/packages/umi-build-dev/src/routes/getRouteConfigFromConfig.test.js
@@ -62,10 +62,23 @@ describe('getRoutesConfigFromConfig', () => {
     ]);
   });
 
-  it('add pages prefix to redirect', () => {
-    const routes = getRoute([{ path: '/a', redirect: 'A' }]);
+  it('relative redirect', () => {
+    const routes = getRoute([
+      { path: '/a' },
+      {
+        path: '/c',
+        routes: [{ path: '/d', redirect: '/f' }, { path: '/e', redirect: 'e' }],
+      },
+    ]);
     expect(routes).toEqual([
-      { path: '/a', redirect: './src/pages/A', exact: true },
+      { path: '/a', exact: true },
+      {
+        path: '/c',
+        routes: [
+          { path: '/d', exact: true, redirect: '/f' },
+          { path: '/e', exact: true, redirect: '/c/e' },
+        ],
+      },
     ]);
   });
 
@@ -106,7 +119,7 @@ describe('getRoutesConfigFromConfig', () => {
         path: '/a',
         routes: [{ path: '/a', component: './src/pages/A', exact: true }],
       },
-      { path: '/b', redirect: './src/pages/B', exact: true },
+      { path: '/b', redirect: '/B', exact: true },
       { path: '/c', routes: [] },
     ]);
   });

--- a/packages/umi-build-dev/src/routes/patchRoutes.js
+++ b/packages/umi-build-dev/src/routes/patchRoutes.js
@@ -1,13 +1,18 @@
 import deprecate from 'deprecate';
+import remove from 'lodash.remove';
+
+let redirects;
 
 export default (routes, config = {}, isProduction) => {
+  redirects = [];
   patchRoutes(routes, config, isProduction);
-  return routes;
+  return [...redirects, ...routes];
 };
 
 function patchRoutes(routes, config, isProduction) {
   let notFoundIndex = null;
   let rootIndex = null;
+
   routes.forEach((route, index) => {
     patchRoute(route, config, isProduction);
     if (route.path === '/404') {
@@ -35,6 +40,11 @@ function patchRoutes(routes, config, isProduction) {
       path: '/index.html',
     });
   }
+
+  const removedRoutes = remove(routes, route => {
+    return route.redirect;
+  });
+  redirects = redirects.concat(removedRoutes);
 }
 
 function patchRoute(route, config, isProduction) {

--- a/packages/umi-build-dev/src/routes/patchRoutes.js
+++ b/packages/umi-build-dev/src/routes/patchRoutes.js
@@ -6,7 +6,8 @@ let redirects;
 export default (routes, config = {}, isProduction) => {
   redirects = [];
   patchRoutes(routes, config, isProduction);
-  return [...redirects, ...routes];
+  routes.unshift(...redirects);
+  return routes;
 };
 
 function patchRoutes(routes, config, isProduction) {

--- a/packages/umi-build-dev/src/routes/patchRoutes.test.js
+++ b/packages/umi-build-dev/src/routes/patchRoutes.test.js
@@ -201,4 +201,31 @@ describe('patchRoutes', () => {
     const routes = patchRoutes([{ path: '/b', meta: { Route: './A' } }]);
     expect(routes).toEqual([{ path: '/b', Route: './A' }]);
   });
+
+  it('redirect hoist', () => {
+    const routes = patchRoutes([
+      { path: '/a', component: './A' },
+      { path: '/b', redirect: '/c' },
+      {
+        path: '/c',
+        routes: [
+          { path: '/c/d', component: 'D' },
+          { path: '/c/e', redirect: '/c/f' },
+          { path: '/c/f', component: 'F' },
+        ],
+      },
+    ]);
+    expect(routes).toEqual([
+      { path: '/c/e', redirect: '/c/f' },
+      { path: '/b', redirect: '/c' },
+      { path: '/a', component: './A' },
+      {
+        path: '/c',
+        routes: [
+          { path: '/c/d', component: 'D' },
+          { path: '/c/f', component: 'F' },
+        ],
+      },
+    ]);
+  });
 });

--- a/packages/umi/src/renderRoutes.js
+++ b/packages/umi/src/renderRoutes.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Switch, Route } from 'react-router-dom';
+import { Switch, Route, Redirect } from 'react-router-dom';
 
 export default function renderRoutes(
   routes,
@@ -17,6 +17,9 @@ export default function renderRoutes(
             exact={route.exact}
             strict={route.strict}
             render={props => {
+              if (route.redirect) {
+                return <Redirect to={route.redirect} />;
+              }
               return (
                 <route.component {...props} {...extraProps} route={route}>
                   {renderRoutes(


### PR DESCRIPTION
Close #404 

---

Checkout [routes-via-config](https://github.com/umijs/umi-examples/tree/master/routes-via-config) for example.