### PR TITLE
fix: simple filter not yaml comment

### DIFF
--- a/packages/umi-build-dev/src/routes/getYamlConfig.js
+++ b/packages/umi-build-dev/src/routes/getYamlConfig.js
@@ -5,18 +5,21 @@ const debug = require('debug')('umi-build-dev:getYamlConfig');
 
 export default function(code) {
   const comments = extractComments(code);
-  return comments.slice(0, 1).reduce((memo, { value }) => {
-    const v = value.replace(/^(\s+)?\*/gm, '');
-    debug(v);
-    try {
-      const yamlResult = yaml.safeLoad(v);
-      return {
-        ...memo,
-        ...yamlResult,
-      };
-    } catch (e) {
-      console.error(`yaml load failed: ${e}`);
-    }
-    return memo;
-  }, {});
+  return comments
+    .slice(0, 1)
+    .filter(c => c.value.includes(':'))
+    .reduce((memo, { value }) => {
+      const v = value.replace(/^(\s+)?\*/gm, '');
+      debug(v);
+      try {
+        const yamlResult = yaml.safeLoad(v);
+        return {
+          ...memo,
+          ...yamlResult,
+        };
+      } catch (e) {
+        console.error(`yaml load failed: ${e}`);
+      }
+      return memo;
+    }, {});
 }

--- a/packages/umi-build-dev/src/routes/getYamlConfig.test.js
+++ b/packages/umi-build-dev/src/routes/getYamlConfig.test.js
@@ -57,4 +57,14 @@ c: d
       a: 'b',
     });
   });
+
+  it('ignore invalid yaml comment', () => {
+    expect(
+      getYamlConfig(`
+/*
+ * this is a normal text
+ */
+    `),
+    ).toEqual({});
+  });
 });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2127199/44137794-47377820-a0a4-11e8-98e4-f31de479b89e.png)

发现生成的 routes 信息包含无关的信息，所以简单过滤下 yaml 加载进来的数据。