### PR TITLE
feat: manifest publicPath support empty prefix

### DIFF
--- a/packages/umi-build-dev/src/plugins/afwebpack-config.js
+++ b/packages/umi-build-dev/src/plugins/afwebpack-config.js
@@ -183,7 +183,11 @@ export default function(api) {
         ),
         ...(config.define || {}),
       },
-      publicPath: isDev ? '/' : config.publicPath || '/',
+      publicPath: isDev
+        ? '/'
+        : config.publicPath != null
+          ? config.publicPath
+          : '/',
     };
   });
 }


### PR DESCRIPTION
build 的时候支持下设置没有前缀 ‘/’ 的 publicPath