### PR TITLE
fix: mock bug with babel7

### DIFF
--- a/packages/umi-build-dev/src/plugins/mock/createMockMiddleware.js
+++ b/packages/umi-build-dev/src/plugins/mock/createMockMiddleware.js
@@ -103,21 +103,23 @@ export default function getMockMiddleware(api) {
   function normalizeConfig(config) {
     return Object.keys(config).reduce((memo, key) => {
       const handler = config[key];
-      const type = typeof handler;
-      assert(
-        type === 'function' || type === 'object',
-        `mock value of ${key} should be function or object, but got ${type}`,
-      );
-      const { method, path } = parseKey(key);
-      const keys = [];
-      const re = pathToRegexp(path, keys);
-      memo.push({
-        method,
-        path,
-        re,
-        keys,
-        handler: createHandler(method, path, handler),
-      });
+      if (key !== '__esModule') {
+        const type = typeof handler;
+        assert(
+          type === 'function' || type === 'object',
+          `mock value of ${key} should be function or object, but got ${type}`,
+        );
+        const { method, path } = parseKey(key);
+        const keys = [];
+        const re = pathToRegexp(path, keys);
+        memo.push({
+          method,
+          path,
+          re,
+          keys,
+          handler: createHandler(method, path, handler),
+        });
+      }
       return memo;
     }, []);
   }


### PR DESCRIPTION
babel7 里面 module 会有一个  `__esModule` 标记是否是 es module，会导致这里的 assert 报错。