### PR TITLE
feat: support tree-shaking

### DIFF
--- a/packages/umi-build-dev/src/plugins/afwebpack-config.js
+++ b/packages/umi-build-dev/src/plugins/afwebpack-config.js
@@ -168,6 +168,7 @@ export default function(api) {
               targets,
               env: {
                 useBuiltIns: 'entry',
+                modules: false,
               },
             },
           ],
@@ -186,8 +187,8 @@ export default function(api) {
       publicPath: isDev
         ? '/'
         : config.publicPath != null
-          ? config.publicPath
-          : '/',
+        ? config.publicPath
+        : '/',
     };
   });
 }


### PR DESCRIPTION
Close #1364

---

e.g. a project used lodash-es

before tree-shaking

```bash
$ umi build && ll ./dist

✔ Webpack
  Compiled successfully in 4.08s

 DONE  Compiled successfully in 4082ms                                                                                                                                 11:37:46

File sizes after gzip:

  112.28 KB  dist/umi.js
  56 B       dist/umi.css

total 704
drwxr-xr-x  5 chencheng  wheel   160B  1  8 11:37 .
drwx------  7 chencheng  wheel   224B  1  8 11:37 ..
-rw-r--r--  1 chencheng  wheel   324B  1  8 11:37 index.html
-rw-r--r--  1 chencheng  wheel    36B  1  8 11:37 umi.css
-rw-r--r--  1 chencheng  wheel   343K  1  8 11:37 umi.js
```

after tree-shaking

```bash
$ umi build && ll ./dist

✔ Webpack
  Compiled successfully in 4.49s

 DONE  Compiled successfully in 4495ms                                                                                                                                 11:37:32

File sizes after gzip:

  81.97 KB  dist/umi.js
  56 B      dist/umi.css

total 528
drwxr-xr-x  5 chencheng  wheel   160B  1  8 11:37 .
drwx------  7 chencheng  wheel   224B  1  8 11:37 ..
-rw-r--r--  1 chencheng  wheel   324B  1  8 11:37 index.html
-rw-r--r--  1 chencheng  wheel    36B  1  8 11:37 umi.css
-rw-r--r--  1 chencheng  wheel   255K  1  8 11:37 umi.js
```
