### PR TITLE
fix: use swDest in register-sw.js

### DIFF
--- a/docs/plugin/umi-plugin-react.md
+++ b/docs/plugin/umi-plugin-react.md
@@ -159,6 +159,7 @@ options include:
 * `workboxPluginMode` Workbox mode, Type: `String`, Default `GenerateSW`(generate a brand new Service Worker); or `InjectManifest`(inject code to existed Service Worker)
 * `workboxOptions` Workbox [Config](https://developers.google.com/web/tools/workbox/modules/workbox-webpack-plugin#full_generatesw_config)，some important options:
   * `swSrc` Type: `String`, Default `src/manifest.json`, only in `InjectManifest` mode
+  * `swDest` Type: `String`, Defaults to `service-worker.js` or the same with basename in `swSrc` if provided
   * `importWorkboxFrom` Type: `String`，Workbox loads from Google CDN by default, you can choose to `'local'` mode which will let Workbox loads from local copies
 
 You can refer to [Workbox](https://developers.google.com/web/tools/workbox/) for more API usages.
@@ -175,7 +176,8 @@ export default {
     workboxPluginMode: 'InjectManifest',
     workboxOptions: {
       importWorkboxFrom: 'local',
-      swSrc: 'path/to/service-worker.js')
+      swSrc: 'path/to/service-worker.js'),
+      swDest: 'my-dest-sw.js'
     }
   }
 }

--- a/docs/zh/plugin/umi-plugin-react.md
+++ b/docs/zh/plugin/umi-plugin-react.md
@@ -148,7 +148,7 @@ export default {
 * 类型：`Object`
 
 开启 PWA 相关功能，包括：
-* 生成 `manifest.json`
+* 生成 `manifest.json`，对于 WebManifest 中引用的 `icons` 图标，建议放在项目根目录 `public/` 文件夹下，最终会被直接拷贝到构建目录中
 * 在 `PRODUCTION` 模式下生成 Service Worker
  
 配置项包含：
@@ -157,6 +157,7 @@ export default {
 * `workboxPluginMode` Workbox 模式，类型：`String`，默认值为 `GenerateSW` 即生成全新 Service Worker ；也可选填 `InjectManifest` 即向已有 Service Worker 注入代码，适合需要配置复杂缓存规则的场景
 * `workboxOptions` Workbox [配置对象](https://developers.google.com/web/tools/workbox/modules/workbox-webpack-plugin#full_generatesw_config)，其中部分重要属性如下:
   * `swSrc` 类型：`String`，默认值为 `src/manifest.json`，只有选择了 `InjectManifest` 模式才需要配置
+  * `swDest` 类型：`String`，最终输出的文件名，默认值为 `service-worker.js` 或者等于 `swSrc` 中的文件名
   * `importWorkboxFrom` 类型：`String`，默认从 Google CDN 加载 Workbox 代码，可选值 `'local'` 适合国内无法访问的环境
 
 更多关于 Workbox 的使用可以参考[官方文档](https://developers.google.com/web/tools/workbox/)。
@@ -173,7 +174,8 @@ export default {
     workboxPluginMode: 'InjectManifest',
     workboxOptions: {
       importWorkboxFrom: 'local',
-      swSrc: 'path/to/service-worker.js')
+      swSrc: 'path/to/service-worker.js'),
+      swDest: 'my-dest-sw.js'
     }
   }
 }

--- a/packages/umi-plugin-react/src/plugins/pwa/registerServiceWorker.js
+++ b/packages/umi-plugin-react/src/plugins/pwa/registerServiceWorker.js
@@ -6,14 +6,16 @@ function dispathServiceWorkerEvent(eventName) {
   window.dispatchEvent(event);
 }
 
-if (process.env.NODE_ENV === 'production') {
-  register(`${process.env.BASE_URL}service-worker.js`, {
-    updated() {
-      dispathServiceWorkerEvent('sw.updated');
-    },
+export default function(swDest) {
+  if (process.env.NODE_ENV === 'production') {
+    register(`${process.env.BASE_URL}${swDest}`, {
+      updated() {
+        dispathServiceWorkerEvent('sw.updated');
+      },
 
-    offline() {
-      dispathServiceWorkerEvent('sw.offline');
-    },
-  });
+      offline() {
+        dispathServiceWorkerEvent('sw.offline');
+      },
+    });
+  }
 }

--- a/packages/umi-plugin-react/src/plugins/pwa/registerServiceWorker.js
+++ b/packages/umi-plugin-react/src/plugins/pwa/registerServiceWorker.js
@@ -7,15 +7,13 @@ function dispathServiceWorkerEvent(eventName) {
 }
 
 export default function(swDest) {
-  if (process.env.NODE_ENV === 'production') {
-    register(`${process.env.BASE_URL}${swDest}`, {
-      updated() {
-        dispathServiceWorkerEvent('sw.updated');
-      },
+  register(`${process.env.BASE_URL}${swDest}`, {
+    updated() {
+      dispathServiceWorkerEvent('sw.updated');
+    },
 
-      offline() {
-        dispathServiceWorkerEvent('sw.offline');
-      },
-    });
-  }
+    offline() {
+      dispathServiceWorkerEvent('sw.offline');
+    },
+  });
 }

--- a/packages/umi-plugin-react/test/generateWebManifest.test.js
+++ b/packages/umi-plugin-react/test/generateWebManifest.test.js
@@ -17,7 +17,9 @@ const APIMock = {
   addHTMLLink: () => {},
   addHTMLHeadScript: () => {},
   addPageWatcher: () => {},
-  onGenerateFiles: () => {},
+  onGenerateFiles: cb => {
+    cb && cb();
+  },
 };
 
 describe('generateWebManifest', () => {


### PR DESCRIPTION
Fix #1380 
* 如果用户配置了 `swDest`，在注册 service worker 时使用作为输出文件名
* 相关更新文档