### PR TITLE
feat(af-webpack): .json 的优先级应该比 js, ts 低

### DIFF
--- a/packages/af-webpack/src/getConfig/index.js
+++ b/packages/af-webpack/src/getConfig/index.js
@@ -54,13 +54,13 @@ export default function(opts) {
       '.web.js',
       '.mjs',
       '.js',
-      '.json',
       '.web.jsx',
       '.jsx',
       '.web.ts',
       '.ts',
       '.web.tsx',
       '.tsx',
+      '.json',
     ]);
 
   if (opts.alias) {


### PR DESCRIPTION
`.json` 的优先级应该比 js, ts 低