### PR TITLE
fix: wrong filepath in browser files

### DIFF
--- a/packages/umi-plugin-react/package.json
+++ b/packages/umi-plugin-react/package.json
@@ -39,7 +39,7 @@
   },
   "umiTools": {
     "browserFiles": [
-      "src/plugins/registerServiceWorker.js",
+      "src/plugins/pwa/registerServiceWorker.js",
       "src/plugins/title/TitleWrapper.js"
     ]
   }


### PR DESCRIPTION
fix #1424 
更新下编译目标为 browser 文件的路径