### PR TITLE
feat: add umi router types

### DIFF
--- a/packages/umi/index.d.ts
+++ b/packages/umi/index.d.ts
@@ -1,5 +1,3 @@
-import { withRouter, RouteComponentProps, RouteProps, match } from 'react-router-dom';
-
 export { default as Link } from './link';
 export { default as NavLink } from './navlink';
 export { default as Redirect } from './redirect';
@@ -8,14 +6,4 @@ export { default as dynamic } from './dynamic';
 export { default as router } from './router';
 export { default as withRouter } from './withRouter';
 
-type IncludeRoute = 'component' | 'exact' | 'path';
-
-interface RouteType extends Pick<RouteProps, IncludeRoute> {
-  _title?: string;
-  _title_default?: string;
-}
-
-export interface RouterTypes extends RouteComponentProps {
-  computedMatch?: match;
-  route?: RouteType;
-}
+export { default as RouterTypes } from './routerTypes';

--- a/packages/umi/index.d.ts
+++ b/packages/umi/index.d.ts
@@ -1,7 +1,21 @@
-export {default as Link} from './link';
-export {default as NavLink} from './navlink';
-export {default as Redirect} from './redirect';
+import { withRouter, RouteComponentProps, RouteProps, match } from 'react-router-dom';
 
-export {default as dynamic} from './dynamic';
-export {default as router} from './router';
-export {default as withRouter} from './withRouter';
+export { default as Link } from './link';
+export { default as NavLink } from './navlink';
+export { default as Redirect } from './redirect';
+
+export { default as dynamic } from './dynamic';
+export { default as router } from './router';
+export { default as withRouter } from './withRouter';
+
+type IncludeRoute = 'component' | 'exact' | 'path';
+
+interface RouteType extends Pick<RouteProps, IncludeRoute> {
+  _title?: string;
+  _title_default?: string;
+}
+
+export interface RouterTypes extends RouteComponentProps {
+  computedMatch?: match;
+  route?: RouteType;
+}

--- a/packages/umi/index.d.ts
+++ b/packages/umi/index.d.ts
@@ -1,9 +1,9 @@
-export { default as Link } from './link';
-export { default as NavLink } from './navlink';
-export { default as Redirect } from './redirect';
+export {default as Link} from './link';
+export {default as NavLink} from './navlink';
+export {default as Redirect} from './redirect';
 
-export { default as dynamic } from './dynamic';
-export { default as router } from './router';
-export { default as withRouter } from './withRouter';
+export {default as dynamic} from './dynamic';
+export {default as router} from './router';
+export {default as withRouter} from './withRouter';
 
-export { default as RouterTypes } from './routerTypes';
+export {default as RouterTypes} from './routerTypes';

--- a/packages/umi/routerTypes.d.ts
+++ b/packages/umi/routerTypes.d.ts
@@ -4,7 +4,7 @@ type IncludeRoute = 'component' | 'exact' | 'path';
 
 type RouteType = Pick<RouteProps, IncludeRoute>;
 
