### PR TITLE
feat: tsConfigFile path support in af-webpack userConfig

### DIFF
--- a/packages/af-webpack/src/getUserConfig/configs/tsConfigFile.js
+++ b/packages/af-webpack/src/getUserConfig/configs/tsConfigFile.js
@@ -1,0 +1,13 @@
+import assert from 'assert';
+
+export default function() {
+  return {
+    name: 'tsConfigFile',
+    validate(val) {
+      assert(
+        typeof val === 'string',
+        `The tsConfigFile config must be String, but got ${val}`,
+      );
+    },
+  };
+}


### PR DESCRIPTION
af-webpack 支持用户用 tsConfigFile 指定 tsconfig.json 路径