### PR TITLE
fix: umi test don't work if have console.log

### DIFF
--- a/packages/umi-build-dev/src/plugins/commands/test.js
+++ b/packages/umi-build-dev/src/plugins/commands/test.js
@@ -35,7 +35,6 @@ export default function(api) {
       if (args.w) args.watch = args.w;
       require('umi-test')
         .default({
-          cwd: api.cwd,
           moduleNameMapper,
           ...args,
         })


### PR DESCRIPTION
Related: https://github.com/facebook/jest/issues/7857