-export default interface RouterTypes extends RouteComponentProps {
+export default interface RouterTypes<T extends Object = {}> extends RouteComponentProps {
   computedMatch?: match;
-  route?: Pick<RouteProps, IncludeRoute>;
+  route?: RouteType & T;
 }

--- a/packages/umi/routerTypes.d.ts
+++ b/packages/umi/routerTypes.d.ts
@@ -1,4 +1,4 @@
-import { withRouter, RouteComponentProps, RouteProps, match } from 'react-router-dom';
+import { RouteComponentProps, RouteProps, match } from 'react-router-dom';
 
 type IncludeRoute = 'component' | 'exact' | 'path';
 

--- a/packages/umi/routerTypes.d.ts
+++ b/packages/umi/routerTypes.d.ts
@@ -2,12 +2,9 @@ import { RouteComponentProps, RouteProps, match } from 'react-router-dom';
 
 type IncludeRoute = 'component' | 'exact' | 'path';
 
-interface RouteType extends Pick<RouteProps, IncludeRoute> {
-  _title?: string;
-  _title_default?: string;
-}
+type RouteType = Pick<RouteProps, IncludeRoute>;
 
-export interface RouterTypes extends RouteComponentProps {
+export default interface RouterTypes extends RouteComponentProps {
   computedMatch?: match;
-  route?: RouteType;
+  route?: Pick<RouteProps, IncludeRoute>;
 }

--- a/packages/umi/routerTypes.d.ts
+++ b/packages/umi/routerTypes.d.ts
@@ -1,0 +1,13 @@
+import { withRouter, RouteComponentProps, RouteProps, match } from 'react-router-dom';
+
+type IncludeRoute = 'component' | 'exact' | 'path';
+
+interface RouteType extends Pick<RouteProps, IncludeRoute> {
+  _title?: string;
+  _title_default?: string;
+}
+
+export interface RouterTypes extends RouteComponentProps {
+  computedMatch?: match;
+  route?: RouteType;
+}

--- a/packages/umi/routerTypes.d.ts
+++ b/packages/umi/routerTypes.d.ts
@@ -1,10 +1,10 @@
-import { RouteComponentProps, RouteProps, match } from 'react-router-dom';
+import { RouteComponentProps as BasicRouteProps, RouteProps, match } from 'react-router-dom';
 
 type IncludeRoute = 'component' | 'exact' | 'path';
 
 type RouteType = Pick<RouteProps, IncludeRoute>;
 
-export default interface RouterTypes<T extends Object = {}> extends RouteComponentProps {
+export default interface RouterTypes<T extends Object = {}> extends BasicRouteProps {
   computedMatch?: match;
   route?: RouteType & T;
 }

--- a/packages/umi/withRouter.d.ts
+++ b/packages/umi/withRouter.d.ts
@@ -1,6 +1,8 @@
 import { withRouter, RouteComponentProps, RouteProps, match } from 'react-router-dom';
 
-interface RouteType extends Pick<RouteProps, 'component' | 'exact' | 'path'> {
+type ExcludeRoute = 'component' | 'exact' | 'path';
+
+interface RouteType extends Pick<RouteProps, ExcludeRoute> {
   _title?: string;
   _title_default?: string;
 }

--- a/packages/umi/withRouter.d.ts
+++ b/packages/umi/withRouter.d.ts
@@ -1,3 +1,2 @@
 import { withRouter } from 'react-router-dom';
-
 export default withRouter;

--- a/packages/umi/withRouter.d.ts
+++ b/packages/umi/withRouter.d.ts
@@ -1,13 +1,13 @@
 import { withRouter, RouteComponentProps, RouteProps, match } from 'react-router-dom';
 
-interface RouteTypes extends Pick<RouteProps, 'component' | 'exact' | 'path'> {
+interface RouteType extends Pick<RouteProps, 'component' | 'exact' | 'path'> {
   _title?: string;
   _title_default?: string;
 }
 
 export interface RouterTypes extends RouteComponentProps {
   computedMatch?: match;
-  route?: RouteTypes;
+  route?: RouteType;
 }
 
 export default withRouter;

--- a/packages/umi/withRouter.d.ts
+++ b/packages/umi/withRouter.d.ts
@@ -1,2 +1,13 @@
-import { withRouter } from 'react-router-dom';
+import { withRouter, RouteComponentProps, RouteProps, match } from 'react-router-dom';
+
+interface RouteTypes extends Pick<RouteProps, 'component' | 'exact' | 'path'> {
+  _title?: string;
+  _title_default?: string;
+}
+
+export interface RouterTypes extends RouteComponentProps {
+  computedMatch?: match;
+  route?: RouteTypes;
+}
+
 export default withRouter;

--- a/packages/umi/withRouter.d.ts
+++ b/packages/umi/withRouter.d.ts
@@ -1,8 +1,8 @@
 import { withRouter, RouteComponentProps, RouteProps, match } from 'react-router-dom';
 
-type ExcludeRoute = 'component' | 'exact' | 'path';
+type IncludeRoute = 'component' | 'exact' | 'path';
 
-interface RouteType extends Pick<RouteProps, ExcludeRoute> {
+interface RouteType extends Pick<RouteProps, IncludeRoute> {
   _title?: string;
   _title_default?: string;
 }

--- a/packages/umi/withRouter.d.ts
+++ b/packages/umi/withRouter.d.ts
@@ -1,15 +1,3 @@
-import { withRouter, RouteComponentProps, RouteProps, match } from 'react-router-dom';
-
-type IncludeRoute = 'component' | 'exact' | 'path';
-
-interface RouteType extends Pick<RouteProps, IncludeRoute> {
-  _title?: string;
-  _title_default?: string;
-}
-
-export interface RouterTypes extends RouteComponentProps {
-  computedMatch?: match;
-  route?: RouteType;
-}
+import { withRouter } from 'react-router-dom';
 
 export default withRouter;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

- TypeScript, router

![image](https://user-images.githubusercontent.com/13595509/54472061-50d5d600-47fd-11e9-95c4-cbbda00b48f4.png)

![image](https://user-images.githubusercontent.com/13595509/54472062-56cbb700-47fd-11e9-819f-4e83d621a3f4.png)


![image](https://user-images.githubusercontent.com/13595509/54472064-5df2c500-47fd-11e9-8eca-a52c6f673463.png)

##### Usage

```ts
// maybe the type's name can discuss.
import { RouterTypes } from 'umi';

const App: React.SFC<RouterTypes> = (props) => {
  console.log('index props', props.route...);
  return (
     <div>Index page</div>
  )
}

```

You can define your own route config:

```ts
// config.js|ts / .umirc.js|ts
export default {
 routes: [
    {
      path: '/',
      component: '../layout',
      routes: [
        { path: '/', component: 'index' },
        {
          path: 'about', 
		  component: 'A',
          title: 'Title',
        }
      ],
    }
  ],
}
```

```ts

// pages/A.tsx

interface RouteExtend {
  title?: string;
}

const App: React.SFC<RouterTypes<RouteExtend>> = (props) => {
  // `props.route` has `title` property you defined.
  return (
     <div>Index page</div>
  )
}
```

