### PR TITLE
feat: use extend2 for deep merge config

### DIFF
--- a/packages/umi-build-dev/package.json
+++ b/packages/umi-build-dev/package.json
@@ -16,6 +16,7 @@
     "dotenv": "^6.0.0",
     "ejs": "^2.5.7",
     "esprima-extract-comments": "^1.1.0",
+    "extend2": "^1.0.0",
     "html-minifier": "^3.5.9",
     "http-proxy-middleware": "^0.18.0",
     "is-plain-object": "^2.0.4",

--- a/packages/umi-build-dev/src/UserConfig.js
+++ b/packages/umi-build-dev/src/UserConfig.js
@@ -5,6 +5,7 @@ import chalk from 'chalk';
 import didyoumean from 'didyoumean';
 import clone from 'lodash.clonedeep';
 import flatten from 'lodash.flatten';
+import extend from 'extend2';
 import { CONFIG_FILES } from './constants';
 import { watch, unwatch } from './getConfig/watch';
 import isEqual from './isEqual';
@@ -97,16 +98,15 @@ class UserConfig {
       initialValue: {},
     });
     if (absConfigPath) {
-      return normalizeConfig({
-        ...defaultConfig,
-        ...requireFile(absConfigPath),
-        ...(env
-          ? requireFile(absConfigPath.replace(/\.js$/, `.${env}.js`))
-          : {}),
-        ...(isDev
-          ? requireFile(absConfigPath.replace(/\.js$/, '.local.js'))
-          : {}),
-      });
+      return normalizeConfig(
+        extend(
+          true,
+          defaultConfig,
+          requireFile(absConfigPath),
+          env ? requireFile(absConfigPath.replace(/\.js$/, `.${env}.js`)) : {},
+          isDev ? requireFile(absConfigPath.replace(/\.js$/, '.local.js')) : {},
+        ),
+      );
     } else {
       return {};
     }
@@ -180,12 +180,15 @@ class UserConfig {
       throw new Error(msg);
     }
 
-    config = normalizeConfig({
-      ...defaultConfig,
-      ...requireFile(file, { onError }),
-      ...(env ? requireFile(file.replace(/\.js$/, `.${env}.js`)) : {}),
-      ...(isDev ? requireFile(file.replace(/\.js$/, '.local.js')) : {}),
-    });
+    config = normalizeConfig(
+      extend(
+        true,
+        defaultConfig,
+        requireFile(file, { onError }),
+        env ? requireFile(file.replace(/\.js$/, `.${env}.js`)) : {},
+        isDev ? requireFile(file.replace(/\.js$/, '.local.js')) : {},
+      ),
+    );
 
     config = this.service.applyPlugins('_modifyConfig', {
       initialValue: config,

--- a/packages/umi-build-dev/src/UserConfig.test.js
+++ b/packages/umi-build-dev/src/UserConfig.test.js
@@ -17,6 +17,12 @@ describe('static UserConfig', () => {
     });
     expect(config).toEqual({
       alias: { a: 'b' },
+      deep: {
+        a: {
+          b: '111',
+          c: '222',
+        },
+      },
     });
   });
 
@@ -30,6 +36,12 @@ describe('static UserConfig', () => {
     expect(config).toEqual({
       alias: { a: 'b' },
       custom: 1,
+      deep: {
+        a: {
+          b: '333',
+          c: '222',
+        },
+      },
     });
   });
 
@@ -43,6 +55,12 @@ describe('static UserConfig', () => {
     expect(config).toEqual({
       alias: { a: 'b' },
       local: 1,
+      deep: {
+        a: {
+          b: '111',
+          c: '222',
+        },
+      },
     });
   });
 
@@ -59,6 +77,12 @@ describe('static UserConfig', () => {
       alias: { a: 'b' },
       local: 1,
       custom: 1,
+      deep: {
+        a: {
+          b: '333',
+          c: '222',
+        },
+      },
     });
   });
 

--- a/packages/umi-build-dev/src/fixtures/UserConfig/config-config/config/config.custom.js
+++ b/packages/umi-build-dev/src/fixtures/UserConfig/config-config/config/config.custom.js
@@ -1,4 +1,9 @@
 
 export default {
   custom: 1,
+  deep: {
+    a: {
+      b: '333'
+    }
+  }
 };

--- a/packages/umi-build-dev/src/fixtures/UserConfig/config-config/config/config.js
+++ b/packages/umi-build-dev/src/fixtures/UserConfig/config-config/config/config.js
@@ -3,5 +3,11 @@ export default {
   alias: {
     a: 'b',
   },
+  deep: {
+    a: {
+      b: '111',
+      c: '222'
+    }
+  }
 }
 


### PR DESCRIPTION
原先的 getConfig 方式不会 deep merge，都会以后一个完整覆盖前一个对象。
这就造成了比较深的对象要在每个 config 都完成声明一遍，比如 define 配置。
extend2 是保持和 egg 一致的配置合并方式。