### PR TITLE
fix: Fixed bugs in the build script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "bootstrap": "lerna bootstrap",
-    "build": "./scripts/build.js",
+    "build": "node ./scripts/build.js",
     "changelog": "lerna-changelog",
     "chore:update-deps": "./scripts/update_deps.sh",
     "test": "node scripts/test.js",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -6,7 +6,7 @@ const { join } = require('path');
 function runUmiTools(...args) {
   console.log(['>> umi-tools', ...args].join(' '));
   return fork(
-    join(process.cwd(), 'node_modules/.bin/umi-tools'),
+    join(process.cwd(), 'node_modules/umi-tools/cli.js'),
     [...args].concat(process.argv.slice(2)),
     {
       stdio: 'inherit',


### PR DESCRIPTION
When I use `npm run build` in widowns git bash, I meet some error and fixed it.
Error exmaple: 

```bash
$ npm run build

> @ build D:\github\umi
> ./scripts/build.js

'.' 不是内部或外部命令，也不是可运行的程序
或批处理文件。

$ npm run build

> @ build D:\github\umi
> node ./scripts/build.js

>> umi-tools build
D:\github\umi\node_modules\.bin\umi-tools:2
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^

SyntaxError: missing ) after argument list

$ node -v
v10.15.1
```

The first parameter of `child_process.fork(modulePath[, args][, options])` should be `modulePath`.
See [Child Process | Node.js v11.10.1 Documentation](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options)