### PR TITLE
feat(umi-test): support --transform-include option

### DIFF
--- a/packages/umi-test/src/index.js
+++ b/packages/umi-test/src/index.js
@@ -8,6 +8,10 @@ process.env.NODE_ENV = 'test';
 
 export default function(opts = {}) {
   const { cwd = process.cwd(), moduleNameMapper } = opts;
+  let transformInclude = opts.transformInclude || [];
+  if (typeof transformInclude === 'string') {
+    transformInclude = [transformInclude];
+  }
 
   const jestConfigFile = join(cwd, 'jest.config.js');
   let userJestConfig = {};
@@ -31,7 +35,11 @@ export default function(opts = {}) {
       '\\.(t|j)sx?$': require.resolve('./transformers/jsTransformer'),
       '\\.svg$': require.resolve('./transformers/fileTransformer'),
     },
-    transformIgnorePatterns: ['node_modules/(?!(umi)/)'],
+    transformIgnorePatterns: [
+      `node_modules/(?!(umi|enzyme-adapter-react-16|${transformInclude.join(
+        '|',
+      )})/)`,
+    ],
     testMatch: ['**/?*.(spec|test|e2e).(j|t)s?(x)'],
     moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx', 'json'],
     setupFilesAfterEnv: [require.resolve('./jasmine')],
@@ -46,6 +54,8 @@ export default function(opts = {}) {
     testPathIgnorePatterns: ['/node_modules/'],
     ...(restUserJestConfig || {}),
   };
+
+  delete opts.transformInclude;
 
   return new Promise((resolve, reject) => {
     jest

--- a/packages/umi-test/src/transformers/jsTransformer.js
+++ b/packages/umi-test/src/transformers/jsTransformer.js
@@ -33,12 +33,12 @@ module.exports = babelJest.createTransformer({
           enzyme: compatDirname(
             'enzyme/package.json',
             cwd,
-            require.resolve('enzyme'),
+            dirname(require.resolve('enzyme/package.json')),
           ),
           'enzyme-adapter-react-16': compatDirname(
             'enzyme-adapter-react-16/package.json',
             cwd,
-            require.resolve('enzyme-adapter-react-16'),
+            dirname(require.resolve('enzyme-adapter-react-16/package.json')),
           ),
         },
       },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- 支持 `--transform-include` cli 参数，用于指定额外需要做 babel 编译的 npm 包
- 顺便解决了 enzyme-adapter-react-16 里引用了 enzyme 却没有通过 babel 编译为正确路径，从而导致多个 enzyme 实例的问题
- close https://github.com/umijs/umi/issues/2159

#### Notes

记录下调 umi-test 里的 transformer 的方法，

1. `umi-test --no-cache` 才会让 transformer 或 babel 插件的修改生效，否则会走缓存
2. transformer 或 babel 插件的 console.log 日志不会显示到输出里，但 console.error 会，所以应该是 pipe 了 stderr 但没有 pipe stdout
