### PR TITLE
feat: redirect to 404 if none router exact match

### DIFF
--- a/packages/umi-build-dev/src/DefaultLayout.js
+++ b/packages/umi-build-dev/src/DefaultLayout.js
@@ -1,5 +1,13 @@
 import React from 'react';
+import { matchRoutes } from 'react-router-config';
 
 export default function(props) {
+  if (process.env.NODE_ENV !== 'development') {
+    const match = matchRoutes(props.route.routes, window.location.pathname);
+    if (!match.find(m => m.match.isExact)) {
+      window.g_history.replace('/404');
+      return '';
+    }
+  }
   return <div>{props.children}</div>;
 }

--- a/packages/umi-build-dev/src/DefaultLayout.js
+++ b/packages/umi-build-dev/src/DefaultLayout.js
@@ -1,13 +1,5 @@
 import React from 'react';
-import { matchRoutes } from 'react-router-config';
 
 export default function(props) {
-  if (process.env.NODE_ENV !== 'development') {
-    const match = matchRoutes(props.route.routes, window.location.pathname);
-    if (!match.find(m => m.match.isExact)) {
-      window.g_history.replace('/404');
-      return '';
-    }
-  }
   return <div>{props.children}</div>;
 }

--- a/packages/umi-build-dev/src/plugins/404/index.js
+++ b/packages/umi-build-dev/src/plugins/404/index.js
@@ -17,18 +17,18 @@ export default function(api) {
         `.trim(),
       };
       const routes = deepclone(memo);
-      const globalLayoutRoute = routes.filter(route => {
-        return route.path === '/' && route.exact !== true;
-      })[0];
-      if (globalLayoutRoute) {
-        globalLayoutRoute.routes = [
-          ...(globalLayoutRoute.routes || []),
-          notFoundRoute,
-        ];
-        return routes;
-      } else {
-        return [...routes, notFoundRoute];
+
+      function addNotFound(_route) {
+        if (!_route.routes) {
+          return;
+        }
+        _route.routes.forEach(_r => addNotFound(_r));
+        _route.routes.push(notFoundRoute);
       }
+
+      routes.forEach(r => addNotFound(r));
+
+      return routes;
     });
   }
 }

--- a/packages/umi-build-dev/src/routes/patchRoutes.js
+++ b/packages/umi-build-dev/src/routes/patchRoutes.js
@@ -26,7 +26,7 @@ function patchRoutes(routes, config, isProduction) {
 
   // Transform /404 to fallback route in production and exportStatic is not set
   if (notFoundIndex !== null && isProduction && !config.exportStatic) {
-    const notFoundRoute = routes.splice(notFoundIndex, 1)[0];
+    const notFoundRoute = routes.slice(notFoundIndex, 1)[0];
     routes.push({ component: notFoundRoute.component });
   }
 


### PR DESCRIPTION
## 生产环境

路由不 exact 匹配，自动跳转到 /404


## 开发环境

会自动在所有嵌套子路由数组的最后添加 umi not found 页面路由，不做自动跳转