### PR TITLE
fix: patchRoutes failed with no path route when exportStatic.htmlSuffix is true

### DIFF
--- a/packages/umi-build-dev/src/routes/patchRoutes.js
+++ b/packages/umi-build-dev/src/routes/patchRoutes.js
@@ -62,7 +62,7 @@ function patchRoute(route, config, isProduction, onPatchRoute) {
   }
 
   // /path -> /path.html
-  if (config.exportStatic && config.exportStatic.htmlSuffix) {
+  if (route.path && config.exportStatic && config.exportStatic.htmlSuffix) {
     route.path = addHtmlSuffix(route.path, !!route.routes);
   }
 

--- a/packages/umi-build-dev/src/routes/patchRoutes.test.js
+++ b/packages/umi-build-dev/src/routes/patchRoutes.test.js
@@ -60,6 +60,13 @@ describe('patchRoutes', () => {
     ]);
   });
 
+  it('exportStatic.htmlSuffix with no path route', () => {
+    const routes = patchRoutes([{ path: '/a' }, { component: './404.js' }], {
+      exportStatic: { htmlSuffix: true },
+    });
+    expect(routes).toEqual([{ path: '/a.html' }, { component: './404.js' }]);
+  });
+
   it('copy /index.html for / if exportStatic', () => {
     let routes;
 


### PR DESCRIPTION
Close #1722
