### PR TITLE
修复runtimePublicPath不生效

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -128,7 +128,7 @@ Specifies the publicPath of the webpack, pointing to the path where the static r
 * Type: `Boolean`
 * Default: `false`
 
-Use the `window.publicPath` specified in the HTML when the value is `true`.
+Use the `window.resourceBaseUrl` specified in the HTML when the value is `true`.
 
 ### cssPublicPath <Badge text="2.2.5+"/>
 

--- a/docs/guide/deploy.md
+++ b/docs/guide/deploy.md
@@ -80,7 +80,7 @@ Then output in html:
 
 ```html
 <script>
-window.publicPath = <%= YOUR_PUBLIC_PATH %>
+window.resourceBaseUrl = <%= YOUR_PUBLIC_PATH %>
 </script>
 ```
 

--- a/docs/zh/config/README.md
+++ b/docs/zh/config/README.md
@@ -128,7 +128,7 @@ export default {
 * 类型：`Boolean`
 * 默认值：`false`
 
-值为 `true` 时使用 HTML 里指定的 `window.publicPath`。
+值为 `true` 时使用 HTML 里指定的 `window.resourceBaseUrl`。
 
 ### cssPublicPath <Badge text="2.2.5+"/>
 

--- a/docs/zh/guide/deploy.md
+++ b/docs/zh/guide/deploy.md
@@ -80,7 +80,7 @@ export default {
 
 ```html
 <script>
-window.publicPath = <%= YOUR PUBLIC_PATH %>
+window.resourceBaseUrl = <%= YOUR PUBLIC_PATH %>
 </script>
 ```
 


### PR DESCRIPTION
开启`runtimePublicPath`并在HTML模版设置`window.publicPath`后编译发现umi仍会插入`publicPath`覆盖了我的设置。阅读源码后发现这里是不是应该是设置`window.resourceBaseUrl`？