### PR TITLE
fix: runtime error overlay don't work

### DIFF
--- a/packages/af-webpack/src/getConfig/dev.js
+++ b/packages/af-webpack/src/getConfig/dev.js
@@ -3,7 +3,7 @@ import { join } from 'path';
 
 export default function(webpackConfig, opts) {
   webpackConfig
-    .devtool(opts.devtool || 'cheap-module-eval-source-map')
+    .devtool(opts.devtool || 'cheap-module-source-map')
     .output.pathinfo(true);
 
   webpackConfig

--- a/packages/af-webpack/src/webpackHotDevClient.js
+++ b/packages/af-webpack/src/webpackHotDevClient.js
@@ -46,7 +46,6 @@ ErrorOverlay.startReportingRuntimeErrors({
   onError: function() {
     hadRuntimeError = true;
   },
-  filename: '/static/js/bundle.js',
 });
 
 if (module.hot && typeof module.hot.dispose === 'function') {


### PR DESCRIPTION
cheap-module-eval-source-map 会导致 `window.addEventListener('error')` 不工作。
