### PR TITLE
feat(af-webpack): enable hard-source-webpack-plugin to boost performance

### DIFF
--- a/packages/af-webpack/package.json
+++ b/packages/af-webpack/package.json
@@ -34,6 +34,7 @@
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^0.11.2",
     "fork-ts-checker-webpack-plugin": "^0.4.1",
+    "hard-source-webpack-plugin": "^0.6.7",
     "html-webpack-plugin": "^2.30.1",
     "inquirer": "^3.3.0",
     "is-plain-object": "^2.0.4",

--- a/packages/af-webpack/src/getConfig.js
+++ b/packages/af-webpack/src/getConfig.js
@@ -487,6 +487,9 @@ export default function getConfig(opts = {}) {
             new webpack.HotModuleReplacementPlugin(),
             new WatchMissingNodeModulesPlugin(join(opts.cwd, 'node_modules')),
             new SystemBellWebpackPlugin(),
+            ...(process.env.HARD_SOURCE === 'none'
+              ? []
+              : [new HardSourceWebpackPlugin()]),
           ].concat(
             opts.devtool
               ? []
@@ -576,9 +579,6 @@ export default function getConfig(opts = {}) {
           context: __dirname,
         },
       }),
-      ...(process.env.HARD_SOURCE === 'none'
-        ? []
-        : [new HardSourceWebpackPlugin()]),
       new ProgressPlugin(),
       ...(process.env.TS_TYPECHECK ? [new ForkTsCheckerWebpackPlugin()] : []),
       ...(opts.ignoreMomentLocale

--- a/packages/af-webpack/src/getConfig.js
+++ b/packages/af-webpack/src/getConfig.js
@@ -17,6 +17,7 @@ import HTMLWebpackPlugin from 'html-webpack-plugin';
 import ProgressPlugin from 'progress-bar-webpack-plugin';
 import { sync as resolveSync } from 'resolve';
 import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
+import HardSourceWebpackPlugin from 'hard-source-webpack-plugin';
 import uglifyJSConfig from './defaultConfigs/uglifyJS';
 import babelConfig from './defaultConfigs/babel';
 import defaultBrowsers from './defaultConfigs/browsers';
@@ -575,6 +576,9 @@ export default function getConfig(opts = {}) {
           context: __dirname,
         },
       }),
+      ...(process.env.HARD_SOURCE === 'none'
+        ? []
+        : [new HardSourceWebpackPlugin()]),
       new ProgressPlugin(),
       ...(process.env.TS_TYPECHECK ? [new ForkTsCheckerWebpackPlugin()] : []),
       ...(opts.ignoreMomentLocale

--- a/packages/umi-plugin-dll/src/index.js
+++ b/packages/umi-plugin-dll/src/index.js
@@ -22,6 +22,7 @@ export default function(api, opts = {}) {
 
   api.register('beforeDevAsync', () => {
     return new Promise(resolve => {
+      process.env.HARD_SOURCE = 'none';
       buildDll({
         webpack,
         afWebpackGetConfig,
@@ -32,6 +33,7 @@ export default function(api, opts = {}) {
         ...opts,
       })
         .then(() => {
+          process.env.HARD_SOURCE = '';
           resolve();
         })
         .catch(e => {


### PR DESCRIPTION

以 [umi-antd-admin](https://github.com/umijs/umi-antd-admin) 为例，dll + hard-source-webpack-plugin 后编译时间 0.9s，启动时间 7.7s。

![image](https://user-images.githubusercontent.com/35128/40160862-866ecbd8-59e1-11e8-8e2b-1f78ecc0b5fb.png)
