### PR TITLE
bugfix: dva plugin should be a plain object

### DIFF
--- a/docs/guide/with-dva.md
+++ b/docs/guide/with-dva.md
@@ -116,7 +116,7 @@ export const dva = {
     },
   },
   plugins: [
-    require('dva-logger'),
+    require('dva-logger')(),
   ],
 };
 ```

--- a/docs/zh/guide/with-dva.md
+++ b/docs/zh/guide/with-dva.md
@@ -115,7 +115,7 @@ export const dva = {
     },
   },
   plugins: [
-    require('dva-logger'),
+    require('dva-logger')(),
   ],
 };
 ```


### PR DESCRIPTION
simply fix the bug of requiring `dva-logger`

in `docs/guide/with-dva.md` & `docs/zh/guide/with-dva.md`

`- require('dva-logger'),`
`+ require('dva-logger')(),`

![umi-bug](https://user-images.githubusercontent.com/8576839/47267532-b8059c00-d577-11e8-913c-1c279a11b00b.png)
