### PR TITLE
Improve plugin system

### DIFF
--- a/packages/af-webpack/src/build.js
+++ b/packages/af-webpack/src/build.js
@@ -13,7 +13,7 @@ const WARN_AFTER_BUNDLE_GZIP_SIZE = 512 * 1024;
 const WARN_AFTER_CHUNK_GZIP_SIZE = 1024 * 1024;
 
 export default function build(opts = {}) {
-  const { webpackConfig, cwd = process.cwd(), onSuccess } = opts;
+  const { webpackConfig, cwd = process.cwd(), onSuccess, onFail } = opts;
   assert(webpackConfig, 'webpackConfig should be supplied.');
   assert(isPlainObject(webpackConfig), 'webpackConfig should be plain object.');
 
@@ -37,6 +37,9 @@ export default function build(opts = {}) {
       console.log();
       console.log(chalk.red('Failed to compile.\n'));
       console.log(`${err}\n`);
+      if (onFail) {
+        onFail(err);
+      }
       process.exit(1);
     }
 

--- a/packages/af-webpack/src/dev.js
+++ b/packages/af-webpack/src/dev.js
@@ -67,7 +67,10 @@ export default function dev({
           send({ type: DONE });
         }
 
-        onCompileDone();
+        onCompileDone({
+          isFirstCompile,
+          stats,
+        });
       });
 
       const serverConfig = {

--- a/packages/umi-build-dev/src/FilesGenerator.js
+++ b/packages/umi-build-dev/src/FilesGenerator.js
@@ -25,7 +25,6 @@ export default class FilesGenerator {
     this.service = service;
     this.routesContent = null;
     this.hasRebuildError = false;
-    this.layoutDirectoryName = service.config.singular ? 'layout' : 'layouts';
   }
 
   generate() {
@@ -113,9 +112,7 @@ export default class FilesGenerator {
   }
 
   generateFiles() {
-    const { paths, config } = this.service;
     this.service.applyPlugins('generateFiles');
-
     this.generateRouterJS();
     this.generateEntry();
   }

--- a/packages/umi-build-dev/src/FilesGenerator.js
+++ b/packages/umi-build-dev/src/FilesGenerator.js
@@ -85,7 +85,7 @@ export default class FilesGenerator {
       dev: { server },
     } = this.service;
     try {
-      this.service.applyPlugins('generateFiles', {
+      this.service.applyPlugins('onGenerateFiles', {
         args: {
           isRebuild: true,
         },
@@ -112,7 +112,7 @@ export default class FilesGenerator {
   }
 
   generateFiles() {
-    this.service.applyPlugins('generateFiles');
+    this.service.applyPlugins('onGenerateFiles');
     this.generateRouterJS();
     this.generateEntry();
   }

--- a/packages/umi-build-dev/src/PluginAPI.js
+++ b/packages/umi-build-dev/src/PluginAPI.js
@@ -1,6 +1,5 @@
 import debug from 'debug';
 import assert from 'assert';
-import { winPath } from 'umi-utils';
 import {
   PLACEHOLDER_IMPORT,
   PLACEHOLDER_RENDER,
@@ -15,6 +14,7 @@ class PluginAPI {
     this.id = id;
     this.service = service;
     this.debug = debug(`umi-plugin: ${id}`);
+    // deprecated
     this.utils = {
       // private for umi-plugin-dll
       _webpack: require('af-webpack/webpack'),
@@ -23,6 +23,7 @@ class PluginAPI {
       _webpackHotDevClientPath: require('af-webpack/react-dev-utils')
         .webpackHotDevClientPath,
     };
+    // deprecated
     this.placeholder = {
       IMPORT: PLACEHOLDER_IMPORT,
       RENDER: PLACEHOLDER_RENDER,

--- a/packages/umi-build-dev/src/PluginAPI.js
+++ b/packages/umi-build-dev/src/PluginAPI.js
@@ -14,6 +14,7 @@ class PluginAPI {
   constructor(id, service) {
     this.id = id;
     this.service = service;
+    this.debug = debug(`umi-plugin: ${id}`);
     this.utils = {
       // private for umi-plugin-dll
       _webpack: require('af-webpack/webpack'),
@@ -21,8 +22,6 @@ class PluginAPI {
       _afWebpackBuild: require('af-webpack/build').default,
       _webpackHotDevClientPath: require('af-webpack/react-dev-utils')
         .webpackHotDevClientPath,
-      winPath,
-      debug: debug(`umi-plugin: ${id}`),
     };
     this.placeholder = {
       IMPORT: PLACEHOLDER_IMPORT,

--- a/packages/umi-build-dev/src/UserConfig.js
+++ b/packages/umi-build-dev/src/UserConfig.js
@@ -136,10 +136,21 @@ class UserConfig {
     this.plugins = plugins.map(p => p(this));
   }
 
+  printError(messages) {
+    if (this.service.dev && this.service.dev.server) {
+      messages = typeof messages === 'string' ? [messages] : messages;
+      this.service.dev.server.sockWrite(
+        this.service.dev.server.sockets,
+        'errors',
+        messages,
+      );
+    }
+  }
+
   getConfig(opts = {}) {
     const env = process.env.UMI_ENV;
     const isDev = process.env.NODE_ENV === 'development';
-    const { paths, printError, cwd } = this.service;
+    const { paths, cwd } = this.service;
     const { force, setConfig } = opts;
 
     const file = getConfigFile(paths.cwd, this.service);
@@ -171,7 +182,7 @@ class UserConfig {
         '',
       )}" 解析出错，请检查语法。
 \r\n${e.toString()}`;
-      printError(msg);
+      this.printError(msg);
       throw new Error(msg);
     }
 
@@ -201,7 +212,7 @@ class UserConfig {
           if (setConfig) {
             setConfig(config);
           }
-          printError(e.message);
+          this.printError(e.message);
           throw new Error(`配置 ${name} 校验失败, ${e.message}`);
         }
       }
@@ -218,7 +229,7 @@ class UserConfig {
         const guess = didyoumean(key, pluginNames);
         const midMsg = guess ? `你是不是想配置 "${guess}" ？ 或者` : '请';
         const msg = `"${relativeFile}" 中配置的 "${key}" 并非约定的配置项，${midMsg}${affixmsg}`;
-        printError(msg);
+        this.printError(msg);
         throw new Error(msg);
       }
     });

--- a/packages/umi-build-dev/src/UserConfig.js
+++ b/packages/umi-build-dev/src/UserConfig.js
@@ -95,8 +95,12 @@ class UserConfig {
     const env = process.env.UMI_ENV;
     const isDev = process.env.NODE_ENV === 'development';
 
+    const defaultConfig = service.applyPlugins('modifyDefaultConfig', {
+      initialValue: {},
+    });
     if (absConfigPath) {
       return normalizeConfig({
+        ...defaultConfig,
         ...requireFile(absConfigPath),
         ...(env
           ? requireFile(absConfigPath.replace(/\.js$/, `.${env}.js`))
@@ -126,7 +130,7 @@ class UserConfig {
     let plugins = Object.keys(map).map(key => {
       return map[key].default;
     });
-    plugins = this.service.applyPlugins('modifyConfigPlugins', {
+    plugins = this.service.applyPlugins('_modifyConfigPlugins', {
       initialValue: plugins,
     });
     this.plugins = plugins.map(p => p(this));

--- a/packages/umi-build-dev/src/UserConfig.js
+++ b/packages/umi-build-dev/src/UserConfig.js
@@ -266,7 +266,7 @@ class UserConfig {
           const { name } = plugin;
           if (!isEqual(newConfig[name], oldConfig[name])) {
             this.service.config[name] = newConfig[name];
-            this.service.applyPlugins('onUserConfigChange', {
+            this.service.applyPlugins('onConfigChange', {
               args: {
                 newConfig,
               },

--- a/packages/umi-build-dev/src/UserConfig.js
+++ b/packages/umi-build-dev/src/UserConfig.js
@@ -53,17 +53,18 @@ function normalizeConfig(config) {
 }
 
 function getConfigFile(cwd, service) {
-  const { printWarn } = service;
   const files = CONFIG_FILES.map(file => join(cwd, file)).filter(file =>
     existsSync(file),
   );
 
   if (files.length > 1) {
-    printWarn(
-      `Muitiple config files ${files.join(', ')} detected, umi will use ${
-        files[0]
-      }.`,
-    );
+    if (service.dev && service.dev.server) {
+      service.dev.server.sockWrite(service.dev.server.sockets, 'warns', [
+        `Muitiple config files ${files.join(', ')} detected, umi will use ${
+          files[0]
+        }.`,
+      ]);
+    }
   }
 
   return files[0];

--- a/packages/umi-build-dev/src/UserConfig.test.js
+++ b/packages/umi-build-dev/src/UserConfig.test.js
@@ -4,7 +4,11 @@ import UserConfig from './UserConfig';
 const base = join(__dirname, './fixtures/UserConfig');
 
 describe('static UserConfig', () => {
-  const service = {};
+  const service = {
+    applyPlugins(name, { initialValue }) {
+      return initialValue;
+    },
+  };
 
   it('config/config.js', () => {
     const config = UserConfig.getConfig({
@@ -115,7 +119,7 @@ describe('instance UserConfig', () => {
           hd: true,
           local: 0,
         };
-      } else if (name === 'modifyConfigPlugins') {
+      } else if (name === '_modifyConfigPlugins') {
         return ['alias', 'hd', 'local'].map(name => {
           return () => {
             return { name };

--- a/packages/umi-build-dev/src/getPlugins.js
+++ b/packages/umi-build-dev/src/getPlugins.js
@@ -59,6 +59,7 @@ Try:
   const builtInPlugins = [
     './plugins/commands/dev',
     './plugins/commands/build',
+    './plugins/commands/test',
     './plugins/output-path',
     './plugins/global-js',
     './plugins/global-css',

--- a/packages/umi-build-dev/src/html/getHTMLContent.js
+++ b/packages/umi-build-dev/src/html/getHTMLContent.js
@@ -108,7 +108,6 @@ export default function(path, service, chunksMap, minifyHTML, isProduction) {
     initialValue: html,
     args: {
       path,
-      route: { path }, // Will remove in umi@2.0
     },
   });
 

--- a/packages/umi-build-dev/src/plugins/404/index.js
+++ b/packages/umi-build-dev/src/plugins/404/index.js
@@ -1,9 +1,9 @@
 import { join } from 'path';
 import deepclone from 'lodash.clonedeep';
+import { winPath } from 'umi-utils';
 
 export default function(api) {
   const { paths } = api.service;
-  const { winPath } = api.utils;
 
   if (process.env.NODE_ENV === 'development') {
     api.register('modifyRoutes', ({ memo }) => {

--- a/packages/umi-build-dev/src/plugins/afwebpack-config.js
+++ b/packages/umi-build-dev/src/plugins/afwebpack-config.js
@@ -14,7 +14,7 @@ const excludes = ['entry', 'outputPath', 'hash'];
 
 export default function(api) {
   const {
-    utils: { debug },
+    debug,
     service: { cwd, config, paths },
   } = api;
 

--- a/packages/umi-build-dev/src/plugins/afwebpack-config.js
+++ b/packages/umi-build-dev/src/plugins/afwebpack-config.js
@@ -19,7 +19,7 @@ export default function(api) {
   } = api;
 
   // 把 af-webpack 的配置插件转化为 umi-build-dev 的
-  api.register('modifyConfigPlugins', ({ memo }) => {
+  api.register('_modifyConfigPlugins', ({ memo }) => {
     plugins.forEach(({ name, validate = noop }) => {
       if (!excludes.includes(name)) {
         memo.push(() => ({

--- a/packages/umi-build-dev/src/plugins/base.js
+++ b/packages/umi-build-dev/src/plugins/base.js
@@ -3,7 +3,7 @@ import assert from 'assert';
 export default function(api) {
   const { config } = api.service;
 
-  api.register('modifyConfigPlugins', ({ memo }) => {
+  api.register('_modifyConfigPlugins', ({ memo }) => {
     memo.push(api => {
       return {
         name: 'base',

--- a/packages/umi-build-dev/src/plugins/commands/build/index.js
+++ b/packages/umi-build-dev/src/plugins/commands/build/index.js
@@ -5,10 +5,7 @@ import HtmlGenerator from '../../../html/HtmlGenerator';
 import getRouteManager from '../getRouteManager';
 
 export default function(api) {
-  const {
-    service,
-    utils: { debug },
-  } = api;
+  const { service, debug } = api;
   const { cwd, paths } = service;
   const RoutesManager = getRouteManager(service);
   RoutesManager.fetchRoutes();
@@ -29,8 +26,6 @@ export default function(api) {
           rimraf.sync(paths.absTmpDirPath);
         }
 
-        service.applyPlugins('onBeforeGenerateHTML');
-
         if (process.env.HTML !== 'none') {
           debug(`Bundle html files`);
           const chunksMap = chunksToMap(stats.compilation.chunks);
@@ -44,7 +39,18 @@ export default function(api) {
           }
         }
 
-        service.applyPlugins('onBuildSuccess');
+        service.applyPlugins('onBuildSuccess', {
+          args: {
+            stats,
+          },
+        });
+      },
+      onFail(err) {
+        service.applyPlugins('onBuildFail', {
+          args: {
+            err,
+          },
+        });
       },
     });
   });

--- a/packages/umi-build-dev/src/plugins/commands/build/index.js
+++ b/packages/umi-build-dev/src/plugins/commands/build/index.js
@@ -29,7 +29,7 @@ export default function(api) {
           rimraf.sync(paths.absTmpDirPath);
         }
 
-        service.applyPlugins('beforeGenerateHTML');
+        service.applyPlugins('onBeforeGenerateHTML');
 
         if (process.env.HTML !== 'none') {
           debug(`Bundle html files`);
@@ -44,7 +44,7 @@ export default function(api) {
           }
         }
 
-        service.applyPlugins('buildSuccess');
+        service.applyPlugins('onBuildSuccess');
       },
     });
   });

--- a/packages/umi-build-dev/src/plugins/commands/dev/index.js
+++ b/packages/umi-build-dev/src/plugins/commands/dev/index.js
@@ -69,7 +69,7 @@ export default function(api) {
       contentBase: './path-do-not-exists',
       _beforeServerWithApp(app) {
         // @private
-        service.applyPlugins('_beforeServerWithApp', { args: { app } });
+        service.applyPlugins('_onBeforeServerWithApp', { args: { app } });
       },
       beforeMiddlewares: service.applyPlugins('modifyBeforeMiddlewares', {
         initialValue: [],
@@ -80,14 +80,11 @@ export default function(api) {
       beforeServer(devServer) {
         server = devServer;
         service.dev.server = server;
-        service.applyPlugins('beforeServer', { args: { devServer } });
+        service.applyPlugins('onBeforeServer', { args: { devServer } });
       },
       afterServer(devServer) {
-        service.applyPlugins('afterServer', { args: { devServer } });
+        service.applyPlugins('onAfterServer', { args: { devServer } });
         startWatch();
-      },
-      onCompileDone: stats => {
-        service.applyPlugins('onCompileDone', { args: { stats } });
       },
     });
   });

--- a/packages/umi-build-dev/src/plugins/commands/dev/index.js
+++ b/packages/umi-build-dev/src/plugins/commands/dev/index.js
@@ -80,11 +80,19 @@ export default function(api) {
       beforeServer(devServer) {
         server = devServer;
         service.dev.server = server;
-        service.applyPlugins('onBeforeServer', { args: { devServer } });
+        service.applyPlugins('beforeDevServer', { args: { devServer } });
       },
       afterServer(devServer) {
-        service.applyPlugins('onAfterServer', { args: { devServer } });
+        service.applyPlugins('afterDevServer', { args: { devServer } });
         startWatch();
+      },
+      onCompileDone({ isFirstCompile, stats }) {
+        service.applyPlugins('onDevCompileDone', {
+          args: {
+            isFirstCompile,
+            stats,
+          },
+        });
       },
     });
   });

--- a/packages/umi-build-dev/src/plugins/commands/test.js
+++ b/packages/umi-build-dev/src/plugins/commands/test.js
@@ -1,0 +1,8 @@
+export default function(api) {
+  api.registerCommand('test', {}, (args = {}) => {
+    require('umi-test').default({
+      ...args,
+      watch: args.w || args.watch,
+    });
+  });
+}

--- a/packages/umi-build-dev/src/plugins/global-css.js
+++ b/packages/umi-build-dev/src/plugins/global-css.js
@@ -1,9 +1,9 @@
 import { join } from 'path';
 import { existsSync } from 'fs';
+import { winPath } from 'umi-utils';
 
 export default function(api) {
   const { paths } = api.service;
-  const { winPath } = api.utils;
 
   api.register('modifyEntryFile', ({ memo }) => {
     const cssImports = [

--- a/packages/umi-build-dev/src/plugins/global-js.js
+++ b/packages/umi-build-dev/src/plugins/global-js.js
@@ -1,9 +1,9 @@
 import { join } from 'path';
 import { existsSync } from 'fs';
+import { winPath } from 'umi-utils';
 
 export default function(api) {
   const { paths } = api.service;
-  const { winPath } = api.utils;
 
   const globalFiles = [
     join(paths.absSrcPath, 'global.tsx'),

--- a/packages/umi-build-dev/src/plugins/history.js
+++ b/packages/umi-build-dev/src/plugins/history.js
@@ -4,7 +4,7 @@ export default function(api) {
   const { IMPORT, HISTORY_MODIFIER } = api.placeholder;
   const { config } = api.service;
 
-  api.register('modifyConfigPlugins', ({ memo }) => {
+  api.register('_modifyConfigPlugins', ({ memo }) => {
     memo.push(api => {
       return {
         name: 'history',

--- a/packages/umi-build-dev/src/plugins/mock/createMockMiddleware.js
+++ b/packages/umi-build-dev/src/plugins/mock/createMockMiddleware.js
@@ -10,7 +10,7 @@ const VALID_METHODS = ['get', 'post', 'put', 'patch', 'delete'];
 const BODY_PARSED_METHODS = ['post', 'put', 'patch'];
 
 export default function getMockMiddleware(api) {
-  const { debug } = api.utils;
+  const { debug } = api;
   const { cwd } = api.service;
   const absMockPath = join(cwd, 'mock');
   const absConfigPath = join(cwd, '.umirc.mock.js');

--- a/packages/umi-build-dev/src/plugins/mock/index.js
+++ b/packages/umi-build-dev/src/plugins/mock/index.js
@@ -1,7 +1,7 @@
 import createMockMiddleware from './createMockMiddleware';
 
 export default function(api) {
-  api.register('_beforeServerWithApp', ({ args: { app } }) => {
+  api.register('_onBeforeServerWithApp', ({ args: { app } }) => {
     if (process.env.MOCK !== 'none' && process.env.HTTP_MOCK !== 'none') {
       app.use(createMockMiddleware(api));
     }

--- a/packages/umi-build-dev/src/plugins/output-path.js
+++ b/packages/umi-build-dev/src/plugins/output-path.js
@@ -11,7 +11,7 @@ export default function(api) {
     }
   });
 
-  api.register('modifyConfigPlugins', ({ memo }) => {
+  api.register('_modifyConfigPlugins', ({ memo }) => {
     memo.push(() => {
       return {
         name: 'outputPath',

--- a/packages/umi-build-dev/src/plugins/proxy.js
+++ b/packages/umi-build-dev/src/plugins/proxy.js
@@ -8,9 +8,7 @@ function PROXY_END(req, res, next) {
 }
 
 export default function(api) {
-  const {
-    utils: { debug },
-  } = api;
+  const { debug } = api;
 
   api.register('beforeServerWithApp', ({ args: { app } }) => {
     const { config, webpackRCConfig } = api.service;

--- a/packages/umi-build-dev/src/routes/routesToJSON.js
+++ b/packages/umi-build-dev/src/routes/routesToJSON.js
@@ -40,10 +40,9 @@ export default (routes, service) => {
             ret = applyPlugins.call(service, 'modifyRouteComponent', {
               initialValue: ret,
               args: {
-                pageJSFile: importPath,
                 importPath,
                 webpackChunkName,
-                config,
+                component,
               },
             });
           }

--- a/packages/umi-build-dev/src/routes/routesToJSON.js
+++ b/packages/umi-build-dev/src/routes/routesToJSON.js
@@ -1,6 +1,7 @@
 import { join, relative } from 'path';
 import isAbsolute from 'path-is-absolute';
 import { winPath } from 'umi-utils';
+import cloneDeep from 'lodash.clonedeep';
 
 let targetLevel = null;
 let level = 0;
@@ -17,10 +18,11 @@ export default (routes, service) => {
   }
 
   const { config, applyPlugins, paths } = service;
-  patchRoutes(routes);
+  const clonedRoutes = cloneDeep(routes);
+  patchRoutes(clonedRoutes);
 
   return JSON.stringify(
-    routes,
+    clonedRoutes,
     (key, value) => {
       switch (key) {
         case 'component':

--- a/packages/umi-build-dev/src/routes/routesToJSON.test.js
+++ b/packages/umi-build-dev/src/routes/routesToJSON.test.js
@@ -111,10 +111,9 @@ describe('routesToJSON', () => {
     expect(applyPluginOpts).toEqual({
       initialValue: "require('../A').default",
       args: {
-        pageJSFile: '../A',
         importPath: '../A',
         webpackChunkName: 'pages__A',
-        config: { react: { dynamicImport: true } },
+        component: './pages/A',
       },
     });
   });

--- a/packages/umi-plugin-dva/src/index.js
+++ b/packages/umi-plugin-dva/src/index.js
@@ -151,7 +151,7 @@ app.use(require('${winPath(require.resolve('dva-immer'))}').default());
     return ret.join('\r\n');
   }
 
-  api.register('generateFiles', () => {
+  api.register('onGenerateFiles', () => {
     const tpl = join(__dirname, '../template/DvaContainer.js');
     let tplContent = readFileSync(tpl, 'utf-8');
     const dvaJS = getDvaJS();

--- a/packages/umi-plugin-dva/src/index.js
+++ b/packages/umi-plugin-dva/src/index.js
@@ -193,7 +193,7 @@ ${ROUTER_MODIFIER}
 
   if (shouldImportDynamic) {
     api.register('modifyRouteComponent', ({ memo, args }) => {
-      const { pageJSFile, webpackChunkName } = args;
+      const { importPath, webpackChunkName } = args;
       if (!webpackChunkName) {
         return memo;
       }
@@ -213,12 +213,12 @@ ${ROUTER_MODIFIER}
       let ret = `
 _dvaDynamic({
   <%= MODELS %>
-  component: () => import(${extendStr}'${pageJSFile}'),
+  component: () => import(${extendStr}'${importPath}'),
   ${loadingOpts}
 })
       `.trim();
       const models = getPageModels(
-        join(paths.absTmpDirPath, pageJSFile),
+        join(paths.absTmpDirPath, importPath),
         api.service,
       );
       if (models && models.length) {

--- a/packages/umi-plugin-locale/examples/base/config/config.js
+++ b/packages/umi-plugin-locale/examples/base/config/config.js
@@ -1,0 +1,9 @@
+export default {
+  plugins: ['umi-plugin-locale'],
+  locale: {
+    enable: true,
+    baseNavigator: false,
+    default: 'en-US',
+  },
+  singular: true,
+};

--- a/packages/umi-plugin-locale/examples/base/package.json
+++ b/packages/umi-plugin-locale/examples/base/package.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "start": "CLEAR_CONSOLE=none umi dev"
+  },
+  "dependencies": {}
+}

--- a/packages/umi-plugin-locale/examples/base/src/locale/en-US.js
+++ b/packages/umi-plugin-locale/examples/base/src/locale/en-US.js
@@ -1,0 +1,3 @@
+export default {
+  test: 'test en {name}',
+};

--- a/packages/umi-plugin-locale/examples/base/src/locale/zh-CN.js
+++ b/packages/umi-plugin-locale/examples/base/src/locale/zh-CN.js
@@ -1,0 +1,3 @@
+export default {
+  test: '测试中文 {name}',
+};

--- a/packages/umi-plugin-locale/examples/base/src/page/index.js
+++ b/packages/umi-plugin-locale/examples/base/src/page/index.js
@@ -1,0 +1,41 @@
+import {
+  formatMessage,
+  setLocale,
+  getLocale,
+  FormattedMessage,
+} from 'umi/locale';
+import { DatePicker } from 'antd';
+
+export default () => {
+  console.log(
+    getLocale(),
+    formatMessage(
+      {
+        id: 'test',
+      },
+      {
+        name: 'antd',
+      },
+    ),
+  );
+  return (
+    <div>
+      hello world. <FormattedMessage id="test" values={{ name: 'antd' }} />
+      <DatePicker />
+      <button
+        onClick={() => {
+          setLocale('en-US');
+        }}
+      >
+        en-US
+      </button>
+      <button
+        onClick={() => {
+          setLocale('zh-CN');
+        }}
+      >
+        zh-CN
+      </button>
+    </div>
+  );
+};

--- a/packages/umi-plugin-locale/examples/base/src/page/temp/index.js
+++ b/packages/umi-plugin-locale/examples/base/src/page/temp/index.js
@@ -1,0 +1,3 @@
+export default () => {
+  return <div>temp.</div>;
+};

--- a/packages/umi-plugin-locale/examples/base/src/page/temp/model.js
+++ b/packages/umi-plugin-locale/examples/base/src/page/temp/model.js
@@ -1,0 +1,4 @@
+export default {
+  namespace: 'temp',
+  state: {},
+};

--- a/packages/umi-plugin-locale/package.json
+++ b/packages/umi-plugin-locale/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "umi-plugin-locale",
+  "version": "1.0.1",
+  "description": "A umi plugin for provide internationalization function.",
+  "main": "./lib/index.js",
+  "authors": [
+    "yutingzhao1991 <yutingzhao1991@sina.com> (https://github.com/yutingzhao1991)"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/umijs/umi/tree/master/packages/umi-plugin-locale"
+  },
+  "homepage": "https://github.com/umijs/umi/tree/master/packages/umi-plugin-locale",
+  "bugs": {
+    "url": "https://github.com/umijs/umi/issues"
+  },
+  "files": [
+    "lib",
+    "src"
+  ],
+  "keywords": [
+    "umi"
+  ],
+  "dependencies": {
+    "prop-types": "^15.6.2",
+    "react-intl": "^2.4.0",
+    "umi-utils": "^0.0.1"
+  }
+}

--- a/packages/umi-plugin-locale/src/index.js
+++ b/packages/umi-plugin-locale/src/index.js
@@ -25,7 +25,7 @@ export function getLocaleFileList(absSrcPath, singular) {
   return localeList;
 }
 
-export default function(api, options) {
+export default function(api, options = {}) {
   const { service, placeholder } = api;
   const { IMPORT } = placeholder;
   const { paths } = service;

--- a/packages/umi-plugin-locale/src/index.js
+++ b/packages/umi-plugin-locale/src/index.js
@@ -1,0 +1,175 @@
+import { join, dirname } from 'path';
+import { existsSync, statSync, readdirSync } from 'fs';
+import { winPath } from 'umi-utils';
+
+// export for test
+export function getLocaleFileList(absSrcPath, singular) {
+  const localeList = [];
+  const localePath = join(absSrcPath, singular ? 'locale' : 'locales');
+  if (existsSync(localePath)) {
+    const localePaths = readdirSync(localePath);
+    for (let i = 0; i < localePaths.length; i++) {
+      const fullname = join(localePath, localePaths[i]);
+      const stats = statSync(fullname);
+      const fileInfo = /^([a-z]{2})-([A-Z]{2})\.(js|ts)$/.exec(localePaths[i]);
+      if (stats.isFile() && fileInfo) {
+        localeList.push({
+          lang: fileInfo[1],
+          country: fileInfo[2],
+          name: `${fileInfo[1]}-${fileInfo[2]}`,
+          path: fullname,
+        });
+      }
+    }
+  }
+  return localeList;
+}
+
+export default function(api, options) {
+  const { service, placeholder } = api;
+  const { IMPORT } = placeholder;
+  const { paths } = service;
+
+  api.register('_modifyConfigPlugins', ({ memo }) => {
+    memo.push(api => {
+      return {
+        name: 'locale',
+        onChange() {
+          api.service.rebuildFiles();
+        },
+      };
+    });
+    return memo;
+  });
+
+  api.register('modifyPageWatchers', ({ memo }) => {
+    return [
+      ...memo,
+      join(paths.absSrcPath, service.config.singular ? 'locale' : 'locales'),
+    ];
+  });
+
+  api.register('modifyRouterContent', ({ memo }) => {
+    const localeFileList = getLocaleFileList(
+      paths.absSrcPath,
+      service.config.singular,
+    );
+    return getLocaleWrapper(localeFileList, memo, options.antd);
+  });
+
+  api.register('modifyRouterFile', ({ memo }) => {
+    const localeFileList = getLocaleFileList(
+      paths.absSrcPath,
+      service.config.singular,
+    );
+    return memo.replace(
+      IMPORT,
+      `
+          ${getInitCode(
+            localeFileList,
+            options.default,
+            options.baseNavigator,
+            options.antd,
+          )}
+          ${IMPORT}
+        `,
+    );
+  });
+
+  api.register('modifyAFWebpackOpts', ({ memo }) => {
+    memo.alias = {
+      ...(memo.alias || {}),
+      'umi/locale': join(__dirname, './locale.js'),
+      'react-intl': dirname(require.resolve('react-intl/package.json')),
+    };
+    return memo;
+  });
+
+  function getLocaleWrapper(localeList, inner, antd = true) {
+    let ret = inner;
+    if (localeList.length) {
+      ret = `<IntlProvider locale={appLocale.locale} messages={appLocale.messages}>
+        <InjectedWrapper>${ret}</InjectedWrapper>
+      </IntlProvider>`;
+    }
+    if (antd) {
+      ret = `<LocaleProvider locale={appLocale.antd || defaultAntd}>
+        ${ret}
+      </LocaleProvider>`;
+    }
+    return ret;
+  }
+
+  function getInitCode(
+    localeList,
+    defaultLocale = 'zh-CN',
+    baseNavigator = true,
+    antd = true,
+    useLocalStorage = true,
+  ) {
+    // 初始化依赖模块的引入
+    // 把 locale 文件夹下的所有的模块的数据添加到 localeInfo 中
+    // 然后按照优先级依次从 localStorage, 浏览器 Navigator（baseNavigator 为 true 时），default 配置中取语言设置
+    // 如果 locale 下没有符合规则的文件，那么也可以仅仅针对 antd 做国际化
+    return `
+      ${
+        localeList.length
+          ? "import { addLocaleData, IntlProvider, injectIntl } from 'react-intl';"
+          : ''
+      }
+      ${localeList.length ? "import { _setIntlObject } from 'umi/locale';" : ''}
+      ${
+        localeList.length
+          ? `const InjectedWrapper = injectIntl(function(props) {
+        _setIntlObject(props.intl);
+        return props.children;
+      })`
+          : ''
+      }
+      const baseNavigator = ${baseNavigator};
+      ${antd ? `import { LocaleProvider } from 'antd';` : ''}
+      ${
+        antd
+          ? `const defaultAntd = require('antd/lib/locale-provider/${defaultLocale.replace(
+              '-',
+              '_',
+            )}');`
+          : ''
+      }
+      const localeInfo = {
+        ${localeList
+          .map(
+            locale => `'${locale.name}': {
+            messages: require('${winPath(locale.path)}').default,
+            locale: '${locale.name}',
+            ${
+              antd
+                ? `antd: require('antd/lib/locale-provider/${locale.lang}_${
+                    locale.country
+                  }'),`
+                : ''
+            }
+            data: require('react-intl/locale-data/${locale.lang}'),
+          }`,
+          )
+          .join(',\n')}
+      };
+      let appLocale = {
+        locale: '${defaultLocale}',
+        messages: {},
+      };
+      if (${useLocalStorage} && localStorage.getItem('umi_locale') && localeInfo[localStorage.getItem('umi_locale')]) {
+        appLocale = localeInfo[localStorage.getItem('umi_locale')];
+      } else if (localeInfo[navigator.language] && baseNavigator){
+        appLocale = localeInfo[navigator.language];
+      } else {
+        appLocale = localeInfo['${defaultLocale}'] || appLocale;
+      }
+      ${
+        localeList.length
+          ? 'appLocale.data && addLocaleData(appLocale.data);'
+          : ''
+      }
+    `;
+  }
+}

--- a/packages/umi-plugin-locale/src/locale.js
+++ b/packages/umi-plugin-locale/src/locale.js
@@ -1,0 +1,41 @@
+/* eslint-disable no-undef */
+const { FormattedMessage } = require('react-intl');
+
+function setLocale(lang) {
+  if (lang !== undefined && !/^([a-z]{2})-([A-Z]{2})$/.test(lang)) {
+    // for reset when lang === undefined
+    throw new Error('setLocale lang format error');
+  }
+  window.localStorage.setItem('umi_locale', lang || '');
+  window.location.reload();
+}
+
+function getLocale() {
+  return window.localStorage.getItem('umi_locale');
+}
+
+let intl = {
+  formatMessage: () => {
+    return null;
+  },
+};
+
+// react-intl 没有直接暴露 formatMessage 这个方法
+// 只能注入到 props 中，所以通过在最外层包一个组件然后组件内调用这个方法来把 intl 这个对象暴露到这里来
+// TODO 查找有没有更好的办法
+function _setIntlObject(theIntl) {
+  // umi 系统 API，不对外暴露
+  intl = theIntl;
+}
+
+function formatMessage() {
+  return intl.formatMessage.call(intl, ...arguments);
+}
+
+export {
+  formatMessage,
+  setLocale,
+  getLocale,
+  FormattedMessage,
+  _setIntlObject,
+};

--- a/packages/umi-plugin-locale/test/__mocks__/react-intl.js
+++ b/packages/umi-plugin-locale/test/__mocks__/react-intl.js
@@ -1,0 +1,1 @@
+export function FormattedMessage() {}

--- a/packages/umi-plugin-locale/test/browserMocks.js
+++ b/packages/umi-plugin-locale/test/browserMocks.js
@@ -1,0 +1,20 @@
+//browserMocks.js
+var localStorageMock = (function() {
+  var store = {};
+
+  return {
+    getItem: function(key) {
+      return store[key] || null;
+    },
+    setItem: function(key, value) {
+      store[key] = value.toString();
+    },
+    clear: function() {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+});

--- a/packages/umi-plugin-locale/test/index.test.js
+++ b/packages/umi-plugin-locale/test/index.test.js
@@ -1,0 +1,195 @@
+import { join } from 'path';
+import localePlugin, { getLocaleFileList } from '../src/index';
+
+const absSrcPath = join(__dirname, '../examples/base/src');
+
+const api = {
+  placeholder: {
+    IMPORT: 'test-placeholder',
+  },
+  utils: {
+    winPath: p => {
+      return p;
+    },
+  },
+  service: {
+    config: {
+      singular: true,
+    },
+    paths: {
+      absSrcPath: absSrcPath,
+    },
+  },
+  register() {},
+};
+
+describe('test plugin', () => {
+  test('not modify content when enable is not true', () => {
+    api.register = (name, handler) => {
+      if (name === 'modifyPageWatchers') {
+        const ret = handler({
+          memo: ['/some/test'],
+        });
+        expect(ret).toEqual(['/some/test']);
+      }
+      if (name === 'modifyRouterContent') {
+        const ret = handler({
+          memo: '<Router />',
+        });
+        expect(ret).toEqual('<Router />');
+      }
+      if (name === 'modifyRouterFile') {
+        const ret = handler({
+          memo: 'test-placeholder',
+        });
+        expect(ret).toEqual('test-placeholder');
+      }
+      if (name === 'modifyAFWebpackOpts') {
+        const ret = handler({
+          memo: {
+            xxx: {},
+            alias: {
+              test: 'hi/hello',
+            },
+          },
+        });
+        expect(ret).toEqual({
+          xxx: {},
+          alias: {
+            test: 'hi/hello',
+          },
+        });
+      }
+    };
+    localePlugin(api);
+  });
+
+  test('enable is true', () => {
+    api.service.config.locale = {
+      enable: true,
+    };
+    api.register = (name, handler) => {
+      if (name === 'modifyPageWatchers') {
+        const ret = handler({
+          memo: ['/some/test'],
+        });
+        expect(ret).toEqual(['/some/test', `${absSrcPath}/locale`]);
+      }
+      if (name === 'modifyRouterContent') {
+        const ret = handler({
+          memo: '<Router />',
+        });
+        expect(ret).toEqual(expect.stringContaining('<Router />'));
+        expect(ret).toEqual(expect.stringContaining('<Router />'));
+        expect(ret).toEqual(expect.stringContaining('<LocaleProvider'));
+        expect(ret).toEqual(expect.stringContaining('<IntlProvider'));
+      }
+      if (name === 'modifyRouterFile') {
+        const ret = handler({
+          memo: 'test-placeholder',
+        });
+        expect(ret).toEqual(expect.stringContaining('test-placeholder'));
+        expect(ret).toEqual(expect.stringContaining('LocaleProvider'));
+        expect(ret).toEqual(expect.stringContaining('IntlProvider'));
+      }
+      if (name === 'modifyAFWebpackOpts') {
+        const ret = handler({
+          memo: {
+            xxx: {},
+            alias: {
+              test: 'hi/hello',
+            },
+          },
+        });
+        expect(ret).toEqual({
+          xxx: {},
+          alias: {
+            test: 'hi/hello',
+            'umi/locale': join(__dirname, '../src/locale.js'),
+            'react-intl': expect.stringContaining('react-intl'),
+          },
+        });
+      }
+    };
+    localePlugin(api);
+  });
+});
+
+test('antd is false', () => {
+  api.service.config.locale = {
+    enable: true,
+    antd: false,
+  };
+  api.register = (name, handler) => {
+    if (name === 'modifyPageWatchers') {
+      const ret = handler({
+        memo: ['/some/test'],
+      });
+      expect(ret).toEqual(['/some/test', `${absSrcPath}/locale`]);
+    }
+    if (name === 'modifyRouterContent') {
+      const ret = handler({
+        memo: '<Router />',
+      });
+      expect(ret).toEqual(expect.stringContaining('<Router />'));
+      expect(ret).toEqual(expect.stringContaining('<Router />'));
+      expect(ret).not.toEqual(expect.stringContaining('<LocaleProvider'));
+      expect(ret).toEqual(expect.stringContaining('<IntlProvider'));
+    }
+    if (name === 'modifyRouterFile') {
+      const ret = handler({
+        memo: 'test-placeholder',
+      });
+      expect(ret).toEqual(expect.stringContaining('test-placeholder'));
+      expect(ret).not.toEqual(expect.stringContaining('LocaleProvider'));
+      expect(ret).not.toEqual(expect.stringContaining('antd'));
+      expect(ret).toEqual(expect.stringContaining('IntlProvider'));
+    }
+    if (name === 'modifyAFWebpackOpts') {
+      const ret = handler({
+        memo: {
+          xxx: {},
+          alias: {
+            test: 'hi/hello',
+          },
+        },
+      });
+      expect(ret).toEqual({
+        xxx: {},
+        alias: {
+          test: 'hi/hello',
+          'umi/locale': join(__dirname, '../src/locale.js'),
+          'react-intl': expect.stringContaining('react-intl'),
+        },
+      });
+    }
+  };
+  localePlugin(api);
+});
+
+describe('test func with singular true', () => {
+  test('getLocaleFileList', () => {
+    const list = getLocaleFileList(absSrcPath, true);
+    expect(list).toEqual([
+      {
+        lang: 'en',
+        country: 'US',
+        name: 'en-US',
+        path: `${absSrcPath}/locale/en-US.js`,
+      },
+      {
+        lang: 'zh',
+        country: 'CN',
+        name: 'zh-CN',
+        path: `${absSrcPath}/locale/zh-CN.js`,
+      },
+    ]);
+  });
+});
+
+describe('test func with singular false', () => {
+  test('getLocaleFileList', () => {
+    const list = getLocaleFileList(absSrcPath, false);
+    expect(list).toEqual([]);
+  });
+});

--- a/packages/umi-plugin-locale/test/index.test.js
+++ b/packages/umi-plugin-locale/test/index.test.js
@@ -17,57 +17,14 @@ const api = {
       singular: true,
     },
     paths: {
-      absSrcPath: absSrcPath,
+      absSrcPath,
     },
   },
   register() {},
 };
 
 describe('test plugin', () => {
-  test('not modify content when enable is not true', () => {
-    api.register = (name, handler) => {
-      if (name === 'modifyPageWatchers') {
-        const ret = handler({
-          memo: ['/some/test'],
-        });
-        expect(ret).toEqual(['/some/test']);
-      }
-      if (name === 'modifyRouterContent') {
-        const ret = handler({
-          memo: '<Router />',
-        });
-        expect(ret).toEqual('<Router />');
-      }
-      if (name === 'modifyRouterFile') {
-        const ret = handler({
-          memo: 'test-placeholder',
-        });
-        expect(ret).toEqual('test-placeholder');
-      }
-      if (name === 'modifyAFWebpackOpts') {
-        const ret = handler({
-          memo: {
-            xxx: {},
-            alias: {
-              test: 'hi/hello',
-            },
-          },
-        });
-        expect(ret).toEqual({
-          xxx: {},
-          alias: {
-            test: 'hi/hello',
-          },
-        });
-      }
-    };
-    localePlugin(api);
-  });
-
   test('enable is true', () => {
-    api.service.config.locale = {
-      enable: true,
-    };
     api.register = (name, handler) => {
       if (name === 'modifyPageWatchers') {
         const ret = handler({
@@ -116,10 +73,6 @@ describe('test plugin', () => {
 });
 
 test('antd is false', () => {
-  api.service.config.locale = {
-    enable: true,
-    antd: false,
-  };
   api.register = (name, handler) => {
     if (name === 'modifyPageWatchers') {
       const ret = handler({
@@ -164,7 +117,9 @@ test('antd is false', () => {
       });
     }
   };
-  localePlugin(api);
+  localePlugin(api, {
+    antd: false,
+  });
 });
 
 describe('test func with singular true', () => {

--- a/packages/umi-plugin-locale/test/locale.test.js
+++ b/packages/umi-plugin-locale/test/locale.test.js
@@ -1,0 +1,59 @@
+import {
+  formatMessage,
+  setLocale,
+  getLocale,
+  FormattedMessage,
+} from '../src/locale';
+
+jest.mock('react-intl');
+
+var localStorageMock = (function() {
+  var store = {};
+
+  return {
+    getItem: function(key) {
+      return store[key] || null;
+    },
+    setItem: function(key, value) {
+      store[key] = value.toString();
+    },
+    clear: function() {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+});
+
+Object.defineProperty(location, 'reload', {
+  value: () => {},
+});
+
+describe('test umi/locale', () => {
+  test('api exist', () => {
+    expect(formatMessage).toBeTruthy();
+    expect(setLocale).toBeTruthy();
+    expect(getLocale).toBeTruthy();
+    expect(FormattedMessage).toBeTruthy();
+  });
+
+  test('setLocale', () => {
+    expect(() => {
+      setLocale('xxll1');
+    }).toThrow();
+    expect(() => {
+      setLocale('zh-cn');
+    }).toThrow();
+    expect(() => {
+      setLocale('zh_CN');
+    }).toThrow();
+
+    setLocale('zh-CN');
+    expect(window.localStorage.getItem('umi_locale')).toBe('zh-CN');
+    expect(getLocale()).toBe('zh-CN');
+    setLocale('en-US');
+    expect(getLocale()).toBe('en-US');
+  });
+});

--- a/packages/umi-plugin-react/package.json
+++ b/packages/umi-plugin-react/package.json
@@ -30,6 +30,7 @@
     "umi-utils": "^0.0.1",
     "umi-plugin-dll": "^0.2.1",
     "umi-plugin-dva": "^0.9.1",
+    "umi-plugin-locale": "^1.0.1",
     "umi-plugin-polyfill": "^0.2.0",
     "webpack": "^4.16.1",
     "workbox-webpack-plugin": "^3.4.1"

--- a/packages/umi-plugin-react/src/index.js
+++ b/packages/umi-plugin-react/src/index.js
@@ -30,9 +30,14 @@ export default function(api, options) {
       ...toObject(options.dva),
       dynamicImport: options.dynamicImport,
     });
+  if (options.locale)
+    require('umi-plugin-locale').default(api, {
+      antd: options.antd,
+      ...options.locale,
+    });
   if (options.polyfills)
     require('./plugins/polyfills').default(api, options.polyfills);
 
   // antd + antd-mobile
-  require('./plugins/antd').default(api);
+  if (options.antd) require('./plugins/antd').default(api, options.antd);
 }

--- a/packages/umi-plugin-react/src/plugins/dynamicImport.js
+++ b/packages/umi-plugin-react/src/plugins/dynamicImport.js
@@ -13,7 +13,7 @@ export default function(api, options) {
     });
 
     api.register('modifyRouteComponent', ({ args }) => {
-      const { webpackChunkName, importPath } = args;
+      const { importPath, webpackChunkName } = args;
 
       let loadingOpts = '';
       if (options.loadingComponent) {

--- a/packages/umi/src/build.js
+++ b/packages/umi/src/build.js
@@ -1,8 +1,0 @@
-import Service from 'umi-build-dev/lib/Service';
-import buildDevOpts from './buildDevOpts';
-
-process.env.NODE_ENV = 'production';
-
-export default function(opts = {}) {
-  new Service(buildDevOpts(opts)).run('build', opts);
-}

--- a/packages/umi/src/dev.js
+++ b/packages/umi/src/dev.js
@@ -1,8 +1,0 @@
-import Service from 'umi-build-dev/lib/Service';
-import buildDevOpts from './buildDevOpts';
-
-process.env.NODE_ENV = 'development';
-
-export default function(opts = {}) {
-  new Service(buildDevOpts(opts)).run('dev', opts);
-}

--- a/packages/umi/src/scripts/build.js
+++ b/packages/umi/src/scripts/build.js
@@ -1,9 +1,12 @@
 import yParser from 'yargs-parser';
-import build from '../build';
+import buildDevOpts from '../buildDevOpts';
+
+process.env.NODE_ENV = 'production';
 
 const argv = yParser(process.argv.slice(2));
-
-build({
+const opts = {
   ...argv,
   plugins: argv.plugins ? argv.plugins.split(',') : [],
-});
+};
+const Service = require('umi-build-dev/lib/Service').default;
+new Service(buildDevOpts(opts)).run('build', opts);

--- a/packages/umi/src/scripts/realDev.js
+++ b/packages/umi/src/scripts/realDev.js
@@ -1,14 +1,17 @@
 import yParser from 'yargs-parser';
-import dev from '../dev';
-
-const argv = yParser(process.argv.slice(2));
+import buildDevOpts from '../buildDevOpts';
 
 // 修复 Ctrl+C 时 dev server 没有正常退出的问题
 process.on('SIGINT', () => {
   process.exit(1);
 });
 
-dev({
+process.env.NODE_ENV = 'development';
+
+const argv = yParser(process.argv.slice(2));
+const opts = {
   ...argv,
   plugins: argv.plugins ? argv.plugins.split(',') : [],
-});
+};
+const Service = require('umi-build-dev/lib/Service').default;
+new Service(buildDevOpts(opts)).run('dev', opts);

--- a/packages/umi/src/scripts/test.js
+++ b/packages/umi/src/scripts/test.js
@@ -1,14 +1,12 @@
-import test from '../test';
+import yParser from 'yargs-parser';
+import buildDevOpts from '../buildDevOpts';
 
-const args = process.argv.slice(2);
+process.env.NODE_ENV = 'development';
 
-const watch = args.indexOf('-w') > -1 || args.indexOf('--watch') > -1;
-const coverage = args.indexOf('--coverage') > -1;
-
-test({
-  watch,
-  coverage,
-}).catch(e => {
-  console.log(e);
-  process.exit(1);
-});
+const argv = yParser(process.argv.slice(2));
+const opts = {
+  ...argv,
+  plugins: argv.plugins ? argv.plugins.split(',') : [],
+};
+const Service = require('umi-build-dev/lib/Service').default;
+new Service(buildDevOpts(opts)).run('test', opts);

--- a/packages/umi/src/test.js
+++ b/packages/umi/src/test.js
@@ -1,1 +1,0 @@
-export default from 'umi-test';


### PR DESCRIPTION
## TODO

* [x] 保证 api.service.routes 输出的稳定性

## 例子

在入口文件 .umi/umi.js 添加一行 `alert('hello umi plugin!');`。

```js
export default (api) => {
  api.register('modifyEntry', ({ memo }) => {
    return `
${memo}
alert('hello umi plugin!');`.trim();
  });
}
```

## 说明

umi 整体是由插件串联起来的，除了基础功能，umi 内部也是由插件实现的。

插件可以做什么？

1. 注册命令行
2. 挖坑填坑
3. UI 插件

### 注册命令行

umi 内部的 dev、build、test 都是由此实现，bigfish 的 pack 也可以改成这种方式。

```js
api.registerCommand('x', options, fn);
```

参考：https://github.com/umijs/umi/blob/master/packages/umi-build-dev/src/plugins/commands/dev/index.js#L25

### 挖坑填坑

插件本质上就是挖坑和填坑，umi 里的坑（hooks）分两类：

1. 事件类型，以 `on`，`before` 和 `after` 为前缀
1. 修改类型，以 `modify` 为前缀，提供 memo 供修改

事件类型。

```js
applyPlugins('a', { args });

register('a', ({ args }) => {
  // do something
});
```

修改类型。

```js
const b = api.register('a', { memo, args });

register('a', ({ memo, args }) => {
  // return new memo
});
```

注意点：

* 所有 hook 都是同步的，目前暂无异步需求
* 插件本身也可以通过 api.service.applyPlugin 挖坑，让其他插件来填
* 插件目前没有依赖机制，通过调整数组的先后顺序实现

### UI 插件

https://cli.vuejs.org/dev-guide/ui-api.html#project-configurations

**方案待定。**

比如，我们有整体的 UI 配置界面，然后可以在这里添加额外的 UI 配置项：

```js
api.describeConfig({ id, desc, options });
```

## 插件接口

### 环境变量

* process.env.NODE_ENV，区分 development 和 production

### api 方法

* register(hook, ({ memo, args }) => {})
* registerCommand(commandName, () => {})
* debug()

封装 register 的辅助方法：

* chainWebpackConfig(webpackConfig)
* ...

### api.service

* cwd
* pkg
* config
* webpackConfig
* paths
  * outputPath
  * absOutputPath
  * pagesPath
  * absPagesPath
  * tmpDirPath
  * absTmpDirPath
  * absSrcPath
* routes
* dev
  * server
  * restart(why)
  * rebuildFiles()

### umi-utils

* winPath(str)
* findJS(baseDir, fileNameWithoutExtname)
* compatDirname(path, cwd, fallback)

## Hooks

### 生命周期相关

* onStart
* onBuildSuccess, args: { stats }
* onBuildFail, args: { err }
* onDevCompileDone, args: { isFirstCompile, stats }
* onGenerateFiles, args: { isRebuild }
* onConfigChange, args: { newConfig }
* beforeDevServer, args: { devServer }
* afterDevServer, args: { devServer }

### 临时文件生成相关

* modifyPageWatchers
* modifyEntryFile
* modifyRouterFile

### 路由相关

* modifyRoutes
* modifyRouterContent
* modifyRouteComponent, args: { importPath, webpackChunkName }

### HTML 相关

* modifyHTMLTemplate
* modifyHTMLScript
* modifyHTML, args: { path }

### 配置相关

* _modifyConfigPlugins，提供额外的配置项
* modifyDefaultConfig，修改默认配置项
* modifyConfig，修改最终配置
* modifyAFWebpackOpts，修改传递给 af-webpack 的配置项
* modifyWebpackConfig，修改最终 webpack 配置，deprecated，推荐用下面的 chainWebpackConfig
* chainWebpackConfig，通过 webpack-chain 修改 webpack 配置

### webpackDevServer 相关

* _onBeforeServerWithApp, args: { app }
* modifyBeforeMiddlewares
* modifyAfterMiddlewares
