### PR TITLE
Update webpack-dev-server

### DIFF
--- a/packages/af-webpack/package.json
+++ b/packages/af-webpack/package.json
@@ -66,7 +66,7 @@
     "webpack": "4.28.1",
     "webpack-bundle-analyzer": "3.0.3",
     "webpack-chain": "5.0.1",
-    "webpack-dev-server": "3.1.10",
+    "webpack-dev-server": "3.1.14",
     "webpack-manifest-plugin": "2.0.4",
     "webpack-merge": "4.1.5",
     "webpackbar": "3.1.3"


### PR DESCRIPTION
webpack-dev-server  Missing Origin Validation
https://www.npmjs.com/advisories/725
Should update webpack-dev-server to version 3.1.11 or later.