### PR TITLE
fix: `xsel` crashes in debian/ubuntu server

### DIFF
--- a/packages/umi-serve/bin/umi-serve.js
+++ b/packages/umi-serve/bin/umi-serve.js
@@ -62,7 +62,9 @@ app.listen(port, () => {
     '',
     `${chalk.grey('Copied local address to clipboard!')}`,
   ];
-  clipboardy.writeSync(localAddress);
+  if (process.platform !== `linux` || process.env.DISPLAY) {
+    clipboardy.writeSync(localAddress);
+  }
   console.log(boxen(message.join('\n'), {
     padding: 1,
     borderColor: 'green',


### PR DESCRIPTION
修复 Linux 环境下剪切板崩溃问题， Linux 图形界面可以通过设置环境变量 `process.env.DISPLAY` 开启。

```bash
/usr/local/share/.config/yarn/global/node_modules/clipboardy/lib/linux.js:10
        throw err;
        ^
Error: xsel: Can't open display: (null)
: Inappropriate ioctl for device
```