### PR TITLE
修改开启hard-source后，修改.umirc配置文件DefinePlugin无效的问题

### DIFF
--- a/packages/af-webpack/src/getConfig/dev.js
+++ b/packages/af-webpack/src/getConfig/dev.js
@@ -21,6 +21,13 @@ export default function(webpackConfig, opts) {
     }
     webpackConfig
       .plugin('hard-source')
-      .use(require('hard-source-webpack-plugin'));
+      .use(require('hard-source-webpack-plugin'),[{
+        environmentHash: {
+          root: process.cwd(),
+          directories: [],
+          files: ['package-lock.json', 'yarn.lock', '.umirc.js', '.umirc.local.js'],
+        },
+      },
+    ]);
   }
 }

--- a/packages/af-webpack/src/getConfig/dev.js
+++ b/packages/af-webpack/src/getConfig/dev.js
@@ -24,7 +24,7 @@ export default function(webpackConfig, opts) {
       .use(require('hard-source-webpack-plugin'),[{
         environmentHash: {
           root: process.cwd(),
-          directories: [],
+          directories: ['config'],
           files: ['package-lock.json', 'yarn.lock', '.umirc.js', '.umirc.local.js'],
         },
       },


### PR DESCRIPTION
Close #1071

``` 
environmentHash: {
     root: process.cwd(),
     directories: [],
      files: ['package-lock.json', 'yarn.lock'],
},
```
默认情况下 他之监听了这2个文件
https://github.com/mzgoddard/hard-source-webpack-plugin#environmenthash