### PR TITLE
fixed #1320

### DIFF
--- a/packages/umi-test/src/index.js
+++ b/packages/umi-test/src/index.js
@@ -15,6 +15,8 @@ export default function(opts = {}) {
     userJestConfig = require(jestConfigFile); // eslint-disable-line
   }
 
+  const { moduleNameMapper: userModuleNameMapper, ...restUserJestConfig } = userJestConfig;
+  
   const config = {
     rootDir: process.cwd(),
     setupFiles: [
@@ -33,13 +35,14 @@ export default function(opts = {}) {
     moduleNameMapper: {
       '\\.(css|less|sass|scss)$': require.resolve('identity-obj-proxy'),
       ...(moduleNameMapper || {}),
+      ...userModuleNameMapper,
     },
     globals: {
       'ts-jest': {
         useBabelrc: true,
       },
     },
-    ...(userJestConfig || {}),
+    ...(restUserJestConfig || {}),
   };
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
jest.config.js的moduleNameMapper改为合并的方式进行配置，避免覆盖默认配置。