### PR TITLE
ts: add _modifyHelpInfo definition && fix IModify and IAdd definition

### DIFF
--- a/packages/umi-types/index.d.ts
+++ b/packages/umi-types/index.d.ts
@@ -279,7 +279,7 @@ export interface IModifyFunc<T, U> {
   (memo: T, args: U): T | T;
 }
 
-export interface IModify<T, U = any> {
+export interface IModify<T, U = {}> {
   (fn: IModifyFunc<T, U> | T): void;
 }
 
@@ -290,7 +290,7 @@ export interface IAddFunc<T, U> {
   (memo: T[], args: U): T | T[];
 }
 
-export interface IAdd<T, U = any> {
+export interface IAdd<T, U = {}> {
   (fn: IAddFunc<T, U> | T | T[]): void;
 }
 

--- a/packages/umi-types/index.d.ts
+++ b/packages/umi-types/index.d.ts
@@ -272,14 +272,14 @@ interface IChangeWebpackConfig {
   (webpackConfig: object): object;
 }
 
-export interface IModifyFunc<T = any, U = any> {
+export interface IModifyFunc<T, U = any> {
   /**
    * https://umijs.org/plugin/develop.html#registermethod
    */
-  (memo: T | undefined, args?: U): T | any;
+  (memo: T, args?: U): T | T;
 }
 
-export interface IModify<T = any, U = any> {
+export interface IModify<T, U = any> {
   (fn: IModifyFunc<T, U> | T): void;
 }
 
@@ -287,7 +287,7 @@ export interface IAddFunc<T = any, U = any> {
   /**
    * https://umijs.org/plugin/develop.html#registermethod
    */
-  (memo: T[] | undefined, args?: U): T | T[];
+  (memo: T[], args?: U): T | T[];
 }
 
 export interface IAdd<T = any, U = any> {

--- a/packages/umi-types/index.d.ts
+++ b/packages/umi-types/index.d.ts
@@ -132,6 +132,20 @@ interface IModifyCommand {
   (fn: IModifyCommandFunc): void;
 }
 
+export interface IModifyHelpInfoOpts {
+  scriptName: string;
+  commands: {
+    [commandName: string]: {
+      opts: {
+        hide: boolean;
+        options: {
+          [key: string]: string;
+        };
+      };
+    };
+  };
+}
+
 /**
  * Tool class API
  * https://umijs.org/plugin/develop.html#tool-class-api
@@ -377,6 +391,7 @@ export interface IApi {
   registerCommand: IRegisterCommand;
   _registerConfig: IRegisterConfig;
   _modifyCommand: IModifyCommand;
+  _modifyHelpInfo: IModify<IModifyHelpInfoOpts>;
 
   /**
    * Tool class API

--- a/packages/umi-types/index.d.ts
+++ b/packages/umi-types/index.d.ts
@@ -272,25 +272,25 @@ interface IChangeWebpackConfig {
   (webpackConfig: object): object;
 }
 
-export interface IModifyFunc<T, U = any> {
+export interface IModifyFunc<T, U> {
   /**
    * https://umijs.org/plugin/develop.html#registermethod
    */
-  (memo: T, args?: U): T | T;
+  (memo: T, args: U): T | T;
 }
 
 export interface IModify<T, U = any> {
   (fn: IModifyFunc<T, U> | T): void;
 }
 
-export interface IAddFunc<T = any, U = any> {
+export interface IAddFunc<T, U> {
   /**
    * https://umijs.org/plugin/develop.html#registermethod
    */
-  (memo: T[], args?: U): T | T[];
+  (memo: T[], args: U): T | T[];
 }
 
-export interface IAdd<T = any, U = any> {
+export interface IAdd<T, U = any> {
   (fn: IAddFunc<T, U> | T | T[]): void;
 }
 
@@ -350,6 +350,10 @@ export interface IBlockDependencies {
   lacks: [string, string][];
   devConflicts: [string, string, string][];
   devLacks: [string, string][];
+}
+
+export interface IMiddlewareFunction {
+  (req: any, res: any, next: any): void;
 }
 
 export interface IApi {
@@ -462,10 +466,10 @@ export interface IApi {
   modifyWebpackConfig: IModify<Configuration>;
   modifyAFWebpackOpts: IModify<IAFWebpackConfig>;
   chainWebpackConfig: IChangeWebpackConfig;
-  addMiddleware: IAdd;
-  addMiddlewareAhead: IAdd;
-  addMiddlewareBeforeMock: IAdd;
-  addMiddlewareAfterMock: IAdd;
+  addMiddleware: IAdd<IMiddlewareFunction>;
+  addMiddlewareAhead: IAdd<IMiddlewareFunction>;
+  addMiddlewareBeforeMock: IAdd<IMiddlewareFunction>;
+  addMiddlewareAfterMock: IAdd<IMiddlewareFunction>;
   addVersionInfo: IAdd<string>;
   addRuntimePlugin: IAdd<string>;
   addRuntimePluginKey: IAdd<string>;


### PR DESCRIPTION
##### Checklist

- [x] commit message follows commit guidelines


##### Description of change

ts: add _modifyHelpInfo definition

另外修正了 IModify 和 IAdd 的定义，主要对应 umi API 的如下规则：
- modifyXxx 第一个参数必定存在，返回也必须要返回（有的可以返回 undefined 的也应该是通过 `IModify<Xxx | undefined>` 来指定，不应该默认给 IModify 都加上 undefined）。
- 第二个参数 args 也必定存在（umi 中的代码逻辑是至少是 `{}`），不需要加 `?`（不然会导致插件中需要多一次判断）
