### PR TITLE
feat: support inspect command to inspect internal webpack config (#1314)

### DIFF
--- a/packages/af-webpack/webpack-chain.js
+++ b/packages/af-webpack/webpack-chain.js
@@ -1,0 +1,1 @@
+module.exports = require('webpack-chain');

--- a/packages/umi-build-dev/src/getPlugins.js
+++ b/packages/umi-build-dev/src/getPlugins.js
@@ -14,6 +14,7 @@ export default function(opts = {}) {
   const builtInPlugins = [
     './plugins/commands/dev',
     './plugins/commands/build',
+    './plugins/commands/inspect',
     './plugins/commands/test',
     './plugins/commands/help',
     './plugins/commands/generate',

--- a/packages/umi-build-dev/src/plugins/commands/inspect/index.js
+++ b/packages/umi-build-dev/src/plugins/commands/inspect/index.js
@@ -1,0 +1,42 @@
+export default function(api) {
+  const { service } = api;
+
+  api.registerCommand(
+    'inspect',
+    {
+      webpack: true,
+      description: 'inspect internal webpack config',
+      usage: 'umi inspect [options]',
+      options: {
+        '--mode':
+          'specify env mode (development or production, default is development)',
+        '--rule <ruleName>': 'inspect a specific module rule',
+        '--plugin <pluginName>': 'inspect a specific plugin',
+        '--rules': 'list all module rule names',
+        '--plugins': 'list all plugin names',
+        '--verbose': 'show full function definitions in output',
+      },
+    },
+    (args = {}) => {
+      const { verbose } = args;
+      const webpackChain = require('af-webpack/webpack-chain');
+      const config = service.webpackConfig;
+
+      let res;
+      if (args.rule) {
+        res = config.module.rules.find(r => r.__ruleNames[0] === args.rule);
+      } else if (args.plugin) {
+        res = config.plugins.find(p => p.__pluginName === args.plugin);
+      } else if (args.rules) {
+        res = config.module.rules.map(r => r.__ruleNames[0]);
+      } else if (args.plugins) {
+        res = config.plugins.map(p => p.__pluginName || p.constructor.name);
+      } else {
+        res = config;
+      }
+
+      const output = webpackChain.toString(res, { verbose });
+      console.log(output);
+    },
+  );
+}

--- a/packages/umi/src/cli.js
+++ b/packages/umi/src/cli.js
@@ -33,6 +33,7 @@ switch (script) {
   case 'build':
   case 'dev':
   case 'test':
+  case 'inspect':
     require(`./scripts/${script}`);
     break;
   default: {

--- a/packages/umi/src/scripts/inspect.js
+++ b/packages/umi/src/scripts/inspect.js
@@ -1,0 +1,13 @@
+import yParser from 'yargs-parser';
+import buildDevOpts from '../buildDevOpts';
+
+const args = yParser(process.argv.slice(2));
+
+if (args.mode === 'production') {
+  process.env.NODE_ENV = 'production';
+} else {
+  process.env.NODE_ENV = 'development';
+}
+
+const Service = require('umi-build-dev/lib/Service').default;
+new Service(buildDevOpts(args)).run('inspect', args);


### PR DESCRIPTION
Close #1314 

e.g.

```bash
umi help inspect

Usage: umi inspect [options]

  Options:

    --mode                specify env mode (development or production, default is development)
    --rule <ruleName>     inspect a specific module rule
    --plugin <pluginName> inspect a specific plugin
    --rules               list all module rule names
    --plugins             list all plugin names
    --verbose             show full function definitions in output
```