### PR TITLE
fix: manifest srcPath with query build error

### DIFF
--- a/packages/umi-plugin-react/src/plugins/pwa/generateWebManifest.js
+++ b/packages/umi-plugin-react/src/plugins/pwa/generateWebManifest.js
@@ -29,7 +29,10 @@ export default function generateWebManifest(api, options) {
   };
   let manifestFilename = basename(srcPath);
 
-  if (existsSync(parse(srcPath).pathname)) {
+  // remove path query
+  srcPath = parse(srcPath).pathname;
+
+  if (existsSync(srcPath)) {
     // watch manifest on DEV mode
     if (process.env.NODE_ENV === 'development') {
       addPageWatcher([srcPath]);


### PR DESCRIPTION
由于在 WebManifestPlugin 里面使用了 srcPath 读取文件，因此需要处理下