### PR TITLE
use semver to judge node version

### DIFF
--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -17,6 +17,7 @@
     "path-is-absolute": "^1.0.1",
     "react-loadable": "^5.5.0",
     "resolve-cwd": "^2.0.0",
+    "semver": "5.5.1",
     "signale": "^1.3.0",
     "slash2": "^2.0.0",
     "umi-build-dev": "^1.1.2",

--- a/packages/umi/src/cli.js
+++ b/packages/umi/src/cli.js
@@ -1,17 +1,16 @@
 import { dirname } from 'path';
 import yParser from 'yargs-parser';
 import signale from 'signale';
+import semver from 'semver';
 import buildDevOpts from './buildDevOpts';
 
 let script = process.argv[2];
 const args = yParser(process.argv.slice(3));
+
 // Node version check
 const nodeVersion = process.versions.node;
-const versions = nodeVersion.split('.');
-const major = versions[0];
-const minor = versions[1];
-if (major * 10 + minor * 1 < 65) {
-  signale.error(`Node version must >= 6.5, but got ${major}.${minor}`);
+if (semver.satisfies(nodeVersion, '<6.5')) {
+  signale.error(`Node version must >= 6.5, but got ${nodeVersion}`);
   process.exit(1);
 }
 


### PR DESCRIPTION
Use [semver](https://github.com/npm/node-semver) to judge node version.

> The semver parser for node (the one npm uses)
