### PR TITLE
feat: support proxy multiple, specific paths to the same target

### DIFF
--- a/packages/af-webpack/src/getUserConfig/configs/proxy.js
+++ b/packages/af-webpack/src/getUserConfig/configs/proxy.js
@@ -1,13 +1,13 @@
 import assert from 'assert';
-import { isPlainObject } from 'lodash';
+import { isPlainObject, isArrayLikeObject } from 'lodash';
 
 export default function() {
   return {
     name: 'proxy',
     validate(val) {
       assert(
-        isPlainObject(val),
-        `The proxy config must be Plain Object, but got ${val}`,
+        isPlainObject(val) || isArrayLikeObject(val),
+        `The proxy config must be Plain Object or Array-like Object, but got ${val}`,
       );
     },
   };


### PR DESCRIPTION
If you want to proxy multiple, specific paths to the same target, you can use an array of one or more objects with a context property:

```
proxy: [{
      context: ['/auth', '/api'],
      target: 'http://localhost:3000',
}]
```
