### PR TITLE
生成模式下生成的404组件，component属性不是真实路径，导致查找model时间过长

### DIFF
--- a/packages/umi-plugin-dva/src/index.js
+++ b/packages/umi-plugin-dva/src/index.js
@@ -32,7 +32,7 @@ export function getModel(cwd, service) {
 function getModelsWithRoutes(routes, service) {
   const { paths } = service;
   return routes.reduce((memo, route) => {
-    if (route.component) {
+    if (route.path && route.component) {
       return [
         ...memo,
         ...getPageModels(join(paths.cwd, route.component), service),


### PR DESCRIPTION
#739 