### PR TITLE
fix: lock babel-plugin-react-require to 3.0.0

### DIFF
--- a/packages/babel-preset-umi/package.json
+++ b/packages/babel-preset-umi/package.json
@@ -35,7 +35,7 @@
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "babel-plugin-macros": "^2.4.2",
-    "babel-plugin-react-require": "^3.0.0",
+    "babel-plugin-react-require": "3.0.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.15"
   },
   "files": [


### PR DESCRIPTION
fix errors like

```bash
Duplicate declaration "React"
> 1 | import React, { Component, Fragment } from '@alipay/bigfish/react';
    |        ^
```