### PR TITLE
feat: support config mock.exclude

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -225,7 +225,7 @@ If set to `true`, enable the directory for singular mode.
 
 ### mock.exclude <Badge text="2.4.5+"/>
 
-- Type: `Array`
+- Type: `Array` of `String`
 - Default: `[]`
 
 Exclude files that are not mock files in the `mock` directory.

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -223,6 +223,26 @@ If set to `true`, enable the directory for singular mode.
 * src/page
 * model (if umi-plugin-dva plugin is enabled)
 
+### mock.exclude <Badge text="2.4.5+"/>
+
+- Type: `Array`
+- Default: `[]`
+
+Exclude files that are not mock files in the `mock` directory.
+
+e.g. exclue all files and directorys starts with `_`,
+
+```js
+export default {
+  mock: {
+    exclude: [
+      'mock/**/_*.js',
+      'mock/_*/**/*.js',
+    ],
+  }
+}
+```
+
 ## webpack
 
 ### chainWebpack

--- a/docs/zh/config/README.md
+++ b/docs/zh/config/README.md
@@ -223,7 +223,7 @@ export default {
 
 ### mock.exclude <Badge text="2.4.5+"/>
 
-* 类型：`Array`
+* 类型：`Array` of `String`
 * 默认值：`[]`
 
 排除 mock 目录下不作 mock 处理的文件。

--- a/docs/zh/config/README.md
+++ b/docs/zh/config/README.md
@@ -221,6 +221,26 @@ export default {
 * src/page
 * model（如果有开启 umi-plugin-dva 插件的话）
 
+### mock.exclude <Badge text="2.4.5+"/>
+
+* 类型：`Array`
+* 默认值：`[]`
+
+排除 mock 目录下不作 mock 处理的文件。
+
+比如要 exclude 所有 `_` 前缀的文件和文件夹，
+
+```js
+export default {
+  mock: {
+    exclude: [
+      'mock/**/_*.js',
+      'mock/_*/**/*.js',
+    ],
+  }
+}
+```
+
 ## webpack
 
 ### chainWebpack

--- a/packages/umi-build-dev/src/plugins/mock/createMockMiddleware.js
+++ b/packages/umi-build-dev/src/plugins/mock/createMockMiddleware.js
@@ -53,10 +53,11 @@ export default function getMockMiddleware(api, errors) {
       ret = require(absConfigPath); // eslint-disable-line
     } else {
       const mockFiles = glob
-        .sync('**/*.js', {
-          cwd: absMockPath,
+        .sync('mock/**/*.js', {
+          cwd,
+          ignore: (api.config.mock || {}).exclude || [],
         })
-        .map(p => join(absMockPath, p))
+        .map(p => join(cwd, p))
         .concat(
           glob
             .sync('**/_mock.js', {

--- a/packages/umi-build-dev/src/plugins/mock/index.js
+++ b/packages/umi-build-dev/src/plugins/mock/index.js
@@ -1,8 +1,27 @@
 import signale from 'signale';
+import { isPlainObject } from 'lodash';
+import assert from 'assert';
 import createMockMiddleware from './createMockMiddleware';
 
 export default function(api) {
   let errors = [];
+
+  api._registerConfig(() => {
+    return api => {
+      return {
+        name: 'mock',
+        validate(val) {
+          assert(
+            isPlainObject(val),
+            `Configure item mock should be Plain Object, but got ${val}.`,
+          );
+        },
+        onChange() {
+          api.service.restart(/* why */ 'Config mock Changed');
+        },
+      };
+    };
+  });
 
   api._beforeServerWithApp(({ app }) => {
     if (process.env.MOCK !== 'none' && process.env.HTTP_MOCK !== 'none') {


### PR DESCRIPTION
比如要忽略 mock 下的所有 `_` 前缀的文件和文件夹，可以这么配：

```js
export default {
  mock: {
    exclude: [
      'mock/**/_*.js',
      'mock/_*/**/*.js'
    ],
  }
}
```