### PR TITLE
try run test

### DIFF
--- a/packages/umi-build-dev/src/routes/getRouteConfigFromDir.test.js
+++ b/packages/umi-build-dev/src/routes/getRouteConfigFromDir.test.js
@@ -8,9 +8,9 @@ describe('getRouteConfigFromDir', () => {
       absPagesPath: join(__dirname, 'fixtures', 'normal'),
     });
     expect(routes).toEqual([
+      { path: '/c/c', exact: true, component: './c/c.js' },
       { path: '/a', exact: true, component: './a.js' },
       { path: '/b', exact: true, component: './b.js' },
-      { path: '/c/c', exact: true, component: './c/c.js' },
     ]);
   });
 
@@ -20,9 +20,9 @@ describe('getRouteConfigFromDir', () => {
       absPagesPath: join(__dirname, 'fixtures', 'file-config'),
     });
     expect(routes).toEqual([
+      { path: '/c/c', exact: true, component: './c/c.js', title: ['c', 'd'] },
       { path: '/a', exact: true, component: './a.js', title: 'a' },
       { path: '/b', exact: true, component: './b.js', title: 'b' },
-      { path: '/c/c', exact: true, component: './c/c.js', title: ['c', 'd'] },
     ]);
   });
 
@@ -51,9 +51,9 @@ describe('getRouteConfigFromDir', () => {
       absPagesPath: join(__dirname, 'fixtures', 'remove-last-index'),
     });
     expect(routes).toEqual([
-      { path: '/a/a', exact: true, component: './a/a/index.js' },
-      { path: '/a', exact: true, component: './a/index.js' },
       { path: '/', exact: true, component: './index.js' },
+      { path: '/a', exact: true, component: './a/index.js' },
+      { path: '/a/a', exact: true, component: './a/a/index.js' },
     ]);
   });
 
@@ -71,9 +71,9 @@ describe('getRouteConfigFromDir', () => {
       absPagesPath: join(__dirname, 'fixtures', 'dynamic-route'),
     });
     expect(routes).toEqual([
-      { path: '/:d', exact: true, component: './$d/index.js' },
-      { path: '/:b/:c', exact: true, component: './$b/$c.js' },
       { path: '/:a', exact: true, component: './$a.js' },
+      { path: '/:b/:c', exact: true, component: './$b/$c.js' },
+      { path: '/:d', exact: true, component: './$d/index.js' },
     ]);
   });
 
@@ -83,8 +83,8 @@ describe('getRouteConfigFromDir', () => {
       absPagesPath: join(__dirname, 'fixtures', 'optional-route'),
     });
     expect(routes).toEqual([
-      { path: '/a?', exact: true, component: './a$.js' },
       { path: '/c?/c', exact: true, component: './c$/c.js' },
+      { path: '/a?', exact: true, component: './a$.js' },
       { path: '/:b?', exact: true, component: './$b$.js' },
     ]);
   });
@@ -95,10 +95,6 @@ describe('getRouteConfigFromDir', () => {
       absPagesPath: join(__dirname, 'fixtures', 'dynamic-route-order'),
     });
     expect(routes).toEqual([
-      { path: '/a', exact: true, component: './a.js' },
-      { path: '/c/a', exact: true, component: './c/a.js' },
-      { path: '/c/d', exact: true, component: './c/d.js' },
-      { path: '/c/:c', exact: true, component: './c/$c.js' },
       {
         path: '/e',
         exact: false,
@@ -109,6 +105,10 @@ describe('getRouteConfigFromDir', () => {
           { path: '/e/:c', exact: true, component: './e/$c.js' },
         ],
       },
+      { path: '/c/a', exact: true, component: './c/a.js' },
+      { path: '/c/d', exact: true, component: './c/d.js' },
+      { path: '/c/:c', exact: true, component: './c/$c.js' },
+      { path: '/a', exact: true, component: './a.js' },
       { path: '/:b', exact: true, component: './$b.js' },
     ]);
   });


### PR DESCRIPTION
Node -v
v11.6.0

主分支的测试用例，我本地一直跑不过，换了个电脑也是不行。
这里举个例子，只有像我现在这样修改，才能通过测试用例。
```sh
mac001:umi xiaohuoni$ npm run debug packages/umi-build-dev/src/routes/getRouteConfigFromDir.test.js

> @ debug /Users/xiaohuoni/Documents/GitHub/umi
> ./packages/umi-test/bin/umi-test.js "packages/umi-build-dev/src/routes/getRouteConfigFromDir.test.js"

 PASS  packages/umi-build-dev/src/routes/getRouteConfigFromDir.test.js
  getRouteConfigFromDir
    ✓ normal (7ms)
    ✓ file config (5ms)
    ✓ file config unexpected key (8ms)
    ✓ index/index (1ms)
    ✓ remove last index (1ms)
    ✓ ignore files (1ms)
    ✓ dynamic route (1ms)
    ✓ optional route (1ms)
    ✓ dynamic route order (2ms)
    ✓ index layout order (1ms)
    ✓ layout
    ✓ global layout (1ms)
    ✓ global layout (sigular) (1ms)
    ✓ global layout not found
    ✓ throw error when have root _layout.js
    ○ skipped 2 tests

Test Suites: 1 passed, 1 total
Tests:       2 skipped, 15 passed, 17 total
Snapshots:   0 total
Time:        3.058s
Ran all test suites matching /packages\/umi-build-dev\/src\/routes\/getRouteConfigFromDir.test.js/i.
```