### PR TITLE
fix: 修复 CheerioSelector 类型丢失 & 为 IRoute 添加 `redirect` 类型路由

### DIFF
--- a/packages/umi-types/config.d.ts
+++ b/packages/umi-types/config.d.ts
@@ -3,13 +3,19 @@ import { ExternalsElement, Condition } from 'webpack';
 
 export type IPlugin<T = any> = string | [string, T];
 
-export interface IRoute {
-  path: string;
-  component: string;
-  routes?: IRoute[];
-  Routes?: string[];
-  [key: string]: any;
-}
+export type IRoute =
+  | {
+      path: string;
+      component: string;
+      routes?: IRoute[];
+      Routes?: string[];
+      [key: string]: any;
+    }
+  | {
+      path: string;
+      redirect: string;
+      [key: string]: any;
+    };
 
 export interface IExportStaticOpts {
   htmlSuffix?: boolean;

--- a/packages/umi-types/config.d.ts
+++ b/packages/umi-types/config.d.ts
@@ -9,11 +9,13 @@ export type IRoute =
       component: string;
       routes?: IRoute[];
       Routes?: string[];
+      redirect?: never;
       [key: string]: any;
     }
   | {
       path: string;
       redirect: string;
+      component?: never;
       [key: string]: any;
     };
 

--- a/packages/umi-types/index.d.ts
+++ b/packages/umi-types/index.d.ts
@@ -1,3 +1,4 @@
+import 'cheerio';
 import IConfig, { IPlugin, IAFWebpackConfig, IRoute } from './config';
 import { Stats, Configuration } from 'webpack';
 
@@ -255,22 +256,6 @@ export interface IAdd<T = any, U = any> {
 
 interface IGetChunkPath {
   (fileName: string): string | null;
-}
-
-interface CheerioStatic extends CheerioSelector {
-  // @types/cheerio/index.d.ts
-  xml(): string;
-  root(): Cheerio;
-  contains(container: CheerioElement, contained: CheerioElement): boolean;
-  parseHTML(
-    data: string,
-    context?: Document,
-    keepScripts?: boolean
-  ): Document[];
-  html(options?: CheerioOptionsInterface): string;
-  html(selector: string, options?: CheerioOptionsInterface): string;
-  html(element: Cheerio, options?: CheerioOptionsInterface): string;
-  html(element: CheerioElement, options?: CheerioOptionsInterface): string;
 }
 
 interface IModifyHTMLWithASTArgs {


### PR DESCRIPTION
```diff
- export interface IRoute {
-   path: string;
-   component: string;
-   routes?: IRoute[];
-   Routes?: string[];
-   [key: string]: any;
- }
+ export type IRoute =
+   | {
+       path: string;
+       component: string;
+       routes?: IRoute[];
+       Routes?: string[];
+       redirect?: never;
+       [key: string]: any;
+     }
+   | {
+       path: string;
+       redirect: string;
+       component?: never;
+       [key: string]: any;
+     };
```