### PR TITLE
feat: support insert chunk scripts in head

### DIFF
--- a/packages/umi-build-dev/src/html/HTMLGenerator.js
+++ b/packages/umi-build-dev/src/html/HTMLGenerator.js
@@ -248,6 +248,9 @@ export default class HTMLGenerator {
     let chunks = ['umi'];
 
     if (this.modifyChunks) chunks = this.modifyChunks(chunks);
+    chunks = chunks.map(chunk => {
+      return isPlainObject(chunk) ? chunk : { name: chunk };
+    });
 
     let routerBaseStr = JSON.stringify(this.config.base || '/');
     const publicPath = this.publicPath || '/';
@@ -276,10 +279,10 @@ export default class HTMLGenerator {
       ].join('\n'),
     });
 
-    chunks.forEach(chunk => {
-      const hashedFileName = this.getHashedFileName(`${chunk}.js`);
+    chunks.forEach(({ name, head }) => {
+      const hashedFileName = this.getHashedFileName(`${name}.js`);
       if (hashedFileName) {
-        scripts.push({
+        (head ? headScripts : scripts).push({
           src: `<%= pathToPublicPath %>${hashedFileName}`,
         });
       }
@@ -293,8 +296,8 @@ export default class HTMLGenerator {
       headScripts = this.modifyHeadScripts(headScripts);
 
     // umi.css should be the last stylesheet
-    chunks.forEach(chunk => {
-      const hashedFileName = this.getHashedFileName(`${chunk}.css`);
+    chunks.forEach(({ name }) => {
+      const hashedFileName = this.getHashedFileName(`${name}.css`);
       if (hashedFileName) {
         links.push({
           rel: 'stylesheet',

--- a/packages/umi-build-dev/src/html/HTMLGenerator.js
+++ b/packages/umi-build-dev/src/html/HTMLGenerator.js
@@ -279,10 +279,10 @@ export default class HTMLGenerator {
       ].join('\n'),
     });
 
-    chunks.forEach(({ name, head }) => {
+    chunks.forEach(({ name, headScript }) => {
       const hashedFileName = this.getHashedFileName(`${name}.js`);
       if (hashedFileName) {
-        (head ? headScripts : scripts).push({
+        (headScript ? headScripts : scripts).push({
           src: `<%= pathToPublicPath %>${hashedFileName}`,
         });
       }

--- a/packages/umi-build-dev/src/html/HTMLGenerator.test.js
+++ b/packages/umi-build-dev/src/html/HTMLGenerator.test.js
@@ -161,7 +161,7 @@ describe('HG', () => {
         defaultDocumentPath: join(__dirname, 'fixtures/document.ejs'),
       },
       modifyChunks() {
-        return ['a', { name: 'b', head: true }, 'umi', 'c'];
+        return ['a', { name: 'b', headScript: true }, 'umi', 'c'];
       },
     });
     const content = hg.getContent({

--- a/packages/umi-build-dev/src/html/HTMLGenerator.test.js
+++ b/packages/umi-build-dev/src/html/HTMLGenerator.test.js
@@ -142,6 +142,53 @@ describe('HG', () => {
     );
   });
 
+  it('getContent with chunks', () => {
+    const hg = new HTMLGenerator({
+      env: 'production',
+      chunksMap: {
+        umi: ['umi.js', 'umi.css'],
+        a: ['a.js'],
+        b: ['b.js', 'b.css'],
+        c: ['c.js', 'c.css'],
+      },
+      minify: false,
+      config: {
+        mountElementId: 'documenttestid',
+      },
+      paths: {
+        cwd: '/a',
+        absPageDocumentPath: '/tmp/files-not-exists',
+        defaultDocumentPath: join(__dirname, 'fixtures/document.ejs'),
+      },
+      modifyChunks() {
+        return ['a', { name: 'b', head: true }, 'umi', 'c'];
+      },
+    });
+    const content = hg.getContent({
+      path: '/',
+    });
+    expect(content.trim()).toEqual(
+      `
+<head>
+
+<link rel="stylesheet" href="/b.css" />
+<link rel="stylesheet" href="/umi.css" />
+<link rel="stylesheet" href="/c.css" />
+<script>
+  window.routerBase = "/";
+</script>
+<script src="/b.js"></script>
+</head>
+<body>
+<div id="documenttestid"></div>
+<script src="/a.js"></script>
+<script src="/umi.js"></script>
+<script src="/c.js"></script>
+</body>
+    `.trim(),
+    );
+  });
+
   it('getContent with publicPath', () => {
     const hg = new HTMLGenerator({
       env: 'production',


### PR DESCRIPTION
Support object type chunk, if you want to insert chunk script to `<head>`.

```
chunks: [
  'a',
  { name: 'b', headScript: true },
  'umi',
]
```

Then the output will be,

```html
<head>
<link rel="stylesheet" href="/a.css" />
<link rel="stylesheet" href="/b.css" />
<link rel="stylesheet" href="/umi.css" />
<script>
  window.routerBase = "/";
</script>
<script src="/b.js"></script>
</head>
<body>
<div id="root"></div>
<script src="/a.js"></script>
<script src="/umi.js"></script>
</body>
```
