### PR TITLE
feat: new option for configuring LocaleProvider for antd-mobile

### DIFF
--- a/docs/plugin/umi-plugin-react.md
+++ b/docs/plugin/umi-plugin-react.md
@@ -108,7 +108,8 @@ options include:
 
 * `default`: 'zh-CN', // default zh-CN
 * `baseNavigator`: true, // default true, when it is true, will use `navigator.language` overwrite default
-* `antd`: true, // use antd, default is true
+* `antd: true`, // config LocaleProvider for antd automatically, default is true
+* `antdMobile: false`, // config LocaleProvider for antd-mobile automatically, default is false
 
 ### library
 

--- a/docs/zh/plugin/umi-plugin-react.md
+++ b/docs/zh/plugin/umi-plugin-react.md
@@ -119,9 +119,10 @@ export default {
 
 配置项包含：
 
-* `default: 'zh-CN'`, // default zh-CN
-* `baseNavigator: true`, // default true, when it is true, will use `navigator.language` overwrite default
-* `antd: true`, // use antd, default is true
+* `default: 'zh-CN'`, // 默认 zh-CN
+* `baseNavigator: true`, // 默认 true，如果设置为true，则umi会用 `navigator.language`替换你设置的default值
+* `antd: true`, // 自动为antd配置LocaleProvider，默认 true
+* `antdMobile: false`, // 自动为antd-mobile配置LocaleProvider，默认 false
 
 ### library
 

--- a/packages/umi-plugin-locale/package.json
+++ b/packages/umi-plugin-locale/package.json
@@ -28,6 +28,7 @@
     "umi"
   ],
   "dependencies": {
+    "antd-mobile": "2.x",
     "globby": "7.1.1",
     "intl": "1.2.5",
     "lodash.groupby": "4.6.0",

--- a/packages/umi-plugin-locale/src/index.js
+++ b/packages/umi-plugin-locale/src/index.js
@@ -15,6 +15,10 @@ const momentLocation = require
   .resolve('moment/locale/zh-cn')
   .replace(/zh\-cn\.js$/, '');
 
+const antdMobileLocation = require
+  .resolve('antd-mobile/lib/locale-provider/en_US')
+  .replace(/en\_US\.js$/, '');
+
 function getMomentLocale(lang, country) {
   if (
     existsSync(
@@ -25,6 +29,17 @@ function getMomentLocale(lang, country) {
   }
   if (existsSync(join(momentLocation, `${lang}.js`))) {
     return lang;
+  }
+  return '';
+}
+
+function getAntdMobileLocale(lang, country) {
+  if (
+    existsSync(
+      join(antdMobileLocation, `${lang}_${country.toLocaleUpperCase()}.js`),
+    )
+  ) {
+    return `${lang}_${country.toLocaleUpperCase()}`;
   }
   return '';
 }
@@ -63,6 +78,7 @@ export function getLocaleFileList(absSrcPath, absPagesPath, singular) {
       country: fileInfo[1],
       paths: groups[name].map(item => winPath(item.path)),
       momentLocale: getMomentLocale(fileInfo[0], fileInfo[1]),
+      antdMobileLocale: getAntdMobileLocale(fileInfo[0], fileInfo[1]),
     };
   });
 }
