### PR TITLE
af-webpack sourceMap bug fix

### DIFF
--- a/packages/af-webpack/src/getConfig/css.js
+++ b/packages/af-webpack/src/getConfig/css.js
@@ -13,10 +13,9 @@ export default function(webpackConfig, opts) {
   const isDev = process.env.NODE_ENV === 'development';
   const cssOpts = {
     importLoaders: 1,
+    sourceMap: !opts.disableCSSSourceMap,
     ...(isDev
-      ? {
-          sourceMap: !opts.disableCSSSourceMap,
-        }
+      ? {}
       : {
           minimize: !(
             process.env.CSS_COMPRESS === 'none' ||
@@ -28,7 +27,6 @@ export default function(webpackConfig, opts) {
                 minifyFontValues: false,
               }
             : false,
-          sourceMap: !opts.disableCSSSourceMap,
         }),
     ...(opts.cssLoaderOptions || {}),
   };

--- a/packages/af-webpack/src/getConfig/css.js
+++ b/packages/af-webpack/src/getConfig/css.js
@@ -14,7 +14,9 @@ export default function(webpackConfig, opts) {
   const cssOpts = {
     importLoaders: 1,
     ...(isDev
-      ? {}
+      ? {
+          sourceMap: !opts.disableCSSSourceMap,
+        }
       : {
           minimize: !(
             process.env.CSS_COMPRESS === 'none' ||


### PR DESCRIPTION
af-webpack 默认配置项中css-loader dev环境下没有开启sourceMap
修改为不区分是否是dev环境，均根据disableCSSSourceMap配置项配置是否开启sourceMap