### PR TITLE
feat: 开放 af-webpack chainConfig 配置

### DIFF
--- a/packages/af-webpack/src/getUserConfig/configs/chainConfig.js
+++ b/packages/af-webpack/src/getUserConfig/configs/chainConfig.js
@@ -1,0 +1,13 @@
+import assert from 'assert';
+
+export default function() {
+  return {
+    name: 'chainConfig',
+    validate(val) {
+      assert(
+        typeof val === 'function',
+        `The chainConfig config must be Function, but got ${val}`,
+      );
+    },
+  };
+}


### PR DESCRIPTION
支持通过 cli 调用 af-webpack 时配置 chainConfig：
- 比如自定义额外的 webpack plugin

.webpackrc.js
```js
export default {
  .chainConfig(c) {}
}
```

```
$ af-webpack dev
```