### PR TITLE
feat: support onRouteChange({ location, routes }) in app.js

### DIFF
--- a/docs/plugin/develop.md
+++ b/docs/plugin/develop.md
@@ -618,6 +618,22 @@ Added version information, displayed in `umi -v` or `umi version`.
 
 Add a runtime plugin with parameters as the absolute path to the file.
 
+e.g.
+
+```js
+api.addRuntimePlugin(require.resolve('./app.js'));
+```
+
+Then in `app.js`:
+
+```
+export function render(oldRender) {
+  setTimeout(oldRender, 1000);
+}
+```
+
+This implements a 1 second delayed rendering application.
+
 ### addRuntimePluginKey
 
 Add a runtime configurable item.

--- a/docs/zh/plugin/develop.md
+++ b/docs/zh/plugin/develop.md
@@ -619,6 +619,22 @@ api.modifyAFWebpackOpts((memo) => {
 
 添加运行时插件，参数为文件的绝对路径。
 
+比如：
+
+```js
+api.addRuntimePlugin(require.resolve('./app.js'));
+```
+
+然后在 app.js 是以下内容：
+
+```
+export function render(oldRender) {
+  setTimeout(oldRender, 1000);
+}
+```
+
+这样就实现了延迟 1s 渲染应用。
+
 ### addRuntimePluginKey
 
 添加运行时可配置项。

--- a/packages/umi-build-dev/src/FilesGenerator.js
+++ b/packages/umi-build-dev/src/FilesGenerator.js
@@ -164,6 +164,7 @@ export default class FilesGenerator {
         'render',
         'rootContainer',
         'modifyRouteProps',
+        'onRouteChange',
       ],
     });
     assert(

--- a/packages/umi-build-dev/template/router.js.tpl
+++ b/packages/umi-build-dev/template/router.js.tpl
@@ -12,11 +12,12 @@ window.g_routes = routes;
 window.g_plugins.applyForEach('patchRoutes', { initialValue: routes });
 
 // route change handler
-function routeChangeHandler(location) {
+function routeChangeHandler(location, action) {
   window.g_plugins.applyForEach('onRouteChange', {
     initialValue: {
       routes,
       location,
+      action,
     },
   });
 }

--- a/packages/umi-build-dev/template/router.js.tpl
+++ b/packages/umi-build-dev/template/router.js.tpl
@@ -11,6 +11,18 @@ let routes = {{{ routes }}};
 window.g_routes = routes;
 window.g_plugins.applyForEach('patchRoutes', { initialValue: routes });
 
+// route change handler
+function routeChangeHandler(location) {
+  window.g_plugins.applyForEach('onRouteChange', {
+    initialValue: {
+      routes,
+      location,
+    },
+  });
+}
+window.g_history.listen(routeChangeHandler);
+routeChangeHandler(window.g_history.location);
+
 export default function RouterWrapper() {
   return (
 {{{ routerContent }}}

--- a/packages/umi/test/fixtures/build/export-static-htmlSuffix/expected/umi.js
+++ b/packages/umi/test/fixtures/build/export-static-htmlSuffix/expected/umi.js
@@ -657,7 +657,7 @@ var _reactDom = _interopRequireDefault(__webpack_require__(24));
 // runtime plugins
 window.g_plugins = __webpack_require__(25);
 window.g_plugins.init({
-  validKeys: ['patchRoutes', 'render', 'rootContainer', 'modifyRouteProps']
+  validKeys: ['patchRoutes', 'render', 'rootContainer', 'modifyRouteProps', 'onRouteChange']
 }); // render
 
 var oldRender = () => {
@@ -2022,7 +2022,19 @@ var routes = [{
 window.g_routes = routes;
 window.g_plugins.applyForEach('patchRoutes', {
   initialValue: routes
-});
+}); // route change handler
+
+function routeChangeHandler(location) {
+  window.g_plugins.applyForEach('onRouteChange', {
+    initialValue: {
+      routes,
+      location
+    }
+  });
+}
+
+window.g_history.listen(routeChangeHandler);
+routeChangeHandler(window.g_history.location);
 
 function RouterWrapper() {
   return _react.default.createElement(Router, {

--- a/packages/umi/test/fixtures/build/export-static-htmlSuffix/expected/umi.js
+++ b/packages/umi/test/fixtures/build/export-static-htmlSuffix/expected/umi.js
@@ -2024,11 +2024,12 @@ window.g_plugins.applyForEach('patchRoutes', {
   initialValue: routes
 }); // route change handler
 
-function routeChangeHandler(location) {
+function routeChangeHandler(location, action) {
   window.g_plugins.applyForEach('onRouteChange', {
     initialValue: {
       routes,
-      location
+      location,
+      action
     }
   });
 }

--- a/packages/umi/test/fixtures/build/export-static/expected/umi.js
+++ b/packages/umi/test/fixtures/build/export-static/expected/umi.js
@@ -2083,11 +2083,12 @@ window.g_plugins.applyForEach('patchRoutes', {
   initialValue: routes
 }); // route change handler
 
-function routeChangeHandler(location) {
+function routeChangeHandler(location, action) {
   window.g_plugins.applyForEach('onRouteChange', {
     initialValue: {
       routes,
-      location
+      location,
+      action
     }
   });
 }

--- a/packages/umi/test/fixtures/build/export-static/expected/umi.js
+++ b/packages/umi/test/fixtures/build/export-static/expected/umi.js
@@ -694,7 +694,7 @@ var _reactDom = _interopRequireDefault(__webpack_require__(25));
 // runtime plugins
 window.g_plugins = __webpack_require__(26);
 window.g_plugins.init({
-  validKeys: ['patchRoutes', 'render', 'rootContainer', 'modifyRouteProps']
+  validKeys: ['patchRoutes', 'render', 'rootContainer', 'modifyRouteProps', 'onRouteChange']
 }); // render
 
 var oldRender = () => {
@@ -2081,7 +2081,19 @@ var routes = [{
 window.g_routes = routes;
 window.g_plugins.applyForEach('patchRoutes', {
   initialValue: routes
-});
+}); // route change handler
+
+function routeChangeHandler(location) {
+  window.g_plugins.applyForEach('onRouteChange', {
+    initialValue: {
+      routes,
+      location
+    }
+  });
+}
+
+window.g_history.listen(routeChangeHandler);
+routeChangeHandler(window.g_history.location);
 
 function RouterWrapper() {
   return _react.default.createElement(Router, {

--- a/packages/umi/test/fixtures/build/simple/expected/umi.js
+++ b/packages/umi/test/fixtures/build/simple/expected/umi.js
@@ -631,7 +631,7 @@ var _reactDom = _interopRequireDefault(__webpack_require__(24));
 // runtime plugins
 window.g_plugins = __webpack_require__(25);
 window.g_plugins.init({
-  validKeys: ['patchRoutes', 'render', 'rootContainer', 'modifyRouteProps']
+  validKeys: ['patchRoutes', 'render', 'rootContainer', 'modifyRouteProps', 'onRouteChange']
 }); // render
 
 var oldRender = () => {
@@ -2006,7 +2006,19 @@ var routes = [{
 window.g_routes = routes;
 window.g_plugins.applyForEach('patchRoutes', {
   initialValue: routes
-});
+}); // route change handler
+
+function routeChangeHandler(location) {
+  window.g_plugins.applyForEach('onRouteChange', {
+    initialValue: {
+      routes,
+      location
+    }
+  });
+}
+
+window.g_history.listen(routeChangeHandler);
+routeChangeHandler(window.g_history.location);
 
 function RouterWrapper() {
   return _react.default.createElement(Router, {

--- a/packages/umi/test/fixtures/build/simple/expected/umi.js
+++ b/packages/umi/test/fixtures/build/simple/expected/umi.js
@@ -2008,11 +2008,12 @@ window.g_plugins.applyForEach('patchRoutes', {
   initialValue: routes
 }); // route change handler
 
-function routeChangeHandler(location) {
+function routeChangeHandler(location, action) {
   window.g_plugins.applyForEach('onRouteChange', {
     initialValue: {
       routes,
-      location
+      location,
+      action
     }
   });
 }

--- a/packages/umi/test/fixtures/build/tree-shaking-with-cjs/expected/umi.js
+++ b/packages/umi/test/fixtures/build/tree-shaking-with-cjs/expected/umi.js
@@ -218,7 +218,7 @@ __webpack_require__.r(__webpack_exports__);
 
 window.g_plugins = __webpack_require__(9);
 window.g_plugins.init({
-  validKeys: ['patchRoutes', 'render', 'rootContainer', 'modifyRouteProps']
+  validKeys: ['patchRoutes', 'render', 'rootContainer', 'modifyRouteProps', 'onRouteChange']
 }); // render
 
 var oldRender = () => {
@@ -774,7 +774,19 @@ var router_routes = [{
 window.g_routes = router_routes;
 window.g_plugins.applyForEach('patchRoutes', {
   initialValue: router_routes
-});
+}); // route change handler
+
+function routeChangeHandler(location) {
+  window.g_plugins.applyForEach('onRouteChange', {
+    initialValue: {
+      routes: router_routes,
+      location
+    }
+  });
+}
+
+window.g_history.listen(routeChangeHandler);
+routeChangeHandler(window.g_history.location);
 function RouterWrapper() {
   return external_window_React_default.a.createElement(Router, {
     history: window.g_history

--- a/packages/umi/test/fixtures/build/tree-shaking-with-cjs/expected/umi.js
+++ b/packages/umi/test/fixtures/build/tree-shaking-with-cjs/expected/umi.js
@@ -776,11 +776,12 @@ window.g_plugins.applyForEach('patchRoutes', {
   initialValue: router_routes
 }); // route change handler
 
-function routeChangeHandler(location) {
+function routeChangeHandler(location, action) {
   window.g_plugins.applyForEach('onRouteChange', {
     initialValue: {
       routes: router_routes,
-      location
+      location,
+      action
     }
   });
 }

--- a/packages/umi/test/fixtures/e2e/normal/app.js
+++ b/packages/umi/test/fixtures/e2e/normal/app.js
@@ -1,0 +1,4 @@
+
+export function onRouteChange({location, routes}) {
+  window.g_location_pathname = location.pathname;
+}

--- a/packages/umi/test/normal.e2e.js
+++ b/packages/umi/test/normal.e2e.js
@@ -22,6 +22,10 @@ describe('normal', () => {
     const routes = await page.evaluate(() => window.g_routes);
     expect(routes[0].path).toEqual('/');
 
+    // app.js -> onRouteChange
+    const pathname = await page.evaluate(() => window.g_location_pathname);
+    expect(pathname).toEqual('/');
+
     // global.js
     const text = await page.evaluate(
       () => document.querySelector('h1').innerHTML,


### PR DESCRIPTION

## Usage

app.js

```js
export function onRouteChange({ location, routes, action }) {
  console.log(`current url: ${location.pathname}`);
}
```

## Options

* location：`Object`, history 提供的 location 对象
* routes: `Array`, 路由配置
* action: `PUSH|POP|REPLACE|undefined`，初次加载时为 `undefined`

注：

1. 初次加载时也会执行，但 action 为 `undefined`
