### PR TITLE
feat: allow the interface to be extended from IRoute

### DIFF
--- a/packages/umi-types/config.d.ts
+++ b/packages/umi-types/config.d.ts
@@ -3,21 +3,14 @@ import { ExternalsElement, Condition } from 'webpack';
 
 export type IPlugin<T = any> = string | [string, T];
 
-export type IRoute =
-  | {
-      path: string;
-      component: string;
-      routes?: IRoute[];
-      Routes?: string[];
-      redirect?: never;
-      [key: string]: any;
-    }
-  | {
-      path: string;
-      redirect: string;
-      component?: never;
-      [key: string]: any;
-    };
+export interface IRoute {
+  path?: string;
+  component?: string;
+  routes?: IRoute[];
+  Routes?: string[];
+  redirect?: string;
+  [key: string]: any;
+}
 
 export interface IExportStaticOpts {
   htmlSuffix?: boolean;


### PR DESCRIPTION
上次的修复虽然允许在 route 中添加其他字段，但使用了 type 导致无法拓展接口，例如 Ant Design Pro 的路由结构：
```ts
import { IRoute } from 'umi-types';
interface MyRoute extends IRoute {
  icon?: string;
  name?: string;
}
```