### PR TITLE
fix: cannot debug child forked process

### DIFF
--- a/packages/af-webpack/src/fork.js
+++ b/packages/af-webpack/src/fork.js
@@ -1,8 +1,36 @@
 import { fork } from 'child_process';
 import send, { RESTART } from './send';
 
+let usedPorts = [];
+
 export default function start(scriptPath) {
-  const child = fork(scriptPath, process.argv.slice(2));
+  const execArgv = process.execArgv.slice(0);
+  const inspectArgvIndex = execArgv.findIndex(argv =>
+    argv.includes('--inspect-brk'),
+  );
+
+  if (inspectArgvIndex > -1) {
+    const inspectArgv = execArgv[inspectArgvIndex];
+    execArgv.splice(
+      inspectArgvIndex,
+      1,
+      inspectArgv.replace(/--inspect-brk=(.*)/, (match, s1) => {
+        let port;
+        try {
+          port = parseInt(s1) + 1;
+        } catch (e) {
+          port = 9230; // node default inspect port plus 1.
+        }
+        if (usedPorts.includes(port)) {
+          port++;
+        }
+        usedPorts.push(port);
+        return `--inspect-brk=${port}`;
+      }),
+    );
+  }
+
+  const child = fork(scriptPath, process.argv.slice(2), { execArgv });
 
   child.on('message', data => {
     const type = (data && data.type) || null;


### PR DESCRIPTION
# Summary

Since all umi instance are spawned via `child_process.fork`, but `execArgv` will be default to `process.execArgv`, causing the parent and child process used the same inspecting port, which takes following error:

```
Starting inspector on 127.0.0.1:9229 failed: address already in use
```

This PR doesn't introduced the mechanism of checking the usage of port like [node-portfinder](https://github.com/indexzero/node-portfinder), it just ensures:

1. Parent and child process won't share the same inspecting port;
2. Multiple child processes won't share the same inspecting port.
 
Refs:

- https://github.com/nodejs/node/issues/9435
- https://github.com/nodejs/node/issues/16872
- [child_process.fork(modulePath[, args][, options])](https://nodejs.org/dist/latest-v8.x/docs/api/child_process.html#child_process_child_process_fork_modulepath_args_options)