### PR TITLE
feat: support modifyRouteProps in runtime

### DIFF
--- a/packages/umi-build-dev/src/FilesGenerator.js
+++ b/packages/umi-build-dev/src/FilesGenerator.js
@@ -158,7 +158,12 @@ export default class FilesGenerator {
       plugins.push('@/app');
     }
     const validKeys = this.service.applyPlugins('addRuntimePluginKey', {
-      initialValue: ['patchRoutes', 'render', 'rootContainer'],
+      initialValue: [
+        'patchRoutes',
+        'render',
+        'rootContainer',
+        'modifyRouteProps',
+      ],
     });
     assert(
       uniq(validKeys).length === validKeys.length,

--- a/packages/umi/src/renderRoutes.js
+++ b/packages/umi/src/renderRoutes.js
@@ -118,13 +118,16 @@ export default function renderRoutes(
                   ...props,
                   ...extraProps,
                 });
+                const newProps = window.g_plugins.apply('modifyRouteProps', {
+                  initialValue: {
+                    ...props,
+                    ...extraProps,
+                    ...compatProps,
+                  },
+                  args: { route },
+                });
                 return (
-                  <route.component
-                    {...props}
-                    {...extraProps}
-                    {...compatProps}
-                    route={route}
-                  >
+                  <route.component {...newProps} route={route}>
                     {childRoutes}
                   </route.component>
                 );

--- a/packages/umi/src/runtimePlugin.js
+++ b/packages/umi/src/runtimePlugin.js
@@ -41,12 +41,12 @@ export function compose(item, { initialValue }) {
   };
 }
 
-export function apply(item, { initialValue }) {
+export function apply(item, { initialValue, args }) {
   if (typeof item === 'string') item = getItem(item);
   assert(Array.isArray(item), `item must be Array`);
   return item.reduce((memo, fn) => {
     assert(typeof fn === 'function', `applied item must be function`);
-    return fn(memo);
+    return fn(memo, args);
   }, initialValue);
 }
 


### PR DESCRIPTION
想到的一些使用场景，这些场景之前用 Routes 也能做，但比较繁琐，而且会多套一层 react 组件。

## 比如想要访问子路径匹配路由的 `match.params` 属性，可以在 `app.js` 下配置，

```js
import { matchRoutes } from 'react-router-config';

export function modifyRouteProps(memo, { route }) {
  if (/* is layout */route.routes) {
    const m = matchRoutes(route.routes, memo.location.pathname);
    if (m && m.length) {
      memo.match = m[m.length - 1].match;
    }
  }

  return memo;
}
```

## 比如实现 title 的 i18n

可以在这一层针对 title 做运行时的转换。
