### PR TITLE
fix: locale for moment.js won't work if it is not set specifically

### DIFF
--- a/packages/umi-plugin-locale/template/wrapper.jsx.tpl
+++ b/packages/umi-plugin-locale/template/wrapper.jsx.tpl
@@ -67,6 +67,10 @@ window.g_lang = appLocale.locale;
 appLocale.data && addLocaleData(appLocale.data);
 {{/localeList.length}}
 
+{{#antd}}
+moment.locale(appLocale.momentLocale);
+{{/antd}}
+
 export default function LocaleWrapper(props) {
   let ret = props.children;
   {{#localeList.length}}


### PR DESCRIPTION
如题，当没有显式设置`moment.locale(xxx)`时，moment的多语言是不生效的