### PR TITLE
feat(umi-build-dev): support config via env, e.g. config.{env}.js

### DIFF
--- a/packages/umi-build-dev/package.json
+++ b/packages/umi-build-dev/package.json
@@ -20,6 +20,7 @@
     "is-plain-object": "^2.0.4",
     "lodash.clonedeep": "^4.5.0",
     "lodash.debounce": "^4.0.8",
+    "lodash.flatten": "^4.4.0",
     "lodash.isequal": "^4.5.0",
     "lodash.remove": "^4.7.0",
     "mkdirp": "^0.5.1",

--- a/packages/umi-build-dev/src/UserConfig.js
+++ b/packages/umi-build-dev/src/UserConfig.js
@@ -268,6 +268,7 @@ class UserConfig {
         CONFIG_FILES.map(file => [
           file,
           env ? [file.replace(/\.js$/, `.${env}.js`)] : [],
+          file.replace(/\.js$/, `.local.js`),
         ]),
       ),
     );

--- a/packages/umi-build-dev/src/UserConfig.test.js
+++ b/packages/umi-build-dev/src/UserConfig.test.js
@@ -15,6 +15,32 @@ describe('UserConfig', () => {
     });
   });
 
+  it('config/config.js with custom', () => {
+    process.env.UMI_ENV = 'custom';
+    const config = UserConfig.getConfig({
+      cwd: join(base, 'config-config'),
+      service,
+    });
+    process.env.UMI_ENV = '';
+    expect(config).toEqual({
+      alias: { a: 'b' },
+      custom: 1,
+    });
+  });
+
+  it('config/config.js with local', () => {
+    process.env.NODE_ENV = 'development';
+    const config = UserConfig.getConfig({
+      cwd: join(base, 'config-config'),
+      service,
+    });
+    process.env.NODE_ENV = '';
+    expect(config).toEqual({
+      alias: { a: 'b' },
+      local: 1,
+    });
+  });
+
   it('.umirc', () => {
     const config = UserConfig.getConfig({
       cwd: join(base, 'umirc'),
@@ -22,6 +48,32 @@ describe('UserConfig', () => {
     });
     expect(config).toEqual({
       alias: { a: 'b' },
+    });
+  });
+
+  it('.umirc with custom', () => {
+    process.env.UMI_ENV = 'custom';
+    const config = UserConfig.getConfig({
+      cwd: join(base, 'umirc'),
+      service,
+    });
+    process.env.UMI_ENV = '';
+    expect(config).toEqual({
+      alias: { a: 'b' },
+      custom: 1,
+    });
+  });
+
+  it('.umirc with custom', () => {
+    process.env.NODE_ENV = 'development';
+    const config = UserConfig.getConfig({
+      cwd: join(base, 'umirc'),
+      service,
+    });
+    process.env.NODE_ENV = '';
+    expect(config).toEqual({
+      alias: { a: 'b' },
+      local: 1,
     });
   });
 });

--- a/packages/umi-build-dev/src/UserConfig.test.js
+++ b/packages/umi-build-dev/src/UserConfig.test.js
@@ -41,6 +41,22 @@ describe('UserConfig', () => {
     });
   });
 
+  it('config/config.js with local and custom', () => {
+    process.env.NODE_ENV = 'development';
+    process.env.UMI_ENV = 'custom';
+    const config = UserConfig.getConfig({
+      cwd: join(base, 'config-config'),
+      service,
+    });
+    process.env.NODE_ENV = '';
+    process.env.UMI_ENV = '';
+    expect(config).toEqual({
+      alias: { a: 'b' },
+      local: 1,
+      custom: 1,
+    });
+  });
+
   it('.umirc', () => {
     const config = UserConfig.getConfig({
       cwd: join(base, 'umirc'),

--- a/packages/umi-build-dev/src/fixtures/UserConfig/config-config/config/config.custom.js
+++ b/packages/umi-build-dev/src/fixtures/UserConfig/config-config/config/config.custom.js
@@ -1,0 +1,4 @@
+
+export default {
+  custom: 1,
+};

--- a/packages/umi-build-dev/src/fixtures/UserConfig/config-config/config/config.local.js
+++ b/packages/umi-build-dev/src/fixtures/UserConfig/config-config/config/config.local.js
@@ -1,0 +1,4 @@
+
+export default {
+  local: 1,
+};

--- a/packages/umi-build-dev/src/fixtures/UserConfig/umirc/.umirc.custom.js
+++ b/packages/umi-build-dev/src/fixtures/UserConfig/umirc/.umirc.custom.js
@@ -1,0 +1,4 @@
+
+export default {
+  custom: 1,
+};

--- a/packages/umi-build-dev/src/fixtures/UserConfig/umirc/.umirc.local.js
+++ b/packages/umi-build-dev/src/fixtures/UserConfig/umirc/.umirc.local.js
@@ -1,0 +1,4 @@
+
+export default {
+  local: 1,
+};

--- a/packages/umi-build-dev/src/registerBabel.js
+++ b/packages/umi-build-dev/src/registerBabel.js
@@ -1,16 +1,32 @@
 import { join } from 'path';
 import isAbsolute from 'path-is-absolute';
 import registerBabel from 'af-webpack/registerBabel';
+import flatten from 'lodash.flatten';
+import { getEnv } from './UserConfig';
 import { CONFIG_FILES } from './constants';
 import winPath from './winPath';
 
-const files = [...CONFIG_FILES, 'webpack.config.js', '.webpackrc.js'];
+let files = null;
+
+function initFiles() {
+  if (files) return;
+  const env = getEnv();
+  files = [
+    ...flatten(
+      CONFIG_FILES.map(file => [file, file.replace(/\.js$/, `.${env}.js`)]),
+    ),
+    'webpack.config.js',
+    '.webpackrc.js',
+  ];
+}
 
 export function addBabelRegisterFiles(extraFiles) {
+  initFiles();
   files.push(...extraFiles);
 }
 
 export default function(babelPreset, opts = {}) {
+  initFiles();
   const { cwd } = opts;
   const only = files.map(f => {
     const fullPath = isAbsolute(f) ? f : join(cwd, f);

--- a/packages/umi-build-dev/src/registerBabel.js
+++ b/packages/umi-build-dev/src/registerBabel.js
@@ -2,7 +2,6 @@ import { join } from 'path';
 import isAbsolute from 'path-is-absolute';
 import registerBabel from 'af-webpack/registerBabel';
 import flatten from 'lodash.flatten';
-import { getEnv } from './UserConfig';
 import { CONFIG_FILES } from './constants';
 import winPath from './winPath';
 
@@ -10,10 +9,14 @@ let files = null;
 
 function initFiles() {
   if (files) return;
-  const env = getEnv();
+  const env = process.env.UMI_ENV;
   files = [
     ...flatten(
-      CONFIG_FILES.map(file => [file, file.replace(/\.js$/, `.${env}.js`)]),
+      CONFIG_FILES.map(file => [
+        file,
+        ...(env ? [file.replace(/\.js$/, `.${env}.js`)] : []),
+        file.replace(/\.js$/, `.local.js`),
+      ]),
     ),
     'webpack.config.js',
     '.webpackrc.js',


### PR DESCRIPTION
Notes:

* 如果有配 `UMI_ENV`，比如 UMI_ENV=cloud，则会用 `config/config.cloud.js` 合并 `config/config.js`
* dev 模式下时会额外加载 `.local.js`，并合并到配置里
* 此方式同样支持 `.umirc.js`，比如 `.umirc.local.js`
* `*.local.js` 的配置文件通常需要添加到 .gitignore，不要提交
