### PR TITLE
fix(af-webpack): update less version to avoid vulnerabilities

### DIFF
--- a/packages/af-webpack/package.json
+++ b/packages/af-webpack/package.json
@@ -39,7 +39,7 @@
     "inquirer": "^3.3.0",
     "is-plain-object": "^2.0.4",
     "is-root": "^1.0.0",
-    "less": "^2.7.2",
+    "less": "^3.0.4",
     "less-loader": "^4.0.5",
     "lodash.isequal": "^4.5.0",
     "pkg-up": "^2.0.0",


### PR DESCRIPTION
By using ant design pro. Npm audit alert me to fix the vulnerabilities, I think it is necessary. And could you build the new version and update the roadhog version?
![image](https://user-images.githubusercontent.com/6986642/42171545-19b45f3c-7e4c-11e8-86dc-0d567ba80991.png)

