### PR TITLE
fix: locale api is undefined before react app mounted

### DIFF
--- a/packages/umi-plugin-locale/index.d.ts
+++ b/packages/umi-plugin-locale/index.d.ts
@@ -87,11 +87,6 @@ export declare function formatNumber(value: number, options?: FormattedNumberPro
 export declare function formatPlural(value: number, options?: FormattedPluralBase): keyof FormattedPluralProps;
 export declare function formatMessage(messageDescriptor: MessageDescriptor, values?: { [key: string]: MessageValue }): string;
 export declare function formatHTMLMessage(messageDescriptor: MessageDescriptor, values?: { [key: string]: MessageValue }): string;
-export declare const locale: string;
-export declare const formats: any;
-export declare const messages: { [id: string]: string };
-export declare const defaultLocale: string;
-export declare const defaultFormats: any;
 export declare function now(): number;
 export declare function onError(error: string): void;
 

--- a/packages/umi-plugin-locale/src/locale.js
+++ b/packages/umi-plugin-locale/src/locale.js
@@ -1,5 +1,6 @@
+/* eslint-disable no-undef, prefer-rest-params */
 const ReactIntl = require('react-intl');
-/* eslint-disable no-undef */
+
 function setLocale(lang) {
   if (lang !== undefined && !/^([a-z]{2})-([A-Z]{2})$/.test(lang)) {
     // for reset when lang === undefined
@@ -15,12 +16,46 @@ function getLocale() {
   return window.g_lang;
 }
 
+// init api methods
+let intl;
+const intlApi = {};
+
+[
+  'formatMessage',
+  'formatHTMLMessage',
+  'formatDate',
+  'formatTime',
+  'formatRelative',
+  'formatNumber',
+  'formatPlural',
+  'now',
+  'onError',
+].forEach(methodName => {
+  intlApi[methodName] = function() {
+    if (intl && intl[methodName]) {
+      // _setIntlObject has been called
+      return intl[methodName].call(intl, ...arguments);
+    } else if (console && console.wran) {
+      console.warn(
+        `[umi-plugin-locale] ${methodName} not initialized yet, you should use it after react app mounted.`,
+      );
+    }
+    return null;
+  };
+});
+
 // react-intl 没有直接暴露 formatMessage 这个方法
 // 只能注入到 props 中，所以通过在最外层包一个组件然后组件内调用这个方法来把 intl 这个对象暴露到这里来
 // TODO 查找有没有更好的办法
-function _setIntlObject(intl) {
+function _setIntlObject(theIntl) {
   // umi 系统 API，不对外暴露
-  Object.assign(module.exports, intl);
+  intl = theIntl;
 }
 
-module.exports = { ...ReactIntl, setLocale, getLocale, _setIntlObject };
+module.exports = {
+  ...ReactIntl,
+  ...intlApi,
+  setLocale,
+  getLocale,
+  _setIntlObject,
+};

--- a/packages/umi-plugin-locale/test/locale.test.js
+++ b/packages/umi-plugin-locale/test/locale.test.js
@@ -7,6 +7,13 @@ import {
   getLocale,
   intlShape,
   setLocale,
+  now,
+  onError,
+  formatDate,
+  formatTime,
+  formatRelative,
+  formatNumber,
+  formatPlural,
   _setIntlObject,
 } from '../src/locale';
 
@@ -66,7 +73,29 @@ describe('test umi/locale', () => {
     expect(setLocale).toBeTruthy();
     expect(getLocale).toBeTruthy();
     expect(FormattedMessage).toBeTruthy();
+    expect(now).toBeTruthy();
+    expect(onError).toBeTruthy();
+    expect(formatDate).toBeTruthy();
+    expect(formatTime).toBeTruthy();
+    expect(formatRelative).toBeTruthy();
+    expect(formatNumber).toBeTruthy();
+    expect(formatPlural).toBeTruthy();
     wrapper.unmount();
+  });
+
+  test('api exist before mounted', () => {
+    expect(formatMessage).toBeTruthy();
+    expect(formatHTMLMessage).toBeTruthy();
+    expect(setLocale).toBeTruthy();
+    expect(getLocale).toBeTruthy();
+    expect(FormattedMessage).toBeTruthy();
+    expect(now).toBeTruthy();
+    expect(onError).toBeTruthy();
+    expect(formatDate).toBeTruthy();
+    expect(formatTime).toBeTruthy();
+    expect(formatRelative).toBeTruthy();
+    expect(formatNumber).toBeTruthy();
+    expect(formatPlural).toBeTruthy();
   });
 
   test('setLocale', () => {


### PR DESCRIPTION
类似 `formatMessage` 这样的 API 在 `react-intl` 在用法是需要通过 context 然后在组件中通过 `this.formatMessage` 来使用。在 `umi-plugin-locale` 中为了更方便，通过封装了一层之后使得用户可以直接调用 formatMessage 来使用，但是有一个问题是必须要 react app 挂载之后 formatMessage 才能实际可用。 

也就是说如果直接在模块初始化部分使用的话是无效了，最初是有一个空的方法做容错处理，后来在 https://github.com/umijs/umi/pull/1730 这个 PR 中去掉了容错的方法，会导致如果再模块初始化阶段拿到的方法是 undefined。

在这个 PR 中重新加上了容错的方法，并且在模块初始化调用的时候给出警告提示。另外去掉了 https://github.com/umijs/umi/pull/1730 这个 PR 中添加的 locale 这些非方法的内容，如果这些内容需要用到的话建议还是类似提供 `getLocale` 这样的方法来调用。