### PR TITLE
feat: support dynamicImport.loadingComponent as stateless function str

### DIFF
--- a/packages/umi-plugin-react/src/plugins/dynamicImport.js
+++ b/packages/umi-plugin-react/src/plugins/dynamicImport.js
@@ -1,4 +1,5 @@
 import { join } from 'path';
+import isReactComponent from '../utils/isReactComponent';
 
 export default function(api, options) {
   const { paths, winPath } = api;
@@ -19,9 +20,13 @@ export default function(api, options) {
 
     let loadingOpts = '';
     if (options.loadingComponent) {
-      loadingOpts = `, loading: require('${winPath(
-        join(paths.absSrcPath, options.loadingComponent),
-      )}').default `;
+      if (isReactComponent(options.loadingComponent.trim())) {
+        loadingOpts = `, loading: ${options.loadingComponent.trim()}`;
+      } else {
+        loadingOpts = `, loading: require('${winPath(
+          join(paths.absSrcPath, options.loadingComponent),
+        )}').default`;
+      }
     }
 
     let extendStr = '';

--- a/packages/umi-plugin-react/src/utils/isReactComponent.js
+++ b/packages/umi-plugin-react/src/utils/isReactComponent.js
@@ -1,0 +1,3 @@
+export default function(componentStr) {
+  return /^\(.*?\)\s*?=>/.test(componentStr);
+}

--- a/packages/umi-plugin-react/src/utils/isReactComponent.test.js
+++ b/packages/umi-plugin-react/src/utils/isReactComponent.test.js
@@ -1,0 +1,10 @@
+import isReactComponent from './isReactComponent';
+
+describe('isReactComponent', () => {
+  test('normal', () => {
+    expect(isReactComponent(`() => {}`)).toEqual(true);
+    expect(isReactComponent(`()  => {}`)).toEqual(true);
+    expect(isReactComponent(`()=> {}`)).toEqual(true);
+    expect(isReactComponent(`(props) => {}`)).toEqual(true);
+  });
+});


### PR DESCRIPTION
e.g.

```js
export default {
  plugins: [
    ['umi-plugin-react', {
      dynamicImport: {
        loadingComponent: `() => <div>...</div>`,
      },
    }],
  ],
}
```