### PR TITLE
fix: lock version of webpack-dev-server

### DIFF
--- a/packages/af-webpack/package.json
+++ b/packages/af-webpack/package.json
@@ -57,7 +57,7 @@
     "webpack": "^4.16.5",
     "webpack-bundle-analyzer": "^2.13.1",
     "webpack-chain": "^4.8.0",
-    "webpack-dev-server": "^3.1.5",
+    "webpack-dev-server": "3.1.5",
     "webpack-manifest-plugin": "^2.0.3",
     "webpack-merge": "^4.1.4",
     "webpackbar": "^2.6.2"


### PR DESCRIPTION
高版本的 webpack-dev-server 中移除了 `webpack-dev-server/lib/optionsSchema.json` 这个文件（目前最高 3.1.8），本地调试 umi 时会报错，锁定到 3.1.5