### PR TITLE
feat: add css-loader option localIdentName

### DIFF
--- a/packages/af-webpack/src/getConfig/css.js
+++ b/packages/af-webpack/src/getConfig/css.js
@@ -46,9 +46,9 @@ export default function(webpackConfig, opts) {
   };
   const cssModulesConfig = {
     modules: true,
-    localIdentName: isDev
+    localIdentName: cssOpts.localIdentName || (isDev
       ? '[name]__[local]___[hash:base64:5]'
-      : '[local]___[hash:base64:5]',
+      : '[local]___[hash:base64:5]'),
   };
   const lessOptions = {
     modifyVars: theme,


### PR DESCRIPTION
给 css-loader 的参数 cssLoaderOptions 中，localIdentName 这个用户没法自定义，应该给加上。另外如果不启用 css module 的话 localIdentName 还是不给用户配好了。