### PR TITLE
Feat: Upgrade atool-monitor to report more data

### DIFF
--- a/packages/umi/bin/umi.js
+++ b/packages/umi/bin/umi.js
@@ -26,12 +26,15 @@ updater({ pkg: pkg }).notify({ defer: true });
 
 function runScript(script, args, isFork) {
   if (isFork) {
+    const reportData = getReportData(script);
     const child = spawn.sync(
       'node',
       [require.resolve(`../lib/scripts/${script}`)].concat(args),
       {stdio: 'inherit'} // eslint-disable-line
     );
-    process.exit(child.status);
+    report(script, reportData, child.status).finally(() => { // 保证 monitor 上传数据完成后再退出进程
+      process.exit(child.status);
+    });
   } else {
     require(`../lib/scripts/${script}`);
   }
@@ -54,7 +57,6 @@ switch (aliasedScript) {
     break;
   case 'build':
   case 'dev':
-    require('atool-monitor').emit();
     runScript(aliasedScript, args, /* isFork */true);
     break;
   case 'test':
@@ -65,4 +67,73 @@ switch (aliasedScript) {
       require('../lib/buildDevOpts').default()
     ).run(script);
     break;
+}
+
+function getReportData(script) {
+  return (script === 'dev' && getDevData()) || (script === 'build' && getBuildData());
+}
+
+function report(script, reportData, status) {
+  if (script === 'dev') {
+    const { appData, appExtraData, devData, devExtraData } = reportData;
+    return reportDev(appData, appExtraData, devData, devExtraData, status);
+  } else if (script === 'build') {
+    const { buildData, extraData } = reportData;
+    return reportBuild(buildData, extraData, status);
+  }
+}
+
+function getDevData() {
+  const appData = {
+    reportFrom: 'umi',
+  };
+  const appExtraData = {
+    umiVersion: require('../package.json').version,
+    antdVersion: require(dirname(require.resolve('antd/package.json'))).version,
+  };
+  const devData = {
+    reportFrom: 'umi',
+    env: {
+      NODE_ENV: process.env.NODE_ENV,
+      UMI_ENV: process.env.UMI_ENV,
+    },
+    startTime: Date.now(),
+  };
+  const devExtraData = {
+    umiVersion: require('../package.json').version,
+  };
+  return { appData, appExtraData, devData, devExtraData };
+}
+
+function getBuildData() {
+  const buildData = {
+    reportFrom: 'umi',
+    env: {
+      NODE_ENV: process.env.NODE_ENV,
+      UMI_ENV: process.env.UMI_ENV,
+    },
+    startTime: Date.now(),
+  };
+  const extraData = {
+    umiVersion: require('../package.json').version,
+  };
+  return { buildData, extraData };
+}
+
+// 上报 app + dev 信息
+function reportDev(appData, appExtraData, devData, devExtraData, status = 0) {
+  const newDevData = Object.assign(devData, {
+    endTime: Date.now(),
+    status: status === 0 ? 'success' : 'fail',
+  });
+  return require('atool-monitor').reportData(appData, appExtraData, newDevData, devExtraData);
+}
+
+// 上报构建信息
+function reportBuild(buildData, extraData, status = 0) {
+  const newBuildData = Object.assign(buildData, {
+    endTime: Date.now(),
+    status: status === 0 ? 'success' : 'fail',
+  });
+  return require('atool-monitor').reportBuildData(newBuildData, extraData);
 }

--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@babel/runtime": "7.0.0-beta.46",
     "@types/react": "^16.1.0",
-    "atool-monitor": "^0.4.4",
+    "atool-monitor": "^1.0.4",
     "babel-preset-umi": "^1.0.0-beta.1",
     "chai": "^4.1.2",
     "cross-spawn": "^6.0.5",


### PR DESCRIPTION
Upgrade [atool-monitor](https://www.npmjs.com/package/atool-monitor) to version `1.x` to report dev data and build data. The interface `reportData` and `reportBuildData` of `atool-monitor` both return a `promise` object.