@@ -133,12 +149,14 @@ export default function(api, options = {}) {
     const wrapperContent = Mustache.render(wrapperTpl, {
       localeList: localeFileList,
       antd: options.antd === undefined ? true : options.antd,
+      antdMobile: options.antdMobile === undefined ? false : options.antdMobile,
       baseNavigator:
         options.baseNavigator === undefined ? true : options.baseNavigator,
       useLocalStorage: true,
       defaultLocale,
       defaultLang: lang,
       defaultAntdLocale: `${lang}_${country}`,
+      defaultAntdMobileLocale: getAntdMobileLocale(lang, country),
       defaultMomentLocale: getMomentLocale(lang, country),
     });
     const wrapperPath = join(paths.absTmpDirPath, './LocaleWrapper.jsx');

--- a/packages/umi-plugin-locale/template/wrapper.jsx.tpl
+++ b/packages/umi-plugin-locale/template/wrapper.jsx.tpl
@@ -35,6 +35,15 @@ let defaultAntd = require('antd/lib/locale-provider/{{defaultAntdLocale}}');
 defaultAntd = defaultAntd.default || defaultAntd;
 {{/antd}}
 
+{{#antdMobile}}
+import { LocaleProvider as LocaleProviderMobile } from 'antd-mobile';
+let defaultAntdMobile = {};
+{{#defaultAntdMobileLocale}}
+defaultAntdMobile = require('antd-mobile/lib/locale-provider/{{defaultAntdMobileLocale}}');
+{{/defaultAntdMobileLocale}}
+defaultAntdMobile = defaultAntdMobile.default || defaultAntdMobile;
+{{/antdMobile}}
+
 const localeInfo = {
   {{#localeList}}
   '{{name}}': {
@@ -43,6 +52,7 @@ const localeInfo = {
     },
     locale: '{{name}}',
     {{#antd}}antd: require('antd/lib/locale-provider/{{lang}}_{{country}}'),{{/antd}}
+    {{#antdMobileLocale}}antdMobile: require('antd-mobile/lib/locale-provider/{{antdMobileLocale}}'),{{/antdMobileLocale}}
     data: require('react-intl/locale-data/{{lang}}'),
     momentLocale: '{{momentLocale}}',
   },
@@ -79,5 +89,10 @@ export default function LocaleWrapper(props) {
     {ret}
   </LocaleProvider>);
   {{/antd}}
+  {{#antdMobile}}
+  ret = (<LocaleProviderMobile locale={appLocale.antdMobile ? (appLocale.antdMobile.default || appLocale.antdMobile) : defaultAntdMobile}>
+    {ret}
+  </LocaleProviderMobile>);
+  {{/antdMobile}}
   return ret;
 }

--- a/packages/umi-plugin-locale/test/index.test.js
+++ b/packages/umi-plugin-locale/test/index.test.js
@@ -46,22 +46,43 @@ describe('test plugin', () => {
   });
 });
 
-test('antd is false', () => {
-  localePlugin(api, {
-    enable: true,
-    antd: false,
-    baseNavigator: false,
+describe('test antd, antdMobile config', () => {
+  test('antd is false', () => {
+    localePlugin(api, {
+      enable: true,
+      antd: false,
+      baseNavigator: false,
+    });
+
+    const ret = readFileSync(wrapperFile, 'utf-8');
+
+    expect(ret).not.toEqual(expect.stringContaining('<LocaleProvider'));
+    expect(ret).toEqual(expect.stringContaining('<IntlProvider'));
+    expect(ret).not.toEqual(
+      expect.stringContaining('antd/lib/locale-provider/zh_CN'),
+    );
+    expect(ret).not.toEqual(expect.stringContaining('moment/locale/zh-cn'));
+    unlinkSync(wrapperFile);
   });
 
-  const ret = readFileSync(wrapperFile, 'utf-8');
+  test('antd is false, antdMobile is true', () => {
+    localePlugin(api, {
+      enable: true,
+      antd: false,
+      antdMobile: true,
+      default: 'en-US',
+      baseNavigator: false,
+    });
 
-  expect(ret).not.toEqual(expect.stringContaining('<LocaleProvider'));
-  expect(ret).toEqual(expect.stringContaining('<IntlProvider'));
-  expect(ret).not.toEqual(
-    expect.stringContaining('antd/lib/locale-provider/zh_CN'),
-  );
-  expect(ret).not.toEqual(expect.stringContaining('moment/locale/zh-cn'));
-  unlinkSync(wrapperFile);
+    const ret = readFileSync(wrapperFile, 'utf-8');
+
+    expect(ret).toEqual(expect.stringContaining('LocaleProviderMobile'));
+    expect(ret).toEqual(expect.stringContaining('<IntlProvider'));
+    expect(ret).toEqual(
+      expect.stringContaining('antd-mobile/lib/locale-provider/en_US'),
+    );
+    unlinkSync(wrapperFile);
+  });
 });
 
 describe('test func with singular true', () => {

--- a/packages/umi-plugin-locale/test/index.test.js
+++ b/packages/umi-plugin-locale/test/index.test.js
@@ -98,6 +98,7 @@ describe('test func with singular true', () => {
           `${absPagesPath}/temp/locale/en-US.js`,
         ],
         momentLocale: '',
+        antdMobileLocale: 'en_US',
       },
       {
         lang: 'zh',
@@ -108,6 +109,7 @@ describe('test func with singular true', () => {
           `${absPagesPath}/temp/locale/zh-CN.js`,
         ],
         momentLocale: 'zh-cn',
+        antdMobileLocale: '',
       },
     ]);
   });


### PR DESCRIPTION
之前只有`locale -> antd: true`的配置，会在`LocaleWrapper.jsx`里生成关于`antd`的`LocaleProvider`配置，但没有关于`antd-mobile`的自动配置。

现在可以通过`locale -> antdMobile: true`，在`LocaleWrapper.jsx`自动生成关于`antd-mobile`的`LocaleProvider`配置，用户就不需要自己在`layout`里做`LocaleProvider`的处理了

效果如下：

```javascript
...
...
import { LocaleProvider as LocaleProviderMobile } from 'antd-mobile';
let defaultAntdMobile = {};
defaultAntdMobile = defaultAntdMobile.default || defaultAntdMobile;

const localeInfo = {
  'en-US': {
    messages: {
      ...require('/Users/admin/test-app/src/locales/en-US.js').default,
    },
    locale: 'en-US',
    antdMobile: require('antd-mobile/lib/locale-provider/en_US'),
    data: require('react-intl/locale-data/en'),
    momentLocale: '',
  },
  'zh-CN': {
    messages: {
      ...require('/Users/admin/test-app/src/locales/zh-CN.js').default,
    },
    locale: 'zh-CN',
    data: require('react-intl/locale-data/zh'),
    momentLocale: 'zh-cn',
  },
};

...
...

export default function LocaleWrapper(props) {
  let ret = props.children;
  ret = (<IntlProvider locale={appLocale.locale} messages={appLocale.messages}>
    <InjectedWrapper>{ret}</InjectedWrapper>
  </IntlProvider>)
  ret = (<LocaleProviderMobile locale={appLocale.antdMobile ? (appLocale.antdMobile.default || appLocale.antdMobile) : defaultAntdMobile}>
    {ret}
  </LocaleProviderMobile>);
  return ret;
}
```