### PR TITLE
Remove deprecated rule `jsx-a11y/href-no-hash`

### DIFF
--- a/packages/eslint-config-umi/package.json
+++ b/packages/eslint-config-umi/package.json
@@ -14,7 +14,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "eslint-config-react-app": "^2.0.0"
+    "eslint-config-react-app": "^2.1.0"
   },
   "peerDependencies": {
     "eslint-plugin-flowtype": "^2.34.1",


### PR DESCRIPTION
https://github.com/facebook/create-react-app/pull/2930
因为2.0.0版本包含了一个不存在的
```
'jsx-a11y/href-no-hash': 'warn',
```
所以需要升级到2.1.0版本