### PR TITLE
feat: add _modifyBlockTarget

### DIFF
--- a/packages/umi-build-dev/src/PluginAPI.js
+++ b/packages/umi-build-dev/src/PluginAPI.js
@@ -105,6 +105,7 @@ export default class PluginAPI {
       '_modifyBlockPackageJSONPath',
       '_modifyBlockDependencies',
       '_modifyBlockFile',
+      '_modifyBlockTarget',
     ].forEach(method => {
       if (Array.isArray(method)) {
         this.registerMethod(...method);

--- a/packages/umi-build-dev/src/plugins/commands/block/block.js
+++ b/packages/umi-build-dev/src/plugins/commands/block/block.js
@@ -217,20 +217,23 @@ export default api => {
           },
         };
         if (existsSync(folderPath)) {
-          if (config.singular) {
-            // @/components/ => @/src/component/ and ./components/ => ./component etc.
-            readdirSync(folderPath).forEach(name => {
-              const thePath = join(folderPath, name);
-              if (statSync(thePath).isDirectory()) {
-                name = getSingularName(name);
-              }
-              debug(`copy ${thePath} to ${join(targetFolder, name)}`);
-              this.fs.copy(thePath, join(targetFolder, name), options);
+          readdirSync(folderPath).forEach(name => {
+            const thePath = join(folderPath, name);
+            if (statSync(thePath).isDirectory() && config.singular) {
+              // @/components/ => @/src/component/ and ./components/ => ./component etc.
+              name = getSingularName(name);
+            }
+            const realTarget = applyPlugins('_modifyBlockTarget', {
+              initialValue: join(targetFolder, name),
+              args: {
+                source: thePath,
+                blockPath: this.path,
+                sourceName: name,
+              },
             });
-          } else {
-            debug(`copy ${folderPath} to ${targetFolder}`);
-            this.fs.copy(folderPath, targetFolder, options);
-          }
+            debug(`copy ${thePath} to ${realTarget}`);
+            this.fs.copy(thePath, realTarget, options);
+          });
         }
       });
     }


### PR DESCRIPTION
app plugin api _modifyBlockTarget.

用于修改区块代码下载的时候可以对目录结构做一些调整，比如可以把区块的 `_mock.js` 文件下载到项目的 mock 文件夹下。