### PR TITLE
feat: The official mirror source is used by everyone

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,2 @@
+# Using an official mirror source
+registry "https://registry.yarnpkg.com"


### PR DESCRIPTION
新增功能原因：

因为本机设置了全局的 `npm` 镜像源，导致安装新的依赖包时 yarn.lock 来源(`resolved`)不一致。

```shell
npm config set registry https://registry.npm.taobao.org 
```