### PR TITLE
Feat: Add atool monitor for umi@1.x

### DIFF
--- a/packages/umi/bin/umi.js
+++ b/packages/umi/bin/umi.js
@@ -52,6 +52,7 @@ switch (aliasedScript) {
   case 'build':
   case 'dev':
   case 'generate':
+    require('atool-monitor').emit();
     runScript(aliasedScript, args, /* isFork */true);
     break;
   case 'test':

--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@babel/runtime": "7.0.0-beta.46",
     "@types/react": "^16.1.0",
+    "atool-monitor": "^0.4.5",
     "babel-preset-umi": "^0.3.1",
     "chai": "^4.1.2",
     "cross-spawn": "^6.0.5",


### PR DESCRIPTION
- Use atool-monitor@0.x, because there is no demands to report more data for now.