### PR TITLE
fix #1925 babel alias: use @ as project root dir

### DIFF
--- a/packages/af-webpack/package.json
+++ b/packages/af-webpack/package.json
@@ -17,6 +17,7 @@
     "autoprefixer": "9.4.5",
     "babel-loader": "8.0.4",
     "babel-plugin-dynamic-import-node": "2.2.0",
+    "babel-plugin-module-resolver": "^3.1.3",
     "babel-plugin-named-asset-import": "0.2.3",
     "babel-preset-umi": "1.3.1",
     "chalk": "2.4.1",

--- a/packages/af-webpack/src/registerBabel.js
+++ b/packages/af-webpack/src/registerBabel.js
@@ -1,5 +1,17 @@
 export default function registerBabel(opts = {}) {
   const { only, ignore, babelPreset, disablePreventTest } = opts;
+  const plugins = [
+    [
+      require.resolve('babel-plugin-module-resolver'),
+      {
+        root: process.cwd(),
+        alias: {
+          '@': '.',
+        },
+      },
+    ],
+  ];
+
   if (disablePreventTest || process.env.NODE_ENV !== 'test') {
     require('@babel/register')({
       presets: [babelPreset],
@@ -7,6 +19,7 @@ export default function registerBabel(opts = {}) {
       ignore,
       babelrc: false,
       cache: false,
+      plugins: plugins,
     });
   }
 }

--- a/packages/af-webpack/test/registerBabel.test.js
+++ b/packages/af-webpack/test/registerBabel.test.js
@@ -1,0 +1,12 @@
+import registerBabel from '../src/registerBabel';
+import { transform } from '@babel/core';
+
+test('build', () => {
+  registerBabel({});
+  const source = './fix1.js';
+  const code = `import something from "${source}";`;
+  const result = transform(code, {});
+  // console.log(code)
+  // console.dir(result)
+  expect(result.options.root != undefined).toBe(true);
+});


### PR DESCRIPTION
usage

```
const pkg = require('@/package.json')
export default {
  'GET /api/users': {
    users: [1, 2],
    pkg: pkg}
};
```