### PR TITLE
feat: umi dashboard

### DIFF
--- a/packages/umi-build-dev/src/getPlugins.js
+++ b/packages/umi-build-dev/src/getPlugins.js
@@ -16,6 +16,7 @@ export default function(opts = {}) {
     './plugins/commands/help',
     './plugins/commands/generate',
     './plugins/commands/version',
+    './plugins/commands/ui',
     './plugins/global-js',
     './plugins/global-css',
     './plugins/base',

--- a/packages/umi-build-dev/src/plugins/commands/ui/createRouteMiddleware.js
+++ b/packages/umi-build-dev/src/plugins/commands/ui/createRouteMiddleware.js
@@ -1,0 +1,26 @@
+import getRouteConfig from '../../../routes/getRouteConfig';
+import getHtmlGenerator from '../getHtmlGenerator';
+import Service from '../../../Service';
+
+export default function createRouteMiddleware(service) {
+  return (req, res) => {
+    const { path } = req;
+    if (path === '/__umiDashboard/routes') {
+      const service = new Service(process.cwd());
+      const projectPaths = service.paths;
+      let projectRoutes = null;
+      try {
+        projectRoutes = getRouteConfig(projectPaths);
+      } catch (err) {
+        projectRoutes = [];
+      }
+      res.setHeader('Content-Type', 'text/json');
+      res.send(JSON.stringify(projectRoutes));
+    } else {
+      const htmlGenerator = getHtmlGenerator(service);
+      const content = htmlGenerator.getMatchedContent(path);
+      res.setHeader('Content-Type', 'text/html');
+      res.send(content);
+    }
+  };
+}

--- a/packages/umi-build-dev/src/plugins/commands/ui/dashboardSocket.js
+++ b/packages/umi-build-dev/src/plugins/commands/ui/dashboardSocket.js
@@ -1,0 +1,90 @@
+import fs from 'fs';
+import sockjs from 'af-webpack/node_modules/sockjs';
+import rimraf from 'rimraf';
+import { exec } from 'child_process';
+import { join } from 'path';
+import chalk from 'chalk';
+
+export default (server, port, HOST) => {
+  server.listeningApp.listen(port, HOST, err => {
+    const socket = sockjs.createServer({
+      // Use provided up-to-date sockjs-client
+      sockjs_url: '/__webpack_dev_server__/sockjs.bundle.js',
+      // Limit useless logs
+      log: (severity, line) => {
+        if (severity === 'error') {
+          server.log.error(line);
+        } else {
+          server.log.debug(line);
+        }
+      },
+    });
+
+    socket.on('connection', connection => {
+      if (!connection) {
+        return;
+      }
+
+      console.log(chalk.bgBlue.bold.white('dashboard server connected!'));
+      if (!server.checkHost(connection.headers)) {
+        server.sockWrite([connection], 'error', 'Invalid Host header');
+        connection.close();
+        return;
+      }
+
+      connection.on('close', () => {
+        console.log(chalk.bgBlue.bold.white('dashboard server disconnected!'));
+      });
+
+      connection.on('data', data => {
+        const FINISH_NEED_RELOAD = 0;
+
+        const deleteFile = (filePath, fileName) => {
+          fs.access(filePath, fs.W_OK, err => {
+            if (err) {
+              return;
+            }
+
+            rimraf(filePath, err => {
+              if (err) {
+                console.log(chalk.bgRed.white(`failed to delete ${filePath}`));
+                return;
+              }
+              connection.write(
+                JSON.stringify({
+                  type: FINISH_NEED_RELOAD,
+                }),
+              );
+              console.log(chalk.redBright(`pages${fileName} has been deleted`));
+            });
+          });
+        };
+
+        if (data.startsWith('UMI_ROUTE_DEL_')) {
+          const routeName = data.substring(14);
+          const routeDirPath = join(process.cwd(), 'pages', routeName);
+          [``, `.js`, `.css`].forEach(fileSuffix =>
+            deleteFile(
+              `${routeDirPath}${fileSuffix}`,
+              `${routeName}${fileSuffix}`,
+            ),
+          );
+        } else if (data.startsWith('UMI_ROUTE_ADD_')) {
+          const routeName = data.substring(14);
+          exec(`umi g page ${routeName}`, () => {
+            console.log(chalk.green(`${routeName} route has been added`));
+            connection.write(
+              JSON.stringify({
+                type: FINISH_NEED_RELOAD,
+              }),
+            );
+          });
+        }
+      });
+    });
+
+    socket.installHandlers(server.listeningApp, {
+      prefix: '/sockjs-dashboard',
+    });
+  });
+};

--- a/packages/umi-build-dev/src/plugins/commands/ui/index.js
+++ b/packages/umi-build-dev/src/plugins/commands/ui/index.js
@@ -1,0 +1,132 @@
+import chalk from 'chalk';
+import { join } from 'path';
+import createRouteMiddleware from './createRouteMiddleware';
+import { unwatch } from '../../../getConfig/watch';
+import getRouteManager from '../getRouteManager';
+import getFilesGenerator from '../getFilesGenerator';
+import initDashboardSocket from './dashboardSocket';
+
+process.env.PORT = 8010;
+
+export default function(api) {
+  const { service, config } = api;
+  const cwd = join(__dirname, './view');
+
+  api.registerCommand(
+    'ui',
+    {
+      webpack: true,
+      description: 'start a dev server for development',
+    },
+    (args = {}) => {
+      const RoutesManager = getRouteManager(service);
+      RoutesManager.fetchRoutes();
+
+      const { port } = args;
+      process.env.NODE_ENV = 'development';
+      service.applyPlugins('onStart');
+
+      const filesGenerator = getFilesGenerator(service, {
+        RoutesManager,
+        mountElementId: config.mountElementId,
+      });
+      filesGenerator.generate();
+
+      let server = null;
+
+      // Add more service methods.
+      service.restart = why => {
+        if (!server) return;
+        if (why) {
+          console.log(chalk.green(`Since ${why}, try to restart server`));
+        } else {
+          console.log(chalk.green(`Try to restart server`));
+        }
+        unwatch();
+        filesGenerator.unwatch();
+        server.close();
+        process.send({ type: 'RESTART' });
+      };
+      service.refreshBrowser = () => {
+        if (!server) return;
+        server.sockWrite(server.sockets, 'content-changed');
+      };
+      service.printError = messages => {
+        if (!server) return;
+        messages = typeof messages === 'string' ? [messages] : messages;
+        server.sockWrite(server.sockets, 'errors', messages);
+      };
+      service.printWarn = messages => {
+        if (!server) return;
+        messages = typeof messages === 'string' ? [messages] : messages;
+        server.sockWrite(server.sockets, 'warns', messages);
+      };
+      service.rebuildTmpFiles = () => {
+        filesGenerator.rebuild();
+      };
+      service.rebuildHTML = () => {
+        // Currently, refresh browser will get new HTML.
+        service.applyPlugins('onHTMLRebuild');
+        service.refreshBrowser();
+      };
+
+      function startWatch() {
+        filesGenerator.watch();
+        service.userConfig.setConfig(service.config);
+        service.userConfig.watchWithDevServer();
+      }
+
+      service
+        ._applyPluginsAsync('_beforeDevServerAsync')
+        .then(() => {
+          require('af-webpack/dev').default({
+            cwd,
+            port,
+            base: service.config.base,
+            webpackConfig: service.webpackConfig,
+            proxy: service.config.proxy || {},
+            contentBase: './path-do-not-exists',
+            _beforeServerWithApp(app) {
+              // @private
+              service.applyPlugins('_beforeServerWithApp', { args: { app } });
+            },
+            beforeMiddlewares: service.applyPlugins('addMiddlewareAhead', {
+              initialValue: [],
+            }),
+            afterMiddlewares: service.applyPlugins('addMiddleware', {
+              initialValue: [createRouteMiddleware(service)],
+            }),
+            beforeServer(devServer) {
+              server = devServer;
+              service.applyPlugins('beforeDevServer', {
+                args: { server: devServer },
+              });
+            },
+            afterServer(devServer) {
+              service.applyPlugins('afterDevServer', {
+                args: { server: devServer },
+              });
+              startWatch();
+            },
+            onCompileDone({ isFirstCompile, stats }) {
+              service.applyPlugins('onDevCompileDone', {
+                args: {
+                  isFirstCompile,
+                  stats,
+                },
+              });
+            },
+          });
+        })
+        .catch(e => {
+          console.error(chalk.red(e));
+        });
+    },
+  );
+
+  api.afterDevServer(({ server }) => {
+    const port = parseInt(process.env.PORT, 10) || 8010;
+    const HOST = process.env.HOST || '0.0.0.0';
+    initDashboardSocket(server, port, HOST);
+  });
+}

--- a/packages/umi-build-dev/src/plugins/commands/ui/view/components/style.less
+++ b/packages/umi-build-dev/src/plugins/commands/ui/view/components/style.less
@@ -1,0 +1,6 @@
+.code {
+  padding: 3px 4px;
+  background-color: #efefef;
+  border: 1px solid #ddd;
+  border-radius: 2px;
+}

--- a/packages/umi-build-dev/src/plugins/commands/ui/view/components/tree.js.less
+++ b/packages/umi-build-dev/src/plugins/commands/ui/view/components/tree.js.less
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Modal, Tree, Icon } from 'antd';
+import styles from './style.less';
+Icon.setTwoToneColor('#c2292b');
+
+const TreeNode = Tree.TreeNode;
+const confirm = Modal.confirm;
+
+export default class Demo extends React.Component {
+  // onSelect = (selectedKeys, info) => {
+  //   console.log('selected', selectedKeys, info);
+  // };
+
+  // onCheck = (checkedKeys, info) => {
+  //   console.log('onCheck', checkedKeys, info);
+  // };
+
+  showDeleteConfirm = path => {
+    const self = this;
+    confirm({
+      title: '删除确认',
+      content: (
+        <span>
+          确定要删除 <code className={styles.code}>{path}</code> 路由吗？
+        </span>
+      ),
+      okText: 'Yes',
+      okType: 'danger',
+      cancelText: 'No',
+      onOk() {
+        self.props.handleDelete(path);
+      },
+    });
+  };
+
+  handleDeleteClick = path => {
+    this.showDeleteConfirm(path);
+  };
+
+  renderRoutes = routes => {
+    return routes.map((route, i) => {
+      if (!route.path) return null;
+      const currDelete = this.handleDeleteClick.bind(this, route.path);
+      return (
+        <TreeNode
+          icon={<Icon type="delete" theme="twoTone" onClick={currDelete} />}
+          title={route.path}
+          key={route.path || i}
+        >
+          {route.routes ? this.renderRoutes(route.routes) : null}
+        </TreeNode>
+      );
+    });
+  };
+
+  render() {
+    const { data } = this.props;
+    const tree = this.renderRoutes(data);
+    return (
+      <Tree showIcon showLine defaultExpandAll>
+        {tree}
+      </Tree>
+    );
+  }
+}

