### PR TITLE
fix: move umi.css to the last

### DIFF
--- a/packages/umi-build-dev/src/html/HTMLGenerator.js
+++ b/packages/umi-build-dev/src/html/HTMLGenerator.js
@@ -291,12 +291,6 @@ export default class HTMLGenerator {
     scripts.push({
       src: `<%= pathToPublicPath %>${this.getHashedFileName('umi.js')}`,
     });
-    if (this.env === 'production' && this.chunksMap['umi.css']) {
-      links.push({
-        rel: 'stylesheet',
-        href: `<%= pathToPublicPath %>${this.getHashedFileName('umi.css')}`,
-      });
-    }
 
     if (this.modifyMetas) metas = this.modifyMetas(metas);
     if (this.modifyLinks) links = this.modifyLinks(links);
@@ -304,6 +298,14 @@ export default class HTMLGenerator {
     if (this.modifyStyles) styles = this.modifyStyles(styles);
     if (this.modifyHeadScripts)
       headScripts = this.modifyHeadScripts(headScripts);
+
+    if (this.env === 'production' && this.chunksMap['umi.css']) {
+      // umi.css should be the last one stylesheet
+      links.push({
+        rel: 'stylesheet',
+        href: `<%= pathToPublicPath %>${this.getHashedFileName('umi.css')}`,
+      });
+    }
 
     // insert tags
     html = html.replace(

--- a/packages/umi-build-dev/src/html/HTMLGenerator.test.js
+++ b/packages/umi-build-dev/src/html/HTMLGenerator.test.js
@@ -108,6 +108,13 @@ describe('HG', () => {
         absPageDocumentPath: '/tmp/files-not-exists',
         defaultDocumentPath: join(__dirname, 'fixtures/document.ejs'),
       },
+      modifyLinks: links => {
+        links.push({
+          rel: 'stylesheet',
+          href: 'http://ant.design/test.css',
+        });
+        return links;
+      },
     });
     const content = hg.getContent({
       path: '/',
@@ -116,6 +123,7 @@ describe('HG', () => {
       `
 <head>
 
+<link rel="stylesheet" href="http://ant.design/test.css" />
 <link rel="stylesheet" href="/umi.css" />
 <script>
   window.routerBase = "/";


### PR DESCRIPTION
umi 的样式应该在其它引入的第三方样式之后，这样才能使得用户在应用中的样式的优先级是最高的，不会被第三方样式覆盖。