### PR TITLE
feat: builddevoptions cwd support dot env

### DIFF
--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -10,6 +10,7 @@
     "chai": "^4.1.2",
     "cross-spawn": "^6.0.5",
     "debug": "^3.1.0",
+    "dotenv": "^6.0.0",
     "ejs": "^2.5.7",
     "is-windows": "^1.0.2",
     "path-is-absolute": "^1.0.1",

--- a/packages/umi/src/buildDevOpts.js
+++ b/packages/umi/src/buildDevOpts.js
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 import isAbsolute from 'path-is-absolute';
 import isWindows from 'is-windows';
 import slash from 'slash2';
@@ -26,10 +26,13 @@ export default function(opts = {}) {
 }
 
 function loadDotEnv() {
-  const parsed = parse(readFileSync(join(process.cwd(), '.env'), 'utf-8'));
-  Object.keys(parsed).forEach(key => {
-    if (!process.env.hasOwnProperty(key)) {
-      process.env[key] = parsed[key];
-    }
-  });
+  const envPath = join(process.cwd(), '.env');
+  if (existsSync(envPath)) {
+    const parsed = parse(readFileSync(envPath, 'utf-8'));
+    Object.keys(parsed).forEach(key => {
+      if (!process.env.hasOwnProperty(key)) {
+        process.env[key] = parsed[key];
+      }
+    });
+  }
 }

--- a/packages/umi/src/buildDevOpts.js
+++ b/packages/umi/src/buildDevOpts.js
@@ -1,9 +1,13 @@
 import { join } from 'path';
+import { readFileSync } from 'fs';
 import isAbsolute from 'path-is-absolute';
 import isWindows from 'is-windows';
 import slash from 'slash2';
+import { parse } from 'dotenv';
 
 export default function(opts = {}) {
+  loadDotEnv();
+
   let cwd = opts.cwd || process.env.APP_ROOT;
   if (cwd) {
     if (!isAbsolute(cwd)) {
@@ -19,4 +23,13 @@ export default function(opts = {}) {
   return {
     cwd,
   };
+}
+
+function loadDotEnv() {
+  const parsed = parse(readFileSync(join(process.cwd(), '.env'), 'utf-8'));
+  Object.keys(parsed).forEach(key => {
+    if (!process.env.hasOwnProperty(key)) {
+      process.env[key] = parsed[key];
+    }
+  });
 }

--- a/packages/umi/src/buildDevOpts.js
+++ b/packages/umi/src/buildDevOpts.js
@@ -26,13 +26,20 @@ export default function(opts = {}) {
 }
 
 function loadDotEnv() {
-  const envPath = join(process.cwd(), '.env');
-  if (existsSync(envPath)) {
-    const parsed = parse(readFileSync(envPath, 'utf-8'));
-    Object.keys(parsed).forEach(key => {
-      if (!process.env.hasOwnProperty(key)) {
-        process.env[key] = parsed[key];
-      }
-    });
-  }
+  const baseEnvPath = join(process.cwd(), '.env');
+  const localEnvPath = `${baseEnvPath}.local`;
+
+  const loadEnv = envPath => {
+    if (existsSync(envPath)) {
+      const parsed = parse(readFileSync(envPath, 'utf-8'));
+      Object.keys(parsed).forEach(key => {
+        if (!process.env.hasOwnProperty(key)) {
+          process.env[key] = parsed[key];
+        }
+      });
+    }
+  };
+
+  loadEnv(baseEnvPath);
+  loadEnv(localEnvPath);
 }


### PR DESCRIPTION
#### 需求是这样的：

目前 APP_ROOT 比较特殊，需要在跑 Service 之前确定 cwd 的地址。
而目前要改变这个值，只能通过命令行传值。
支持 .env 的方式会比较方便，跑 `umi g page` 的时候也不需要 alias 了。