### PR TITLE
fix(umi-build-dev): redirect don't compatible with bigfish's style

### DIFF
--- a/packages/umi-build-dev/src/routes/getRouteConfigFromConfig.js
+++ b/packages/umi-build-dev/src/routes/getRouteConfigFromConfig.js
@@ -31,7 +31,13 @@ function patchRoute(route, pagesPath, parentRoutePath) {
   }
   if (route.indexRoute) {
     if (route.indexRoute.redirect) {
-      route.redirect = route.indexRoute.redirect;
+      if (!route.routes) {
+        route.routes = [];
+      }
+      route.routes.unshift({
+        path: route.path,
+        redirect: route.indexRoute.redirect,
+      });
     }
     if (route.indexRoute.component) {
       if (!route.routes) {

--- a/packages/umi-build-dev/src/routes/getRouteConfigFromConfig.test.js
+++ b/packages/umi-build-dev/src/routes/getRouteConfigFromConfig.test.js
@@ -111,7 +111,7 @@ describe('getRoutesConfigFromConfig', () => {
   it('bigfish compatibility', () => {
     const routes = getRoute([
       { path: '/a', indexRoute: { component: 'A' } },
-      { path: '/b', indexRoute: { redirect: 'B' } },
+      { path: '/b', indexRoute: { redirect: '/a' } },
       { path: '/c', childRoutes: [] },
     ]);
     expect(routes).toEqual([
@@ -119,7 +119,10 @@ describe('getRoutesConfigFromConfig', () => {
         path: '/a',
         routes: [{ path: '/a', component: './src/pages/A', exact: true }],
       },
-      { path: '/b', redirect: '/B', exact: true },
+      {
+        path: '/b',
+        routes: [{ path: '/b', exact: true, redirect: '/a' }],
+      },
       { path: '/c', routes: [] },
     ]);
   });


### PR DESCRIPTION
例子：https://github.com/umijs/umi-examples/tree/master/routes-via-config-bigfish
