### PR TITLE
feat(af-webpack): disable hard source and tsconfigpathsplugin by default

### DIFF
--- a/packages/af-webpack/src/getConfig.js
+++ b/packages/af-webpack/src/getConfig.js
@@ -401,6 +401,7 @@ export default function getConfig(opts = {}) {
         ...opts.alias,
       },
       plugins:
+        process.env.TS_CONFIG_PATHS_PLUGIN &&
         process.env.TS_CONFIG_PATHS_PLUGIN !== 'none'
           ? [new TsConfigPathsPlugin()]
           : [],
@@ -508,9 +509,9 @@ export default function getConfig(opts = {}) {
             // Disable this plugin since it causes 100% cpu when have lost deps
             // new WatchMissingNodeModulesPlugin(join(opts.cwd, 'node_modules')),
             new SystemBellWebpackPlugin(),
-            ...(process.env.HARD_SOURCE === 'none'
-              ? []
-              : [new HardSourceWebpackPlugin()]),
+            ...(process.env.HARD_SOURCE && process.env.HARD_SOURCE !== 'none'
+              ? [new HardSourceWebpackPlugin()]
+              : []),
           ].concat(
             opts.devtool
               ? []


### PR DESCRIPTION

由于反馈比较多，所以默认禁用以下两个功能：

1. hard-source-webpack-plugin，这个提效明显，关闭他其实很犹豫
2. awesome-typescript-loader 的 ts_config_paths_plugin

可通过 HARD_SOURCE=1 和 TS_CONFIG_PATHS_PLUGIN=1 开启。

Close #521 

