### PR TITLE
fix: af-webpack should resolve eslintrc according to APP_ROOT

### DIFF
--- a/packages/af-webpack/src/getConfig.js
+++ b/packages/af-webpack/src/getConfig.js
@@ -336,17 +336,18 @@ export default function getConfig(opts = {}) {
   }
 
   // 读用户的 eslintrc
-  if (existsSync(resolve('.eslintrc'))) {
+  const userEslintRulePath = resolve(opts.cwd, '.eslintrc');
+  if (existsSync(userEslintRulePath)) {
     try {
-      const userRc = readRc(resolve('.eslintrc'));
+      const userRc = readRc(userEslintRulePath);
       debug(`userRc: ${JSON.stringify(userRc)}`);
       if (userRc.extends) {
-        debug(`use user's .eslintrc: ${resolve('.eslintrc')}`);
+        debug(`use user's .eslintrc: ${userEslintRulePath}`);
         eslintOptions.useEslintrc = true;
         eslintOptions.baseConfig = false;
         eslintOptions.ignore = true;
       } else {
-        debug(`extend with user's .eslintrc: ${resolve('.eslintrc')}`);
+        debug(`extend with user's .eslintrc: ${userEslintRulePath}`);
         eslintOptions.baseConfig = {
           ...eslintOptions.baseConfig,
           ...userRc,


### PR DESCRIPTION
## Problem
when exec `"APP_ROOT=yunfengdie/app/assets umi build"` in [egg](https://github.com/eggjs/examples/blob/master/assets-with-umi/package.json#L36), af-webpack still look eslintrc in `/.eslintrc`, which should be `/yunfengdie/app/assets/.eslintrc`


