### PR TITLE
test增加对png等多媒体文件的mock支持

### DIFF
--- a/packages/umi-test/src/fileMock.js
+++ b/packages/umi-test/src/fileMock.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = {};

--- a/packages/umi-test/src/index.js
+++ b/packages/umi-test/src/index.js
@@ -34,8 +34,9 @@ export default function(opts = {}) {
     setupTestFrameworkScriptFile: require.resolve('./jasmine'),
     moduleNameMapper: {
       '\\.(css|less|sass|scss)$': require.resolve('identity-obj-proxy'),
-      ...(moduleNameMapper || {}),
+      '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': require.resolve('./fileMock.js'),
       ...(userModuleNameMapper || {}),
+      ...(moduleNameMapper || {}),
     },
     globals: {
       'ts-jest': {


### PR DESCRIPTION
默认的moduleNameMapper里包含了一条【'^@/(.*)$': 'C:\\Mutou\\work\\antdpro-csr-upgrade-to-v2\\antdpro-csr-v2\\src\\/$1'】规则，这条规则可能会覆盖jest.config.js里的moduleNameMapper的规则，所以把userModuleNameMapper调前了。

另外增加了对png、jpg等格式文件的mock。