### PR TITLE
fix: manifest fileName

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -395,7 +395,7 @@ Configure options for [node-sass](https://github.com/sass/node-sass#options). No
 
 ### manifest
 
-After configuration, manifest.json will be generated and the option will be passed to [https://www.npmjs.com/package/webpack-manifest-plugin](https://www.npmjs.com/package/webpack-manifest-plugin).
+After configuration, asset-manifest.json will be generated and the option will be passed to [https://www.npmjs.com/package/webpack-manifest-plugin](https://www.npmjs.com/package/webpack-manifest-plugin).
 such as:
 
 ```markup


### PR DESCRIPTION
The default fileName of manifest option is `asset-manifest.json`(check `af-webpack/lib/getConfig/prod.js`:51),
different with webpack-manifest-plugin's default `manifest.json`(check https://github.com/danethurber/webpack-manifest-plugin/blob/1.x/README.md).