### PR TITLE
fix: missing prompt.d.ts in package files

### DIFF
--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -49,6 +49,7 @@
     "dynamic.d.ts",
     "link.d.ts",
     "navlink.d.ts",
+    "prompt.d.ts",
     "redirect.d.ts",
     "router.d.ts",
     "withRouter.d.ts"


### PR DESCRIPTION
missing prompt.d.ts in umi package