### PR TITLE
fix: title locale bug when separator not include space

### DIFF
--- a/packages/umi-build-dev/src/routes/routesToJSON.js
+++ b/packages/umi-build-dev/src/routes/routesToJSON.js
@@ -54,7 +54,9 @@ export default (routes, service) => {
             .map(
               v =>
                 `require('${winPath(
-                  relative(paths.absTmpDirPath, join(paths.cwd, v)),
+                  precedingDot(
+                    relative(paths.absTmpDirPath, join(paths.cwd, v)),
+                  ),
                 )}').default`,
             )
             .join(', ')}]`;
@@ -72,6 +74,10 @@ function patchRoutes(routes, webpackChunkName) {
     patchRoute(route, webpackChunkName);
   });
   level -= 1;
+}
+
+function precedingDot(p) {
+  return p.startsWith('.') ? p : `./${p}`;
 }
 
 function normalizeEntry(entry) {

--- a/packages/umi-build-dev/src/routes/routesToJSON.test.js
+++ b/packages/umi-build-dev/src/routes/routesToJSON.test.js
@@ -5,7 +5,7 @@ const service = {
   paths: {
     cwd: '$CWD$',
     absSrcPath: '$SRC$',
-    absTmpDirPath: '$CWD$/.pages/.umi',
+    absTmpDirPath: '$CWD$/pages/.umi',
     tmpDirPath: './pages/.umi',
     absCompilingComponentPath: '$COMPILING$',
   },
@@ -118,9 +118,17 @@ describe('routesToJSON', () => {
   });
 
   it('Routes', () => {
-    const json = routesToJSON([{ Routes: ['./routes/A'] }], service, {});
+    const json = routesToJSON(
+      [
+        {
+          Routes: ['./routes/A', './pages/.umi/B'],
+        },
+      ],
+      service,
+      {},
+    );
     expect(JSON.parse(json)).toEqual([
-      { Routes: "[require('../../routes/A').default]" },
+      { Routes: "[require('../../routes/A').default, require('./B').default]" },
     ]);
   });
 

--- a/packages/umi-plugin-react/src/plugins/title/index.js
+++ b/packages/umi-plugin-react/src/plugins/title/index.js
@@ -8,7 +8,10 @@ export default (api, option) => {
   const wrapperPath = join(paths.absTmpDirPath, './TitleWrapper.jsx');
 
   // write titleWrapper at while launching
-  writeTitleWrapper(wrapperPath, option.useLocale, option);
+  api.beforeDevServer(() => {
+    // in beforeDevServer for wait absTmpDirPath(.umi) created
+    writeTitleWrapper(wrapperPath, option.useLocale, option);
+  });
 
   api.onOptionChange(newOption => {
     option = newOption;

--- a/packages/umi-plugin-react/src/plugins/title/index.js
+++ b/packages/umi-plugin-react/src/plugins/title/index.js
@@ -5,15 +5,16 @@ import Mustache from 'mustache';
 
 export default (api, option) => {
   const { paths, config } = api;
+  const wrapperPath = join(paths.absTmpDirPath, './TitleWrapper.jsx');
 
   // write titleWrapper at while launching
-  writeTitleWrapper(paths, option.useLocale, option);
+  writeTitleWrapper(wrapperPath, option.useLocale, option);
 
   api.onOptionChange(newOption => {
     option = newOption;
 
     // write titleWrapper whenever title option changed
-    writeTitleWrapper(paths, option.useLocale, option);
+    writeTitleWrapper(wrapperPath, option.useLocale, option);
     api.rebuildHTML();
   });
 
@@ -37,14 +38,13 @@ export default (api, option) => {
       // only open this plugin when option exist
       route.Routes = [
         ...(route.Routes || []),
-        relative(paths.cwd, join(__dirname, 'TitleWrapper.jsx')),
+        relative(paths.cwd, wrapperPath),
       ];
     }
   });
 };
 
-function writeTitleWrapper(paths, useLocale, option) {
-  const wrapperPath = join(__dirname, './TitleWrapper.jsx');
+function writeTitleWrapper(targetPath, useLocale, option) {
   const wrapperTpl = readFileSync(
     join(__dirname, './template/TitleWrapper.js.tpl'),
     'utf-8',
@@ -53,7 +53,7 @@ function writeTitleWrapper(paths, useLocale, option) {
     useLocale,
     option,
   });
-  writeFileSync(wrapperPath, wrapperContent, 'utf-8');
+  writeFileSync(targetPath, wrapperContent, 'utf-8');
 }
 
 function parseOption(option) {

--- a/packages/umi-plugin-react/src/plugins/title/template/TitleWrapper.js.tpl
+++ b/packages/umi-plugin-react/src/plugins/title/template/TitleWrapper.js.tpl
@@ -16,8 +16,8 @@ export default class UmiReactTitle extends React.Component {
     const separator = '{{option.separator}}' || ' - ';
     const title = this.props.route._title.split(separator).map(item => {
       return formatMessage({
-        id: item,
-        defaultMessage: item,
+        id: item.trim(),
+        defaultMessage: item.trim(),
       });
     })
     return title.join(separator);

--- a/packages/umi-plugin-react/test/normal.e2e.js
+++ b/packages/umi-plugin-react/test/normal.e2e.js
@@ -71,7 +71,7 @@ describe('normal', () => {
     const titleText = await page.evaluate(
       () => document.querySelector('title').innerHTML,
     );
-    expect(titleText).toEqual('testpage');
+    expect(titleText).toEqual('标题测试');
   });
 
   it('mock', async () => {

--- a/packages/umi-plugin-react/test/normal/.umirc.js
+++ b/packages/umi-plugin-react/test/normal/.umirc.js
@@ -26,7 +26,16 @@ export default {
         },
         polyfills: [],
         antd: true,
-        title: '默认标题',
+        title: {
+          defaultTitle: '默认标题',
+          useLocale: true,
+          format: '{current} {separator} {parent}',
+          separator: '|',
+        },
+        locale: {
+          default: 'zh-CN',
+          baseNavigator: false,
+        },
 
         headScripts: [{ content: `window.scripts = ['headScript1'];` }],
         scripts: [

--- a/packages/umi-plugin-react/test/normal/locales/en-US.js
+++ b/packages/umi-plugin-react/test/normal/locales/en-US.js
@@ -1,0 +1,3 @@
+export default {
+  'title.test': 'title test',
+};

--- a/packages/umi-plugin-react/test/normal/locales/zh-CN.js
+++ b/packages/umi-plugin-react/test/normal/locales/zh-CN.js
@@ -1,0 +1,3 @@
+export default {
+  'title.test': '标题测试',
+};

--- a/packages/umi-plugin-react/test/normal/pages/a.js
+++ b/packages/umi-plugin-react/test/normal/pages/a.js
@@ -1,5 +1,5 @@
 /*
-title: testpage
+title: title.test
 */
 export default () => {
   return <h1>Page a</h1>;


### PR DESCRIPTION
- 添加 title 和国际化的 e2e 测试
- 查找 title 的 locale 资源的时候添加 trim，避免找不到对应的 key
- 修复 routesToJSON.js 中 Route 的路径可能不包含 `.` 的情况