### PR TITLE
feat: support loadingComponent from npm

### DIFF
--- a/packages/umi-plugin-react/src/plugins/dynamicImport.js
+++ b/packages/umi-plugin-react/src/plugins/dynamicImport.js
@@ -1,5 +1,6 @@
 import { join } from 'path';
 import isReactComponent from '../utils/isReactComponent';
+import isRelativePath from '../utils/isRelativePath';
 
 export default function(api, options) {
   const { paths, winPath } = api;
@@ -22,10 +23,12 @@ export default function(api, options) {
     if (options.loadingComponent) {
       if (isReactComponent(options.loadingComponent.trim())) {
         loadingOpts = `, loading: ${options.loadingComponent.trim()}`;
-      } else {
+      } else if(isRelativePath(options.loadingComponent.trim())){
         loadingOpts = `, loading: require('${winPath(
           join(paths.absSrcPath, options.loadingComponent),
         )}').default`;
+      } else {
+        loadingOpts = `, loading: require('${options.loadingComponent.trim()}').default`;        
       }
     }
 

--- a/packages/umi-plugin-react/src/plugins/dynamicImport.js
+++ b/packages/umi-plugin-react/src/plugins/dynamicImport.js
@@ -23,7 +23,7 @@ export default function(api, options) {
     if (options.loadingComponent) {
       if (isReactComponent(options.loadingComponent.trim())) {
         loadingOpts = `, loading: ${options.loadingComponent.trim()}`;
-      } else if(isRelativePath(options.loadingComponent.trim())){
+      } else if (isRelativePath(options.loadingComponent.trim())) {
         loadingOpts = `, loading: require('${winPath(
           join(paths.absSrcPath, options.loadingComponent),
         )}').default`;

--- a/packages/umi-plugin-react/src/utils/isRelativePath.js
+++ b/packages/umi-plugin-react/src/utils/isRelativePath.js
@@ -1,0 +1,4 @@
+export default function(path) {
+    return /^\.{1,2}\//.test(path);
+}
+  

--- a/packages/umi-plugin-react/src/utils/isRelativePath.test.js
+++ b/packages/umi-plugin-react/src/utils/isRelativePath.test.js
@@ -1,0 +1,9 @@
+import isRelativePath from './isRelativePath';
+
+describe('isRelativePath', () => {
+  test('normal', () => {
+    expect(isRelativePath(`./test`)).toEqual(true);
+    expect(isRelativePath(`../test`)).toEqual(true);
+    expect(isRelativePath(`test`)).toEqual(false);
+  });
+});


### PR DESCRIPTION


- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

支持 loadingComponent 来源与 npm 包而不是单纯的相对路径

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
