### PR TITLE
fix: avoid unexpect title change when ues title plugin with tween

### DIFF
--- a/packages/umi-plugin-react/src/plugins/title/TitleWrapper.js
+++ b/packages/umi-plugin-react/src/plugins/title/TitleWrapper.js
@@ -5,7 +5,9 @@ export default class UmiReactTitle extends React.Component {
     document.title = this.props.route._title;
   }
   componentWillUnmount() {
-    document.title = this.props.route._title_default;
+    if (document.title === this.props.route._title) {
+      document.title = this.props.route._title_default;
+    }
   }
   render() {
     return this.props.children;


### PR DESCRIPTION
close #1278