### PR TITLE
fix: process receive sigint should exit 0

### DIFF
--- a/packages/umi/src/scripts/realDev.js
+++ b/packages/umi/src/scripts/realDev.js
@@ -1,10 +1,24 @@
 import yParser from 'yargs-parser';
 import buildDevOpts from '../buildDevOpts';
 
-// 修复 Ctrl+C 时 dev server 没有正常退出的问题
-process.on('SIGINT', () => {
-  process.exit(1);
-});
+let closed = false;
+
+// kill(2) Ctrl-C
+process.once('SIGINT', () => onSignal('SIGINT'));
+// kill(3) Ctrl-\
+process.once('SIGQUIT', () => onSignal('SIGQUIT'));
+// kill(15) default
+process.once('SIGTERM', () => onSignal('SIGTERM'));
+
+function onSignal(signal) {
+  if (closed) return;
+  closed = true;
+  console.warn('umi dev receive signal %s, closing.', signal);
+  // sleep to make sure SIGTERM send to the child processes
+  setTimeout(() => {
+    process.exit(0);
+  }, 5000);
+}
 
 process.env.NODE_ENV = 'development';
 


### PR DESCRIPTION
SIGINT 信号应该通知进程正常退出。
现在 CTRL + C 会报一堆红色的错误信息，让人误解。