### PR TITLE
fix: locale plugin compatible antd ^3.11.4

### DIFF
--- a/packages/umi-plugin-locale/template/wrapper.jsx.tpl
+++ b/packages/umi-plugin-locale/template/wrapper.jsx.tpl
@@ -26,7 +26,8 @@ import moment from 'moment';
 {{#defaultMomentLocale}}
 import 'moment/locale/{{defaultMomentLocale}}';
 {{/defaultMomentLocale}}
-const defaultAntd = require('antd/lib/locale-provider/{{defaultAntdLocale}}');
+let defaultAntd = require('antd/lib/locale-provider/{{defaultAntdLocale}}');
+defaultAntd = defaultAntd.default || defaultAntd;
 {{/antd}}
 
 const localeInfo = {
@@ -69,7 +70,7 @@ export default function LocaleWrapper(props) {
   </IntlProvider>)
   {{/localeList.length}}
   {{#antd}}
-  ret = (<LocaleProvider locale={appLocale.antd || defaultAntd}>
+  ret = (<LocaleProvider locale={appLocale.antd ? (appLocale.antd.default || appLocale.antd) : defaultAntd}>
     {ret}
   </LocaleProvider>);
   {{/antd}}


### PR DESCRIPTION
3.11.4 里不能 locale = require('antd/lib/locale-provider/zh_CN') 了，要改成 require('antd/lib/locale-provider/zh_CN').default