### PR TITLE
fix: namespace can be ignored if filename is not model.js

### DIFF
--- a/packages/umi-plugin-dva/src/index.js
+++ b/packages/umi-plugin-dva/src/index.js
@@ -115,14 +115,23 @@ export default function(api, opts = {}) {
       getGlobalModels(api, shouldImportDynamic),
       optsToArray(opts.exclude),
     )
-      .map(path =>
-        `
-    app.model({ namespace: '${basename(
-      path,
-      extname(path),
-    )}', ...(require('${path}').default) });
-  `.trim(),
-      )
+      .map(path => {
+        if (path.endsWith('/model.js')) {
+          return `
+          app.model({ namespace: '${basename(
+            path,
+            extname(path),
+          )}', ...(require('${path}').default) });
+        `.trim();
+        }
+
+        return `
+        app.model({ ...(require('${path}').default), namespace: '${basename(
+          path,
+          extname(path),
+        )}', });
+      `.trim();
+      })
       .join('\r\n');
   }
 


### PR DESCRIPTION
文档里谈到`文件名即 namespace，可以省去 model 导出的 namespace key`。

尝试了一下，发现model里一旦去掉了`namespace`，就会报错: `Error: [app.model] namespace should be defined`，检查后发现是因为生成的`DvaContainer.js`里关于model注册的部分是这样的：

```javascript
app.model({ namespace: 'app', ...(require('/path/test-umi/src/models/app.js').default) });
```
所以如果`app.js`里如果没写`namespace`的话，会是这样的结果

```javascript
app.model({ namespace: 'app', ...{namespace: undefined, ...} });
```

`namespace`会被覆盖成`undefined`。于是有了这次PR。

只有在model的文件名不具备namespace含义（即：单文件model.js）时，才使用

```javascript
app.model({ namespace: 'model', ...(require('/path/test-umi/src/pages/login/model.js').default) });
```

否则使用

```javascript
app.model({ ...(require('/path/test-umi/src/models/app.js').default), namespace: 'app', });
```

用文件名代表的namespace，覆盖model里声明的namespace