### PR TITLE
Add support for terserJS

### DIFF
--- a/packages/af-webpack/package.json
+++ b/packages/af-webpack/package.json
@@ -49,6 +49,7 @@
     "strip-ansi": "4.0.0",
     "strip-json-comments": "^2.0.1",
     "style-loader": "^0.22.1",
+    "terser-webpack-plugin": "^1.1.0",
     "ts-loader": "^4.5.0",
     "tslint": "^5.8.0",
     "tslint-loader": "^3.5.3",

--- a/packages/af-webpack/src/getConfig/prod.js
+++ b/packages/af-webpack/src/getConfig/prod.js
@@ -1,5 +1,7 @@
+import TerserPlugin from 'terser-webpack-plugin';
 import UglifyPlugin from 'uglifyjs-webpack-plugin';
 import isPlainObject from 'is-plain-object';
+import terserOptions from './terserOptions';
 import uglifyOptions from './uglifyOptions';
 
 function mergeConfig(config, userConfig) {
@@ -56,16 +58,25 @@ export default function(webpackConfig, opts) {
       .plugin('hash-module-ids')
       .use(require('webpack/lib/HashedModuleIdsPlugin'));
 
-    webpackConfig.optimization.minimizer([
-      new UglifyPlugin(
-        mergeConfig(
-          {
-            ...uglifyOptions,
-            sourceMap: !!opts.devtool,
-          },
-          opts.uglifyJSOptions,
-        ),
-      ),
-    ]);
+    let minimizerPlugin = opts.minimizer === 'terser' ?
+        new TerserPlugin(
+          mergeConfig(
+            {
+              ...terserOptions,
+              sourceMap: !!opts.devtool,
+            },
+            opts.terserOptions,
+          )
+        ) :
+        new UglifyPlugin(
+          mergeConfig(
+            {
+              ...uglifyOptions,
+              sourceMap: !!opts.devtool,
+            },
+            opts.uglifyJSOptions,
+          ),
+        );
+    webpackConfig.optimization.minimizer([minimizerPlugin]);
   }
 }

--- a/packages/af-webpack/src/getConfig/terserOptions.js
+++ b/packages/af-webpack/src/getConfig/terserOptions.js
@@ -1,0 +1,57 @@
+/**
+ * ref:
+ * - https://github.com/facebook/create-react-app/blob/581c453/packages/react-scripts/config/webpack.config.prod.js#L120-L154
+ * - https://github.com/vuejs/vue-cli/blob/dev/packages/@vue/cli-service/lib/config/uglifyOptions.js
+ */
+export default {
+  terserOptions: {
+    parse: {
+      ecma: 8,
+    },
+    compress: {
+      ecma: 5,
+      warnings: false,
+
+      // turn off flags with small gains to speed up minification
+      arrows: false,
+      collapse_vars: false, // 0.3kb
+      comparisons: false,
+      computed_props: false,
+      hoist_funs: false,
+      hoist_props: false,
+      hoist_vars: false,
+      inline: false,
+      loops: false,
+      negate_iife: false,
+      properties: false,
+      reduce_funcs: false,
+      reduce_vars: false,
+      switches: false,
+      toplevel: false,
+      typeofs: false,
+
+      // a few flags with noticable gains/speed ratio
+      // numbers based on out of the box vendor bundle
+      booleans: true, // 0.7kb
+      if_return: true, // 0.4kb
+      sequences: true, // 0.7kb
+      unused: true, // 2.3kb
+
+      // required features to drop conditional branches
+      conditionals: true,
+      dead_code: true,
+      evaluate: true,
+    },
+    mangle: {
+      safari10: true,
+    },
+    output: {
+      ecma: 5,
+      comments: false,
+      ascii_only: true,
+    },
+  },
+  sourceMap: false,
+  cache: true,
+  parallel: true,
+};

--- a/packages/af-webpack/src/getUserConfig/configs/terserOptions.js
+++ b/packages/af-webpack/src/getUserConfig/configs/terserOptions.js
@@ -1,0 +1,14 @@
+import assert from 'assert';
+import isPlainObject from 'is-plain-object';
+
+export default function() {
+  return {
+    name: 'terserOptions',
+    validate(val) {
+      assert(
+        isPlainObject(val) || typeof val === 'function',
+        `The terserOptions config must be Plain Object or function, but got ${val}`,
+      );
+    },
+  };
+}


### PR DESCRIPTION
[TerserJS](https://github.com/terser-js/terser#mangle-options) is an
alternative to UglifyJS which supports es6.

Added options:

`minimizer: "terser" (default: uglify)`
`terserJSOptions: {}`