### PR TITLE
 fix: manifest fileName

### DIFF
--- a/docs/zh/config/README.md
+++ b/docs/zh/config/README.md
@@ -395,7 +395,7 @@ export default {
 
 ### manifest
 
-配置后会生成 manifest.json，option 传给 [https://www.npmjs.com/package/webpack-manifest-plugin](https://www.npmjs.com/package/webpack-manifest-plugin)。
+配置后会生成 asset-manifest.json，option 传给 [https://www.npmjs.com/package/webpack-manifest-plugin](https://www.npmjs.com/package/webpack-manifest-plugin)。
 比如：
 
 ```markup


### PR DESCRIPTION
The default fileName of manifest option is `asset-manifest.json`(check `af-webpack/lib/getConfig/prod.js`:51),
different with webpack-manifest-plugin's default `manifest.json`(check https://github.com/danethurber/webpack-manifest-plugin/blob/1.x/README.md).