### PR TITLE
fix(umi-build-dev): dynamic import code splitting

### DIFF
--- a/packages/umi-build-dev/src/getWebpackConfig.js
+++ b/packages/umi-build-dev/src/getWebpackConfig.js
@@ -43,7 +43,11 @@ export default function(service = {}) {
         [libraryName]: [setPublicPathFile, entryScript],
       };
 
-  const pageCount = isDev ? null : Object.keys(routes).length;
+  let pageCount = routes.length;
+  const rootRoute = routes.filter(route => route.path === '/')[0];
+  if (rootRoute && rootRoute.routes) {
+    pageCount = rootRoute.routes.length;
+  }
   debug(`pageCount: ${pageCount}`);
 
   // default react, support config with preact

--- a/packages/umi-build-dev/src/routes/routesToJSON.js
+++ b/packages/umi-build-dev/src/routes/routesToJSON.js
@@ -3,7 +3,15 @@ import isAbsolute from 'path-is-absolute';
 import winPath from '../winPath';
 import normalizeEntry from '../normalizeEntry';
 
+let targetLevel = 1;
+let level = 0;
+
 export default (routes, service, requestedMap, env) => {
+  const rootRoute = routes.filter(route => route.path === '/')[0];
+  if (rootRoute && rootRoute.routes) {
+    targetLevel = 2;
+  }
+
   const { config, applyPlugins, paths } = service;
   patchRoutes(routes);
 
@@ -78,14 +86,16 @@ export default (routes, service, requestedMap, env) => {
 };
 
 function patchRoutes(routes, webpackChunkName) {
+  level += 1;
   routes.forEach(route => {
     patchRoute(route, webpackChunkName);
   });
+  level -= 1;
 }
 
 function patchRoute(route, webpackChunkName) {
   if (route.component && !route.component.startsWith('() =>')) {
-    if (!webpackChunkName) {
+    if (!webpackChunkName || level <= targetLevel) {
       webpackChunkName = normalizeEntry(route.component || 'common_component');
     }
     route.component = [

--- a/packages/umi-build-dev/src/routes/routesToJSON.test.js
+++ b/packages/umi-build-dev/src/routes/routesToJSON.test.js
@@ -51,6 +51,80 @@ describe('routesToJSON', () => {
     ]);
   });
 
+  it('dynamic load when env is production (dynamicLevel = 1)', () => {
+    const json = routesToJSON(
+      [
+        { component: './pages/A' },
+        {
+          path: '/B',
+          component: './pages/B',
+          routes: [{ component: './pages/B/B' }, { component: './pages/B/C' }],
+        },
+      ],
+      service,
+      {},
+      'production',
+    );
+    expect(JSON.parse(json)).toEqual([
+      {
+        component:
+          "dynamic(() => import(/* webpackChunkName: ^pages__A^ */'../A'), {})",
+      },
+      {
+        path: '/B',
+        component:
+          "dynamic(() => import(/* webpackChunkName: ^pages__B^ */'../B'), {})",
+        routes: [
+          {
+            component:
+              "dynamic(() => import(/* webpackChunkName: ^pages__B^ */'../B/B'), {})",
+          },
+          {
+            component:
+              "dynamic(() => import(/* webpackChunkName: ^pages__B^ */'../B/C'), {})",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('dynamic load when env is production (dynamicLevel = 2)', () => {
+    const json = routesToJSON(
+      [
+        { component: './pages/A' },
+        {
+          path: '/',
+          component: './pages/B',
+          routes: [{ component: './pages/B/B' }, { component: './pages/B/C' }],
+        },
+      ],
+      service,
+      {},
+      'production',
+    );
+    expect(JSON.parse(json)).toEqual([
+      {
+        component:
+          "dynamic(() => import(/* webpackChunkName: ^pages__A^ */'../A'), {})",
+      },
+      {
+        path: '/',
+        component:
+          "dynamic(() => import(/* webpackChunkName: ^pages__B^ */'../B'), {})",
+        routes: [
+          {
+            component:
+              "dynamic(() => import(/* webpackChunkName: ^pages__B__B^ */'../B/B'), {})",
+          },
+          {
+            component:
+              "dynamic(() => import(/* webpackChunkName: ^pages__B__C^ */'../B/C'), {})",
+          },
+        ],
+      },
+    ]);
+  });
+
   it('dynamic load when env is production (with loading)', () => {
     const json = routesToJSON(
       [{ component: './pages/A' }],


### PR DESCRIPTION
## 规则

* dynamicLevel 默认为 1
* 根节点下 path 为 / 的 route 如果有 routes，则 dynamicLevel 为 2

## 例子

### 无 layout

```
+ pages
  - a.js
  - b.js
  + c
    - _layout.js
    - c1.js
    - c2.js
```

note: 

* dynamicLevel 为 1
* 拆 a.js、b.js、c.js（包含 c1、c2 及其 _layout.js）

### 有 layout

```
+ layouts/index.js
+ pages
  - a.js
  - b.js
  + c
    - _layout.js
    - c1.js
    - c2.js
```

note:

* dynamicLevel 为 2
* layouts/index.js 会合并到 common-umi 里
* 拆 a.js、b.js、c.js（包含 c1、c2 及其 _layout.js）

### 多 layout

```
[
  { path: '/login' },
  { path: '/', routes: [
    { path: '/a' },
    { path: '/b' },
    { path: '/c', routes: [
      { path: '/c1' },
      { path: '/c2' },
    ] },
  ]},
]
```

* dynamicLevel 为 2
* 拆 /login 和 /，由于有差异，所以不会自动合并到 common-umi
* 拆 a.js、b.js、c.js（包含 c1、c2 及其 _layout.js）
