### PR TITLE
fix: #689, add isPathnameMatched as extraProps to test if a location.…

### DIFF
--- a/docs/guide/add-404-page.md
+++ b/docs/guide/add-404-page.md
@@ -11,3 +11,27 @@ export default () => {
 ```
 
 开发模式下，umi 会添加一个默认的 404 页面，但你仍可通过精确地访问 `/404` 来验证 404 页面。
+
+**404页面布局**
+
+如果对于`404`页面有不同的布局需求，可以在`layouts/index.js`通过`props.isPathnameMatched`属性来确认用户当前访问的地址是否一个已存在的路由，如下：
+
+```javascript
+export default function(props) {
+
+  if (!props.isPathnameMatched) { // 404专属布局
+    return <NotFoundLayout>{ props.children }</NotFoundLayout>
+  }
+
+  if (props.location.pathname === '/login') {
+    return <SimpleLayout>{ props.children }</SimpleLayout>
+  }
+  return (
+    <>
+      <Header />
+      { props.children }
+      <Footer />
+    </>
+  );
+}
+```

--- a/docs/guide/router.md
+++ b/docs/guide/router.md
@@ -160,6 +160,30 @@ export default () => {
 
 注：开发模式下，umi 会添加一个默认的 404 页面来辅助开发，但你仍然可通过精确地访问 /404 来验证 404 页面。
 
+**404页面布局**
+
+如果对于`404`页面有不同的布局需求，可以在`layouts/index.js`通过`props.isPathnameMatched`属性来确认用户当前访问的地址是否一个已存在的路由，如下：
+
+```javascript
+export default function(props) {
+
+  if (!props.isPathnameMatched) { // 404专属布局
+    return <NotFoundLayout>{ props.children }</NotFoundLayout>
+  }
+
+  if (props.location.pathname === '/login') {
+    return <SimpleLayout>{ props.children }</SimpleLayout>
+  }
+  return (
+    <>
+      <Header />
+      { props.children }
+      <Footer />
+    </>
+  );
+}
+```
+
 ## 路由过滤
 
 如果你需要在 `pages` 下组织文件，那么有可能某些文件是不需要添加到路由的，那么你可以通过 [umi-plugin-routes](https://github.com/umijs/umi/tree/master/packages/umi-plugin-routes) 插件进行排除。

--- a/packages/umi-build-dev/src/FilesGenerator.js
+++ b/packages/umi-build-dev/src/FilesGenerator.js
@@ -238,7 +238,7 @@ if (process.env.NODE_ENV === 'production') {
     return `
 <Router history={window.g_history}>
   <Route render={({ location }) =>
-    renderRoutes(routes, {}, { location })
+    renderRoutes(routes, { isPathnameMatched: pathnameMatcher(location) }, { location })
   } />
 </Router>
     `.trim();

--- a/packages/umi-build-dev/template/router.js.tpl
+++ b/packages/umi-build-dev/template/router.js.tpl
@@ -2,6 +2,7 @@ import React from 'react';
 import { Router as DefaultRouter, Route, Switch } from 'react-router-dom';
 import dynamic from '<%= libraryName %>/dynamic';
 import renderRoutes from '<%= libraryName %>/_renderRoutes';
+import getRouteMatchers from '<%= libraryName %>/_routeMatchers';
 <%= IMPORT %>
 
 let Router = DefaultRouter;
@@ -11,6 +12,7 @@ let routes = <%= ROUTES %>;
 <%= ROUTES_MODIFIER %>
 
 export default function() {
+  const pathnameMatcher = getRouteMatchers(routes);
   return (
 <%= ROUTER %>
   );

--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -11,6 +11,7 @@
     "ejs": "^2.5.7",
     "is-windows": "^1.0.2",
     "path-is-absolute": "^1.0.1",
+    "path-to-regexp": "^2.2.1",
     "query-string": "^5.0.0",
     "slash2": "^2.0.0",
     "umi-build-dev": "^0.20.7",

--- a/packages/umi/src/buildDevOpts.js
+++ b/packages/umi/src/buildDevOpts.js
@@ -38,6 +38,7 @@ export default function(opts = {}) {
       router: require.resolve('./router'),
       withRouter: require.resolve('./withRouter'),
       _renderRoutes: require.resolve('./renderRoutes'),
+      _routeMatchers: require.resolve('./routeMatchers'),
       _createHistory: require.resolve('./createHistory'),
     },
     hash,

--- a/packages/umi/src/routeMatchers.js
+++ b/packages/umi/src/routeMatchers.js
@@ -1,0 +1,21 @@
+import pathToRegexp from 'path-to-regexp';
+
+const routeMatchers = [];
+
+function addToRouteMatchers(routes) {
+  routes.forEach(route => {
+    if (route.path && route.exact) {
+      routeMatchers.push(pathToRegexp(route.path));
+    }
+    if (route.routes && route.routes.length) {
+      addToRouteMatchers(route.routes);
+    }
+  });
+}
+
+export default function getRouteMatchers(routes) {
+  addToRouteMatchers(routes);
+  return function(location) {
+    return routeMatchers.some(m => m.exec(location.pathname));
+  };
+}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -43,6 +43,7 @@ const BROWSER_FILES = [
   'packages/umi/src/navlink.js',
   'packages/umi/src/router.js',
   'packages/umi/src/renderRoutes.js',
+  'packages/umi/src/routeMatchers.js',
   'packages/umi/src/withRouter.js',
   'packages/umi/src/utils.js',
   'packages/umi-build-dev/src/plugins/404/NotFound.js',


### PR DESCRIPTION
This is a fix for [issue-689](https://github.com/umijs/umi/issues/689).

The idea is:

1. collect all `exact` routes at the first time user load up the website
2. pass `{ isPathnameMatched: pathnameMatcher(location) }` as  `extraProps` whenever route changed

After that, we can test if current `location.pathname` is exist or not by reading `props.isPathnameMatched` in `layouts/index.js`