### PR TITLE
fix: 修复 af-webpack bin 函数调用和变量覆盖错误的问题

### DIFF
--- a/packages/af-webpack/bin/af-webpack.js
+++ b/packages/af-webpack/bin/af-webpack.js
@@ -25,14 +25,14 @@ switch (process.argv[2]) {
 }
 
 function getWebpackConfig() {
-  const { config: userConfig } = getUserConfig({
+  const { config: userConfig } = getUserConfig.default({
     cwd,
   });
   return getConfig.default({
-    ...userConfig,
-    cwd,
     entry: {
       index: './index.ts',
     },
+    ...userConfig,
+    cwd,
   });
 }


### PR DESCRIPTION
修复 af-webpack cli 脚本中的两个问题：
- entry 覆盖顺序有误
- 函数调用有误