### PR TITLE
feat: put registration into event data

### DIFF
--- a/packages/umi-plugin-react/src/plugins/pwa/registerServiceWorker.js
+++ b/packages/umi-plugin-react/src/plugins/pwa/registerServiceWorker.js
@@ -1,19 +1,39 @@
 import { register } from 'register-service-worker';
 
-function dispathServiceWorkerEvent(eventName) {
-  const event = document.createEvent('Event');
-  event.initEvent(eventName, true, true);
+// polyfill the CustomEvent in ie9/10/11
+// https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
+(function() {
+  if (typeof window.CustomEvent === 'function') return false;
+
+  function CustomEvent(event, params) {
+    params = params || { bubbles: false, cancelable: false, detail: undefined };
+    var evt = document.createEvent('CustomEvent');
+    evt.initCustomEvent(
+      event,
+      params.bubbles,
+      params.cancelable,
+      params.detail,
+    );
+    return evt;
+  }
+
+  CustomEvent.prototype = window.Event.prototype;
+  window.CustomEvent = CustomEvent;
+})();
+
+function dispatchServiceWorkerEvent(eventName, eventData) {
+  const event = new CustomEvent(eventName, { detail: eventData });
   window.dispatchEvent(event);
 }
 
 export default function(swDest) {
   register(`${process.env.BASE_URL}${swDest}`, {
-    updated() {
-      dispathServiceWorkerEvent('sw.updated');
+    updated(registration) {
+      dispatchServiceWorkerEvent('sw.updated', registration);
     },
 
     offline() {
-      dispathServiceWorkerEvent('sw.offline');
+      dispatchServiceWorkerEvent('sw.offline', {});
     },
   });
 }


### PR DESCRIPTION
发送 ServiceWorker 更新事件时带上 `registration`，便于接收事件的组件使用。
例如通过这个 [ServiceWorkerRegistration](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration) 对象可以取得当前处于 `waiting` 状态的 SW，进行后续弹出更新提示框的动作。
```js
updated(registration) {
  dispatchServiceWorkerEvent('sw.updated', registration);
}
```

另外针对 ie11 使用了 [CustomEvent Polyfill](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill)