### PR TITLE
feat: add htm suffix

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -203,6 +203,13 @@ such as:
 
 Enable the `.html` suffix.
 
+### exportStatic.htmSuffix
+
+* Type: `Boolean`
+* Default: `false`
+
+Enable the `.htm` suffix.
+
 ### exportStatic.dynamicRoot
 
 * Type: `Boolean`
@@ -253,7 +260,7 @@ such as:
 chainWebpack(config, { webpack }) {
   // Set alias
   config.resolve.alias.set('a', 'path/to/a');
-  
+
   // Delete progress bar plugin
   config.plugins.delete('progress');
 }

--- a/docs/zh/config/README.md
+++ b/docs/zh/config/README.md
@@ -203,6 +203,13 @@ export default {
 
 启用 `.html` 后缀。
 
+### exportStatic.htmSuffix
+
+* 类型：`Boolean`
+* 默认值：`false`
+
+启用 `.htm` 后缀。
+
 ### exportStatic.dynamicRoot
 
 * 类型：`Boolean`
@@ -253,7 +260,7 @@ export default {
 chainWebpack(config, { webpack }) {
   // 设置 alias
   config.resolve.alias.set('a', 'path/to/a');
-  
+
   // 删除进度条插件
   config.plugins.delete('progress');
 }
@@ -410,7 +417,7 @@ export default {
 
 ### lessLoaderOptions
 
-给 [less-loader](https://github.com/webpack-contrib/less-loader) 的额外配置项。 
+给 [less-loader](https://github.com/webpack-contrib/less-loader) 的额外配置项。
 
 ### cssLoaderOptions
 

--- a/packages/umi-build-dev/src/routes/patchRoutes.js
+++ b/packages/umi-build-dev/src/routes/patchRoutes.js
@@ -62,8 +62,13 @@ function patchRoute(route, config, isProduction, onPatchRoute) {
   }
 
   // /path -> /path.html
-  if (route.path && config.exportStatic && config.exportStatic.htmlSuffix) {
-    route.path = addHtmlSuffix(route.path, !!route.routes);
+  if (route.path && config.exportStatic) {
+    if (config.exportStatic.htmSuffix) {
+      route.path = addHtmlSuffix(route.path, !!route.routes, 'htm');
+    }
+    if (config.exportStatic.htmlSuffix) {
+      route.path = addHtmlSuffix(route.path, !!route.routes, 'html');
+    }
   }
 
   // 权限路由
@@ -89,11 +94,11 @@ function patchRoute(route, config, isProduction, onPatchRoute) {
   }
 }
 
-function addHtmlSuffix(path, hasRoutes) {
+function addHtmlSuffix(path, hasRoutes, suffix = 'html') {
   if (path === '/') return path;
   if (hasRoutes) {
-    return path.endsWith('/') ? path : `${path}(.html)?`;
+    return path.endsWith('/') ? path : `${path}(.${suffix})?`;
   } else {
-    return path.endsWith('/') ? `${path.slice(0, -1)}.html` : `${path}.html`;
+    return path.endsWith('/') ? `${path.slice(0, -1)}.${suffix}` : `${path}.${suffix}`;
   }
 }


### PR DESCRIPTION
支持 `.htm` 访问，

有两个问题是：
- [ ] `htmlSuffix` 和 `htmSuffix` build 出来的 html，会多一个 `*(.htm)`

![image](https://user-images.githubusercontent.com/13595509/53465915-bf3f3800-3a8a-11e9-9c43-826530836dc8.png)

- [ ] `htmSuffix` 支持 `.htm` 后，访问 `/about` 默认 redirect 到 `/about.html`，需要在配置里手动 `redirect`。


也可以这样处理：


```jsx
export default [
  {
    path: '/(index.html|index.htm)?',
    component: '../layout',
    indexRoute: { component: 'Home' },
    childRoutes: [
      {
        path: '/about(.html|.htm)?',
        indexRoute: { component: 'About' },
        childRoutes: [{
          path: 'history(.html|.htm)?',
          component: 'About/History'
        }],
      },
    ],
  },
];

```