### PR TITLE
fix @babel/preset-env browsers config

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -27,7 +27,9 @@ const browserBabelConfig = {
     [
       require.resolve('@babel/preset-env'),
       {
-        browsers: ['last 2 versions', 'IE 10'],
+        targets: {
+          browsers: ['last 2 versions', 'IE 10'],
+        },
       },
     ],
     require.resolve('@babel/preset-react'),


### PR DESCRIPTION
之前的配置一直是错的， `@babel/preset-env` 的最新版会做[校验](https://github.com/babel/babel/commit/3de053cc6c94be9411deb213cfc53c1392b5f6eb#diff-511b392361cfba9fae7bdc816eae9308)导致 build 报错。

配置参考： https://new.babeljs.io/docs/en/next/babel-preset-env.html#targetsbrowsers

另外 umi 里面锁死了 `@babel/preset-env` 为 7.0.0-beta.46，这个问题暂时不会暴露。