### PR TITLE
路由地址为绝对地址时按需加载对应的页面 model

### DIFF
--- a/packages/umi-plugin-dva/src/index.js
+++ b/packages/umi-plugin-dva/src/index.js
@@ -202,7 +202,16 @@ _dvaDynamic({
   ${loadingOpts}
 })
       `.trim();
-      const models = getPageModels(join(paths.absTmpDirPath, importPath), api);
+       
+      let models;
+      if (_path.isAbsolute(importPath)) {
+        // 按需加载 node_modules 下面依赖包页面 model
+        // importPath 为绝对路径时，单独处理获取 model 绝对路径
+        models = [_path.resolve(importPath, '../model.js')];
+      } else {
+        models = getPageModels((0, _path.join)(paths.absTmpDirPath, importPath), api);
+      }
+      
       if (models && models.length) {
         ret = ret.replace(
           '<%= MODELS %>',


### PR DESCRIPTION
路由地址为绝对地址时按需加载对应的页面 model，其中一个应用场景是引用 `node_modules` 下依赖包(也是个umi工程)里面的页面，此时希望可以对 model 做按需加载。

页面绝对路径: `/Users/xxx/Documents/tmp/umi-model-demo/node_modules/umi-user-demo/lib/pages/priv/index.js`

对应的页面 model 路径为：`/Users/xxx/Documents/tmp/umi-model-demo/node_modules/umi-user-demo/lib/pages/priv/model.js`