### PR TITLE
feat: upgrade babel-loader to 8.0.4, since it supported .customize in 8.0.3

### DIFF
--- a/packages/af-webpack/package.json
+++ b/packages/af-webpack/package.json
@@ -15,7 +15,7 @@
     "address": "^1.0.3",
     "assert": "^1.4.1",
     "autoprefixer": "^9.1.1",
-    "babel-loader": "^8.0.0",
+    "babel-loader": "^8.0.4",
     "babel-plugin-dynamic-import-node": "^2.0.0",
     "babel-plugin-named-asset-import": "^0.2.2",
     "babel-preset-umi": "^1.2.0-beta.3",


### PR DESCRIPTION
避免出现类似 `Unknown option .customize` 的问题，如图：

![wechatimg71](https://user-images.githubusercontent.com/35128/47069541-c1160680-d221-11e8-8856-3d90df42bd57.png)
