### PR TITLE
feat: code in block src folder support singular

### DIFF
--- a/packages/umi-build-dev/src/plugins/commands/block/block.test.js
+++ b/packages/umi-build-dev/src/plugins/commands/block/block.test.js
@@ -51,6 +51,8 @@ import { api } from '@/services/yes';
 import { ok } from '@/page/ttt';
 import test2 from '@/goos/test';
 import types from '@types/yes';
+import { parseutil } from '../utils/parse';
+import test from './components/test';
 
 // test comment
 export default() {
@@ -66,6 +68,8 @@ import { api } from '@/service/yes';
 import { ok } from '@/page/ttt';
 import test2 from '@/goos/test';
 import types from '@types/yes';
+import { parseutil } from '../util/parse';
+import test from './component/test';
 
 // test comment
 export default() {

--- a/packages/umi-build-dev/src/plugins/commands/block/download.js
+++ b/packages/umi-build-dev/src/plugins/commands/block/download.js
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { existsSync } from 'fs';
 import { spawnSync } from 'child_process';
 import mkdirp from 'mkdirp';
@@ -106,6 +106,11 @@ export function getPathWithUrl(url, log, args) {
   } else if (/^[\w\-]+$/.test(url)) {
     realUrl = `https://github.com/umijs/umi-blocks/tree/master/${url}`;
     log.info(`will use ${realUrl} as the block url`);
+  } else if (/^[\.\/]/.test(url)) {
+    // locale path for test
+    const blockPath = resolve(__dirname, url);
+    log.info(`will use ${blockPath} as the block url`);
+    return blockPath;
   } else {
     throw new Error(`${url} can't match any Pattern`);
   }

--- a/packages/umi-build-dev/src/plugins/commands/block/download.test.js
+++ b/packages/umi-build-dev/src/plugins/commands/block/download.test.js
@@ -92,5 +92,10 @@ describe('test block download utils', () => {
         dryRun: true,
       }),
     ).toEqual('/Users/test/.umi/blocks/github.com/umijs/umi-blocks/demo-test');
+    expect(
+      getPathWithUrl('/test/test/locale', mockLog, {
+        dryRun: true,
+      }),
+    ).toEqual('/test/test/locale');
   });
 });


### PR DESCRIPTION
```
- src
  - models
  - locales
  - components
  - index.js
```

to

```
- page
  - demo
     - model
     - locale
     - component
     - index.js
```