### PR TITLE
fix: extraBabelIncludes not use extraBabelPlugins

### DIFF
--- a/packages/af-webpack/src/getConfig/index.js
+++ b/packages/af-webpack/src/getConfig/index.js
@@ -137,6 +137,7 @@ export default function(opts) {
     presets: [
       [require.resolve('babel-preset-umi'), { transformRuntime: false }],
     ],
+    plugins: [...(opts.extraBabelPlugins || [])],
     ...babelOptsCommon,
   };
   if (opts.disableDynamicImport) {


### PR DESCRIPTION
Close #1658

这里还要确认下 extraBabelPlugins 是否应该要应用到 extraBabelIncludes 这个上面？我理解 extraBabelIncludes 中的 babel 的配置应该和 src 中保持一致才对。

@sorrycc babelOptsForDeps 和 babelOpts 直接保持一致会不会有问题？