### PR TITLE
页面无限筛选

### DIFF
--- a/packages/umi-plugin-locale/src/locale.js
+++ b/packages/umi-plugin-locale/src/locale.js
@@ -4,8 +4,10 @@ function setLocale(lang) {
     // for reset when lang === undefined
     throw new Error('setLocale lang format error');
   }
-  window.localStorage.setItem('umi_locale', lang || '');
-  window.location.reload();
+  if (getLocale() !== lang) {
+    window.localStorage.setItem('umi_locale', lang || '');
+    window.location.reload();
+  }
 }
 
 function getLocale() {


### PR DESCRIPTION
当设置语言的时候，会无限刷新页面，没有判断当前语言是否相等