### PR TITLE
fix: route.component could be absolute

### DIFF
--- a/packages/umi-build-dev/src/routes/getRouteConfigFromConfig.js
+++ b/packages/umi-build-dev/src/routes/getRouteConfigFromConfig.js
@@ -86,10 +86,10 @@ function patchRoute(route, pagesPath, parentRoutePath) {
 }
 
 function resolveComponent(pagesPath, component) {
-  const ret = winPath(join(pagesPath, component));
   if (isAbsolute(component)) {
     return winPath(component);
   }
+  const ret = winPath(join(pagesPath, component));
   if (ret.indexOf('./') !== 0) {
     return `./${ret}`;
   }

--- a/packages/umi-build-dev/src/routes/getRouteConfigFromConfig.js
+++ b/packages/umi-build-dev/src/routes/getRouteConfigFromConfig.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { join } from 'path';
+import { join, isAbsolute } from 'path';
 import { cloneDeep } from 'lodash';
 import { winPath, isUrl } from 'umi-utils';
 
@@ -87,6 +87,9 @@ function patchRoute(route, pagesPath, parentRoutePath) {
 
 function resolveComponent(pagesPath, component) {
   const ret = winPath(join(pagesPath, component));
+  if (isAbsolute(component)) {
+    return winPath(component);
+  }
   if (ret.indexOf('./') !== 0) {
     return `./${ret}`;
   }


### PR DESCRIPTION
路由配置里使用组件的绝对路径