### PR TITLE
fix: Minimize the use of the lodash module

### DIFF
--- a/packages/umi/src/runtimePlugin.js
+++ b/packages/umi/src/runtimePlugin.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { isPlainObject } from 'lodash';
+import isPlainObject from 'lodash/isPlainObject';
 
 let plugins = null;
 let validKeys = [];


### PR DESCRIPTION
现在 umi@2.3.2 版本打包分析的时候，发现会打包 lodash 模块进去

![image](https://user-images.githubusercontent.com/3281438/50693406-d0169300-1071-11e9-9202-e9c45ec4d752.png)

在项目工程里 node_modules/umi/lib/runtimePlugin.js 里，require 整个 lodash 模块

![image](https://user-images.githubusercontent.com/3281438/50693584-559a4300-1072-11e9-8419-07af9035dec8.png)

应该是 tree shaking 没生效；
我提这次PR，现改成按需引用 
```
import isPlainObject from 'lodash/isPlainObject';
```
