### PR TITLE
feat: upgrade dva-loading to 2.1.0-beta.2

### DIFF
--- a/packages/umi-plugin-dva/package.json
+++ b/packages/umi-plugin-dva/package.json
@@ -6,7 +6,7 @@
     "babel-plugin-dva-hmr": "^0.4.1",
     "dva": "^2.5.0-beta.2",
     "dva-immer": "^0.2.3",
-    "dva-loading": "^2.0.5",
+    "dva-loading": "^2.1.0-beta.2",
     "globby": "^7.1.1",
     "lodash.uniq": "^4.5.0",
     "object-assign": "^4.1.1",


### PR DESCRIPTION
for @babel/runtime@7
