### PR TITLE
fix(umi-build-dev): winPath causes NotFound route crash

### DIFF
--- a/packages/umi-build-dev/src/routes/getRouteConfigFromDir.js
+++ b/packages/umi-build-dev/src/routes/getRouteConfigFromDir.js
@@ -77,7 +77,7 @@ Routes conflict:
       addRoute(memo, {
         path: normalizePath(newDirPath),
         exact: true,
-        component: `./${relative(cwd, absPageFile)}`,
+        component: `./${winPath(relative(cwd, absPageFile))}`,
         isParamsRoute,
       });
     } else {
@@ -94,7 +94,7 @@ Routes conflict:
         addRoute(memo, {
           path: normalizePath(newDirPath),
           exact: false,
-          component: `./${relative(cwd, absLayoutFile)}`,
+          component: `./${winPath(relative(cwd, absLayoutFile))}`,
           routes,
           isParamsRoute,
         });
@@ -108,7 +108,7 @@ Routes conflict:
     addRoute(memo, {
       path,
       exact: true,
-      component: `./${relative(cwd, absFilePath)}`,
+      component: `./${winPath(relative(cwd, absFilePath))}`,
       isParamsRoute,
     });
   }


### PR DESCRIPTION
Close #562 
Close #556 

Thanks for the [PR](https://github.com/umijs/umi/pull/562) from @hansnow .
