### PR TITLE
Fix the directory path that containes .css

### DIFF
--- a/packages/af-webpack/src/getConfig/css.js
+++ b/packages/af-webpack/src/getConfig/css.js
@@ -122,7 +122,7 @@ export default function(webpackConfig, opts) {
 
   if (opts.cssModulesWithAffix) {
     applyCSSRules(
-      webpackConfig.module.rule('.module.css').test(/\.module\.css/),
+      webpackConfig.module.rule('.module.css').test(/\.module\.css$/),
       {
         cssModules: true,
       },
@@ -161,7 +161,7 @@ export default function(webpackConfig, opts) {
   applyCSSRules(
     webpackConfig.module
       .rule('css')
-      .test(/\.css/)
+      .test(/\.css$/)
       .exclude.add(cssExclude)
       .end(),
     {
@@ -171,7 +171,7 @@ export default function(webpackConfig, opts) {
   applyCSSRules(
     webpackConfig.module
       .rule('css-in-node_modules')
-      .test(/\.css/)
+      .test(/\.css$/)
       .include.add(/node_modules/)
       .end(),
     {},

--- a/packages/af-webpack/src/getConfig/css.js
+++ b/packages/af-webpack/src/getConfig/css.js
@@ -128,14 +128,14 @@ export default function(webpackConfig, opts) {
       },
     );
     applyCSSRules(
-      webpackConfig.module.rule('.module.less').test(/\.module\.less/),
+      webpackConfig.module.rule('.module.less').test(/\.module\.less$/),
       {
         cssModules: true,
         less: true,
       },
     );
     applyCSSRules(
-      webpackConfig.module.rule('.module.sass').test(/\.module\.(sass|scss)/),
+      webpackConfig.module.rule('.module.sass').test(/\.module\.(sass|scss)$/),
       {
         cssModules: true,
         sass: true,
@@ -179,7 +179,7 @@ export default function(webpackConfig, opts) {
   applyCSSRules(
     webpackConfig.module
       .rule('less')
-      .test(/\.less/)
+      .test(/\.less$/)
       .exclude.add(cssExclude)
       .end(),
     {
@@ -190,7 +190,7 @@ export default function(webpackConfig, opts) {
   applyCSSRules(
     webpackConfig.module
       .rule('less-in-node_modules')
-      .test(/\.less/)
+      .test(/\.less$/)
       .include.add(/node_modules/)
       .end(),
     {
@@ -200,7 +200,7 @@ export default function(webpackConfig, opts) {
   applyCSSRules(
     webpackConfig.module
       .rule('sass')
-      .test(/\.(sass|scss)/)
+      .test(/\.(sass|scss)$/)
       .exclude.add(cssExclude)
       .end(),
     {
@@ -211,7 +211,7 @@ export default function(webpackConfig, opts) {
   applyCSSRules(
     webpackConfig.module
       .rule('sass-in-node_modules')
-      .test(/\.(sass|scss)/)
+      .test(/\.(sass|scss)$/)
       .include.add(/node_modules/)
       .end(),
     {


### PR DESCRIPTION
- 当项目目录路径中包含 `.css` 时会导致 `css` 解析错误:

![image](https://user-images.githubusercontent.com/14918822/47839525-fa3ba280-dded-11e8-8b85-bf5566a4a08b.png)