--- a/packages/umi-build-dev/src/plugins/commands/ui/view/package.json.less
+++ b/packages/umi-build-dev/src/plugins/commands/ui/view/package.json.less
@@ -1,0 +1,22 @@
+{
+  "private": true,
+  "scripts": {
+    "start": "umi dev",
+    "build": "umi build",
+    "test": "umi test",
+    "lint": "eslint --ext .js src mock tests",
+    "precommit": "lint-staged"
+  },
+  "lint-staged": {
+    "*.{js,jsx}": [
+      "eslint --fix",
+      "git add"
+    ]
+  },
+  "engines": {
+    "node": ">=8.0.0"
+  },
+  "devDependencies": {
+    "antd": "^3.9.2"
+  }
+}

--- a/packages/umi-build-dev/src/plugins/commands/ui/view/pages/index.js.less
+++ b/packages/umi-build-dev/src/plugins/commands/ui/view/pages/index.js.less
@@ -1,0 +1,134 @@
+import React from 'react';
+import 'whatwg-fetch';
+import { Input, Spin } from 'antd';
+import { stripLastSlash } from 'af-webpack/lib/utils';
+import url from 'url';
+import SockJS from 'sockjs-client';
+import RouteTree from '../components/tree';
+import styles from './index.less';
+import 'antd/dist/antd.css';
+
+const Search = Input.Search;
+class Dashboard extends React.Component {
+  constructor(props) {
+    super(props);
+    this.routeInput = React.createRef();
+    this.state = {
+      routes: [],
+      sock: null,
+      forceUpdateIndex: 0,
+      updating: true,
+    };
+  }
+
+  componentDidMount() {
+    this.getRouterConfig();
+    this.initDevSocket();
+  }
+
+  initDevSocket = () => {
+    const sock = new SockJS(
+      process.env.SOCKET_SERVER
+        ? `${stripLastSlash(process.env.SOCKET_SERVER)}/sockjs-dashboard`
+        : url.format({
+            protocol: window.location.protocol,
+            hostname: window.location.hostname,
+            port: window.location.port,
+            // Hardcoded in WebpackDevServer
+            pathname: '/sockjs-dashboard',
+          })
+    );
+    sock.onopen = () => {
+      console.log('open');
+      sock.send('test');
+    };
+
+    sock.onmessage = mes => {
+      const message = JSON.parse(mes.data);
+      console.log(message);
+      if (message.type === 0) {
+        console.log('need refresh');
+        this.getRouterConfig();
+      }
+    };
+
+    sock.onclose = function() {
+      console.log('close');
+    };
+
+    console.log(sock);
+    this.setState({
+      sock,
+    });
+  };
+
+  getRouterConfig = () => {
+    fetch('/__umiDashboard/routes')
+      .then(res => res.json())
+      .then(routes => {
+        this.setState({
+          routes,
+          updating: false,
+        });
+      });
+  };
+
+  deleteRouteFile = path => {
+    console.log(`UMI_DEL_${path}`);
+    const { sock } = this.state;
+    sock.send(`UMI_ROUTE_DEL_${path}`);
+    this.setState({
+      updating: true,
+    });
+  };
+
+  addRouteFile = path => {
+    const { sock, forceUpdateIndex } = this.state;
+    sock.send(`UMI_ROUTE_ADD_${path}`);
+    this.setState({
+      forceUpdateIndex: forceUpdateIndex + 1,
+      updating: true,
+    });
+  };
+
+  renderRoutes = routes => {
+    return (
+      <ul>
+        {routes.map((route, i) => {
+          if (!route.path) return null;
+          return (
+            <li key={route.key || i}>
+              <p to={route.path}>{route.path}</p>
+              {route.routes ? this.renderRoutes(route.routes) : null}
+            </li>
+          );
+        })}
+      </ul>
+    );
+  };
+
+  render() {
+    const { routes, forceUpdateIndex, updating } = this.state;
+    return (
+      <div className={styles.wrapper}>
+        <h1 className={styles.title}>🛠 umi dashboard</h1>
+        <Spin spinning={updating} style={{ minHeight: 400 }}>
+          <Search
+            key={forceUpdateIndex}
+            ref={this.routeInput}
+            placeholder="route to add"
+            enterButton="add"
+            size="large"
+            onSearch={path => this.addRouteFile(path)}
+            style={{ width: 250 }}
+          />
+          <div className={styles.treeWrapper}>
+            <RouteTree data={routes} handleDelete={this.deleteRouteFile} />
+          </div>
+        </Spin>
+      </div>
+    );
+  }
+}
+
+export default Dashboard;

