### PR TITLE
feat: add config.disableRedirectHoist

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -38,6 +38,13 @@ Configure routing.
 If `routes` is configured, the negotiated route will not take effect.
 :::
 
+### disableRedirectHoist
+
+* 类型：`Boolean`
+* 默认值：`false`
+
+For some reason, we hoist all redirect when parsing the route config, but this caused some problems, so add this configuration to disable redirect hoist.
+
 ### history
 
 * Type: `String`
@@ -72,6 +79,13 @@ Specifies the publicPath of the webpack, pointing to the path where the static r
 * Default: `false`
 
 Use the `window.publicPath` specified in the HTML when the value is `true`.
+
+### hash
+
+* Type: `Boolean`
+* Default: `false`
+
+Whether to enable the hash file suffix.
 
 ### context
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -162,7 +162,7 @@ Make sure node version is above 8 and then execute:
 $ node --inspect-brk ./node_modules/.bin/umi test
 ```
 
-Then open [chrome://inspect/#devices](chrome://inspect/#devices) in the browser for inspect and breakpoints.
+Then open chrome://inspect/#devices in the browser for inspect and breakpoints.
 
 ## Deployment
 

--- a/docs/zh/config/README.md
+++ b/docs/zh/config/README.md
@@ -38,6 +38,15 @@ export default {
 如果配置了 `routes`，则约定式路由会不生效。
 :::
 
+### disableRedirectHoist
+
+* 类型：`Boolean`
+* 默认值：`false`
+
+禁用 redirect 上提。
+
+出于一些原因的考虑，我们在处理路由时把所有 redirect 声明提到路由最前面进行匹配，但这导致了一些问题，所以添加了这个配置项，禁用 redirect 上提。
+
 ### history
 
 * 类型：`String`
@@ -72,6 +81,13 @@ export default {
 * 默认值：`false`
 
 值为 `true` 时使用 HTML 里指定的 `window.publicPath`。
+
+### hash
+
+* Type: `Boolean`
+* Default: `false`
+
+是否开启 hash 文件后缀。
 
 ### context
 

--- a/packages/umi-build-dev/src/getConfig/configPlugins/disableRedirectHoist.js
+++ b/packages/umi-build-dev/src/getConfig/configPlugins/disableRedirectHoist.js
@@ -1,0 +1,16 @@
+import assert from 'assert';
+
+export default function(api) {
+  return {
+    name: 'disableRedirectHoist',
+    validate(val) {
+      assert(
+        typeof val === 'boolean',
+        `disableRedirectHoist should be Boolean, but got ${val.toString()}.`,
+      );
+    },
+    onChange() {
+      api.service.rebuildTmpFiles();
+    },
+  };
+}

--- a/packages/umi-build-dev/src/routes/patchRoutes.js
+++ b/packages/umi-build-dev/src/routes/patchRoutes.js
@@ -6,7 +6,9 @@ let redirects;
 export default (routes, config = {}, isProduction, onPatchRoute) => {
   redirects = [];
   patchRoutes(routes, config, isProduction, onPatchRoute);
-  routes.unshift(...redirects);
+  if (!config.disableRedirectHoist) {
+    routes.unshift(...redirects);
+  }
   return routes;
 };
 
@@ -37,10 +39,12 @@ function patchRoutes(routes, config, isProduction, onPatchRoute) {
     });
   }
 
-  const removedRoutes = remove(routes, route => {
-    return route.redirect;
-  });
-  redirects = redirects.concat(removedRoutes);
+  if (!config.disableRedirectHoist) {
+    const removedRoutes = remove(routes, route => {
+      return route.redirect;
+    });
+    redirects = redirects.concat(removedRoutes);
+  }
 }
 
 function patchRoute(route, config, isProduction, onPatchRoute) {

--- a/packages/umi-build-dev/src/routes/patchRoutes.test.js
+++ b/packages/umi-build-dev/src/routes/patchRoutes.test.js
@@ -241,4 +241,36 @@ describe('patchRoutes', () => {
       },
     ]);
   });
+
+  it('disable redirect hoist', () => {
+    const routes = patchRoutes(
+      [
+        { path: '/a', component: './A' },
+        { path: '/b', redirect: '/c' },
+        {
+          path: '/c',
+          routes: [
+            { path: '/c/d', component: 'D' },
+            { path: '/c/e', redirect: '/c/f' },
+            { path: '/c/f', component: 'F' },
+          ],
+        },
+      ],
+      {
+        disableRedirectHoist: true,
+      },
+    );
+    expect(routes).toEqual([
+      { path: '/a', component: './A' },
+      { path: '/b', redirect: '/c' },
+      {
+        path: '/c',
+        routes: [
+          { path: '/c/d', component: 'D' },
+          { path: '/c/e', redirect: '/c/f' },
+          { path: '/c/f', component: 'F' },
+        ],
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
出于一些原因的考虑，我们在处理路由时把所有 redirect 声明提到路由最前面进行匹配，但这导致了一些问题，所以添加了这个配置项，禁用 redirect 上提。

比如：

1. https://github.com/ant-design/ant-design-pro/issues/2259
2. 下面的路由配置，访问 `/console` 会访问到 `/console/overview`，因为 redirect 规则往前提了。

```
routes: [{
      path: '/',
      component: 'Index/App',
      indexRoute: { redirect: '/console' },
      routes: [
        {
          path: '/',
          component: '../components/layout/Default',
          routes: [
            {
              path: '/console',
              component: 'Index/Dashboard',
            },
            {
              path: '/:productName',
              indexRoute: { redirect: '/:productName/overview' },
              routes: [
                {
                  path: '/:productName/overview',
                  component: 'Index/product/Overview'
                },
              ]
            },

          ]
        }
      ],
  }],
```