### PR TITLE
feat: use PAGES_PATH as the first choice

### DIFF
--- a/packages/umi-build-dev/src/getPaths.js
+++ b/packages/umi-build-dev/src/getPaths.js
@@ -16,16 +16,18 @@ export default function(service) {
   let pagesPath = 'pages';
   if (process.env.PAGES_PATH) {
     pagesPath = process.env.PAGES_PATH;
+  } else {
+    if (test(join(cwd, 'src/page'))) {
+      pagesPath = 'src/page';
+    }
+    if (test(join(cwd, 'src/pages'))) {
+      pagesPath = 'src/pages';
+    }
+    if (test(join(cwd, 'page'))) {
+      pagesPath = 'page';
+    }
   }
-  if (test(join(cwd, 'src/page'))) {
-    pagesPath = 'src/page';
-  }
-  if (test(join(cwd, 'src/pages'))) {
-    pagesPath = 'src/pages';
-  }
-  if (test(join(cwd, 'page'))) {
-    pagesPath = 'page';
-  }
+
   const absPagesPath = join(cwd, pagesPath);
   const absSrcPath = join(absPagesPath, '../');
 


### PR DESCRIPTION
When PAGES_PATH exist and  pages folder exits too, should use PAGES_PATH.