--- a/packages/umi-build-dev/src/plugins/commands/ui/view/pages/index.less
+++ b/packages/umi-build-dev/src/plugins/commands/ui/view/pages/index.less
@@ -1,0 +1,19 @@
+.wrapper {
+  padding: 30px 50px 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+}
+
+.title {
+  color: #288ef9;
+  text-align: center;
+  font-size: 32px;
+  font-family: 'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande',
+    'Lucida Sans', Arial, sans-serif;
+}
+
+.treeWrapper {
+  padding: 10px 0;
+}

--- a/packages/umi-build-dev/src/plugins/commands/ui/view/umirc.js.less
+++ b/packages/umi-build-dev/src/plugins/commands/ui/view/umirc.js.less
@@ -1,0 +1,3 @@
+module.exports = {
+  extraBabelIncludes: ['/node_modules/ddd/index.tsx'],
+};

--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -12,6 +12,7 @@
     "debug": "^3.1.0",
     "dotenv": "^6.0.0",
     "ejs": "^2.5.7",
+    "fs-extra": "^7.0.0",
     "is-windows": "^1.0.2",
     "path-is-absolute": "^1.0.1",
     "react-loadable": "^5.5.0",

--- a/packages/umi/src/cli.js
+++ b/packages/umi/src/cli.js
@@ -30,6 +30,9 @@ switch (script) {
   case 'test':
     require(`./scripts/${script}`);
     break;
+  case 'ui':
+    require(`./scripts/${script}`);
+    break;
   case '-v':
   case '--version':
     script = 'version';

--- a/packages/umi/src/scripts/realUi.js
+++ b/packages/umi/src/scripts/realUi.js
@@ -1,0 +1,64 @@
+import yParser from 'yargs-parser';
+import { join } from 'path';
+import fs, { renameSync, readdirSync, statSync, access } from 'fs';
+import { copy, ensureDir } from 'fs-extra';
+import child_process from 'child_process';
+import buildDevOpts from '../buildDevOpts';
+let closed = false;
+
+// kill(2) Ctrl-C
+process.once('SIGINT', () => onSignal('SIGINT'));
+// kill(3) Ctrl-\
+process.once('SIGQUIT', () => onSignal('SIGQUIT'));
+// kill(15) default
+process.once('SIGTERM', () => onSignal('SIGTERM'));
+
+function onSignal(signal) {
+  if (closed) return;
+  closed = true;
+  process.exit(0);
+}
+
+function fileWalk(path, cb) {
+  const pa = readdirSync(path);
+  pa.forEach(name => {
+    const info = statSync(`${path}/${name}`);
+    if (info.isDirectory()) {
+      fileWalk(`${path}/${name}`, cb);
+    } else {
+      cb(`${path}/${name}`);
+    }
+  });
+}
+
+const uiCwd = join(
+  __dirname,
+  '../../node_modules/umi-build-dev/lib/plugins/commands/ui/view',
+);
+
+ensureDir(join(process.cwd(), 'pages/.umi/dashboard'), () => {
+  copy(uiCwd, join(process.cwd(), 'pages/.umi/dashboard'), err => {
+    fileWalk(join(process.cwd(), 'pages/.umi/dashboard'), filePath => {
+      if (filePath.endsWith('umirc.js.less')) {
+        renameSync(filePath, filePath.replace('umirc.js.less', '.umirc.js'));
+      }
+
+      if (
+        (filePath.endsWith('.js.less') || filePath.endsWith('.json.less')) &&
+        !filePath.endsWith('umirc.js.less')
+      ) {
+        renameSync(filePath, filePath.slice(0, -5));
+      }
+    });
+
+    child_process.execSync('yarn install', {
+      cwd: join(process.cwd(), 'pages/.umi/dashboard'),
+    });
+    process.env.NODE_ENV = 'development';
+    const args = yParser(process.argv.slice(2));
+    const Service = require('umi-build-dev/lib/Service').default;
+    new Service(
+      buildDevOpts({ cwd: join(process.cwd(), 'pages/.umi/dashboard') }),
+    ).run('ui', args);
+  });
+});

--- a/packages/umi/src/scripts/ui.js
+++ b/packages/umi/src/scripts/ui.js
@@ -1,0 +1,17 @@
+import fork from 'umi-build-dev/lib/fork';
+
+const child = fork(require.resolve('./realUi.js'));
+child.on('message', data => {
+  if (process.send) {
+    process.send(data);
+  }
+});
+child.on('exit', code => {
+  if (code === 1) {
+    process.exit(code);
+  }
+});
+
+process.on('SIGINT', () => {
+  child.kill('SIGINT');
+});


### PR DESCRIPTION
**效果**：目前已经实现了约定式路由的获取增加及删除。配置式路由目前可以获取，但增删目前只操作了文件所以在修改后会与 .umirc 不匹配会报错（TODO）。

**侵入**：对 umi 的 cli 加了个 ui 的分支。对 afwebpack，如果执行的 `umi ui` 的话会启动一个额外的 socket server 来响应界面添加和删除路由。