### PR TITLE
fix: import from lost dep will cause 100% cpu

### DIFF
--- a/packages/af-webpack/src/getConfig.js
+++ b/packages/af-webpack/src/getConfig.js
@@ -485,7 +485,8 @@ export default function getConfig(opts = {}) {
       ...(isDev
         ? [
             new webpack.HotModuleReplacementPlugin(),
-            new WatchMissingNodeModulesPlugin(join(opts.cwd, 'node_modules')),
+            // Disable this plugin since it causes 100% cpu when have lost deps
+            // new WatchMissingNodeModulesPlugin(join(opts.cwd, 'node_modules')),
             new SystemBellWebpackPlugin(),
             ...(process.env.HARD_SOURCE === 'none'
               ? []

--- a/packages/umi-build-dev/src/UserConfig.js
+++ b/packages/umi-build-dev/src/UserConfig.js
@@ -95,13 +95,19 @@ class UserConfig {
     const env = process.env.UMI_ENV;
     const isDev = process.env.NODE_ENV === 'development';
 
-    return normalizeConfig({
-      ...requireFile(absConfigPath),
-      ...(env ? requireFile(absConfigPath.replace(/\.js$/, `.${env}.js`)) : {}),
-      ...(isDev
-        ? requireFile(absConfigPath.replace(/\.js$/, '.local.js'))
-        : {}),
-    });
+    if (absConfigPath) {
+      return normalizeConfig({
+        ...requireFile(absConfigPath),
+        ...(env
+          ? requireFile(absConfigPath.replace(/\.js$/, `.${env}.js`))
+          : {}),
+        ...(isDev
+          ? requireFile(absConfigPath.replace(/\.js$/, '.local.js'))
+          : {}),
+      });
+    } else {
+      return {};
+    }
   }
 
   constructor(service) {


### PR DESCRIPTION
ref: #521 

---

依赖一个不存在的模块时，会导致 cpu 100%+，原因是 https://github.com/facebook/create-react-app/blob/next/packages/react-dev-utils/WatchMissingNodeModulesPlugin.js 这个插件引起的，cnpm/tnpm 下明显会卡，yarn 有一点感觉，但不明显，create-react-app 也有这个问题，但他们用 yarn，所以不明显（换成 cnpm/tnpm 安装就很明显了）。
