### PR TITLE
fix: 配置式路由为绝对路径时按需加载页面 Model

### DIFF
--- a/packages/umi-plugin-dva/src/index.js
+++ b/packages/umi-plugin-dva/src/index.js
@@ -42,6 +42,12 @@ function getModelsWithRoutes(routes, api) {
 }
 
 function getPageModels(cwd, api) {
+  // 配置式路由为绝对路径时按需加载页面 Model
+  const { paths } = api;
+  if (!isAbsolute(cwd)) {
+    cwd = join(paths.absTmpDirPath, cwd);
+  }
+  
   let models = [];
   while (!isSrcPath(cwd, api) && !isRoot(cwd)) {
     models = models.concat(getModel(cwd, api));
@@ -203,14 +209,7 @@ _dvaDynamic({
 })
       `.trim();
       
-      let models = [];
-      // 配置式路由为绝对路径时按需加载页面 Model
-      if (isAbsolute(importPath)) {
-        const modelPath = findJS(dirname(importPath), 'model');
-        if (modelPath) models = [modelPath];
-      } else {
-        models = getPageModels(join(paths.absTmpDirPath, importPath), api);
-      }
+      const models = getPageModels(join(importPath), api);
       
       if (models && models.length) {
         ret = ret.replace(

--- a/packages/umi-plugin-dva/src/index.js
+++ b/packages/umi-plugin-dva/src/index.js
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { join, dirname, basename, extname } from 'path';
+import { join, dirname, basename, extname, isAbsolute } from 'path';
 import globby from 'globby';
 import uniq from 'lodash.uniq';
 import isRoot from 'path-is-root';
@@ -202,7 +202,16 @@ _dvaDynamic({
   ${loadingOpts}
 })
       `.trim();
-      const models = getPageModels(join(paths.absTmpDirPath, importPath), api);
+      
+      let models = [];
+      // 配置式路由为绝对路径时按需加载页面 Model
+      if (isAbsolute(importPath)) {
+        const modelPath = findJS(dirname(importPath), 'model');
+        if (modelPath) models = [modelPath];
+      } else {
+        models = getPageModels(join(paths.absTmpDirPath, importPath), api);
+      }
+      
       if (models && models.length) {
         ret = ret.replace(
           '<%= MODELS %>',


### PR DESCRIPTION
目前配置式路由写成绝对路径，页面可以出来，但是需要手动注册 model（window.g_app.model() 手动注册的 model 为全局 model，不能按需加载），很麻烦，改成路由为绝对路径时按需注册页面 Model。

```
// .umirc.js

routes: [
  // component 属性写成相对路径时可以按需加载 model，写成绝对路径目前无法按需加载 model
  // 希望写成绝对路径也能按需加载 model
  { 
    path: '/user', 
    component: path.join(process.cwd(), 'src/pages/user/index.js'),
  },
]
```