### PR TITLE
fix: remove empty title when context.title is undefined

### DIFF
--- a/packages/umi-build-dev/src/html/HTMLGenerator.test.js
+++ b/packages/umi-build-dev/src/html/HTMLGenerator.test.js
@@ -569,4 +569,30 @@ describe('HG', () => {
     expect(c2.includes('"/umi.js"') && c2.includes('"/umi.css"')).toEqual(true);
     expect(c2.includes('<title>bctitle-/b/c</title>')).toEqual(true);
   });
+
+  it('get content with default document when title is undefined', () => {
+    const hg = new HTMLGenerator({
+      env: 'production',
+      minify: false,
+      config: {
+        mountElementId: 'root',
+      },
+      chunksMap: {
+        umi: ['umi.js', 'umi.css'],
+      },
+      paths: {
+        cwd: '/a',
+        absPageDocumentPath: '/tmp/files-not-exists',
+        defaultDocumentPath: join(__dirname, '../../template/document.ejs'),
+      },
+      routes: [{ path: '/a' }],
+      modifyContext: context => {
+        return context;
+      },
+    });
+
+    const c1 = hg.getMatchedContent('/a');
+    expect(c1.includes('"/umi.js"') && c1.includes('"/umi.css"')).toEqual(true);
+    expect(c1.includes('<title>')).toEqual(false);
+  });
 });

--- a/packages/umi-build-dev/template/document.ejs
+++ b/packages/umi-build-dev/template/document.ejs
@@ -3,7 +3,9 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no" />
-<title><%= context.title %></title>
+<% if (context.title != null) { %>
+  <title><%= context.title %></title>
+<% } %>
 </head>
 <body>
 


### PR DESCRIPTION
避免出现 `<title></title>` 这样的情况。在 chair 里面 title 可能是后端渲染的，避免引用了 umi 生产的 html 碎片后出现重复的 title。