### PR TITLE
fix: suppress ts-jest warning

### DIFF
--- a/packages/umi-test/src/index.js
+++ b/packages/umi-test/src/index.js
@@ -36,7 +36,7 @@ export default function(opts = {}) {
     },
     globals: {
       'ts-jest': {
-        useBabelrc: true,
+        babelConfig: true,
       },
     },
     ...(userJestConfig || {}),


### PR DESCRIPTION
current run 'umi test' show
```
> umi test

ts-jest[backports] (WARN) "[jest-config].globals.ts-jest.tsConfigFile" is deprecated, use "[jest-config].globals.ts-jest.tsConfig" instead.
ts-jest[backports] (WARN) Your Jest configuration is outdated. Use the CLI to help migrating it: ts-jest config:migrate <config-file>.
```
[Related document](https://kulshekhar.github.io/ts-jest/user/config/babelConfig)