### PR TITLE
fix: same reference to common route config will lead to wrong path

### DIFF
--- a/packages/umi-build-dev/src/routes/getRouteConfigFromConfig.js
+++ b/packages/umi-build-dev/src/routes/getRouteConfigFromConfig.js
@@ -1,23 +1,24 @@
 import assert from 'assert';
 import { join, isAbsolute } from 'path';
-import { cloneDeep } from 'lodash';
+import { clone } from 'lodash';
 import { winPath, isUrl } from 'umi-utils';
 
 export default (routes, pagesPath = 'src/pages', parentRoutePath = '/') => {
-  // cloneDeep 是为了避免 patch 多次
-  const clonedRoutes = cloneDeep(routes);
-  patchRoutes(clonedRoutes, pagesPath, parentRoutePath);
-  return clonedRoutes;
+  return patchRoutes(routes, pagesPath, parentRoutePath);
 };
 
 function patchRoutes(routes, pagesPath, parentRoutePath) {
   assert(Array.isArray(routes), `routes should be Array, but got ${routes}`);
-  routes.forEach(route => {
-    patchRoute(route, pagesPath, parentRoutePath);
+
+  return routes.map(route => {
+    return patchRoute(route, pagesPath, parentRoutePath);
   });
 }
 
 function patchRoute(route, pagesPath, parentRoutePath) {
+  // clone 是为了避免 patch 多次
+  route = clone(route);
+
   // route.component start from pages
   if (route.component) {
     route.component = resolveComponent(pagesPath, route.component);
@@ -77,7 +78,7 @@ function patchRoute(route, pagesPath, parentRoutePath) {
     route.redirect = winPath(join(parentRoutePath, route.redirect));
   }
   if (route.routes) {
-    patchRoutes(route.routes, pagesPath, route.path);
+    route.routes = patchRoutes(route.routes, pagesPath, route.path);
   } else if (!('exact' in route)) {
     route.exact = true;
   }

--- a/packages/umi-build-dev/src/routes/getRouteConfigFromConfig.test.js
+++ b/packages/umi-build-dev/src/routes/getRouteConfigFromConfig.test.js
@@ -113,6 +113,49 @@ describe('getRoutesConfigFromConfig', () => {
     ]);
   });
 
+  it('same reference', () => {
+    const commonRoutes = [
+      {
+        path: '/c',
+        component: 'C',
+      },
+    ];
+
+    const routes = getRoute([
+      {
+        path: '/a',
+        routes: commonRoutes,
+      },
+      {
+        path: '/b',
+        routes: commonRoutes,
+      },
+    ]);
+
+    expect(routes).toEqual([
+      {
+        path: '/a',
+        routes: [
+          {
+            path: '/c',
+            component: './src/pages/C',
+            exact: true,
+          },
+        ],
+      },
+      {
+        path: '/b',
+        routes: [
+          {
+            path: '/c',
+            component: './src/pages/C',
+            exact: true,
+          },
+        ],
+      },
+    ]);
+  });
+
   it('bigfish compatibility', () => {
     process.env.BIGFISH_COMPAT = true;
     const routes = getRoute([


### PR DESCRIPTION
…wrong path (#1998)

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/issues/1998

这个问题的出现是因为：lodash.cloneDeep 为了处理 circular references 的问题，每次 clone 过每个部分以后就会记录在一个 Stack 中，对指向同一个对象的 clone 不会重复处理。

lodash.cloneDeep 的行为不能配置，所以我换了下实现，性能上应该不受影响。