### PR TITLE
typescript增加abortOnError

### DIFF
--- a/packages/umi-library/src/getRollupConfig.ts
+++ b/packages/umi-library/src/getRollupConfig.ts
@@ -23,6 +23,7 @@ interface IGetRollupConfigOpts {
   typescriptOpts: ITypescriptOptions;
 }
 
+
 interface IPkg {
   dependencies?: Object;
   peerDependencies?: Object;

--- a/packages/umi-library/src/getRollupConfig.ts
+++ b/packages/umi-library/src/getRollupConfig.ts
@@ -13,13 +13,14 @@ import tempDir from 'temp-dir';
 import autoprefixer from 'autoprefixer';
 import NpmImport from 'less-plugin-npm-import';
 import getBabelConfig from './getBabelConfig';
-import { IBundleOptions } from './types';
+import { IBundleOptions, ITypescriptOptions } from './types';
 
 interface IGetRollupConfigOpts {
   cwd: string;
   entry: string;
   type: ModuleFormat;
   bundleOpts: IBundleOptions;
+  typescriptOpts: ITypescriptOptions;
 }
 
 interface IPkg {
@@ -29,7 +30,7 @@ interface IPkg {
 }
 
 export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
-  const { type, entry, cwd, bundleOpts } = opts;
+  const { type, entry, cwd, bundleOpts, typescriptOpts } = opts;
   const {
     umd,
     esm,
@@ -149,6 +150,7 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
                 target: 'esnext',
               },
             },
+            ...typescriptOpts,
           }),
         ]
       : []),

--- a/packages/umi-library/src/types.d.ts
+++ b/packages/umi-library/src/types.d.ts
@@ -59,3 +59,7 @@ export interface IOpts {
   watch?: boolean;
   buildArgs?: IBundleOptions;
 }
+
+export interface ITypescriptOptions {
+  abortOnError: boolean;
+}


### PR DESCRIPTION
目前我们项目正在迁移到umi-library上，但一些静态检查没有清理干净，rollup-plugin-typescript2默认abortOnError为true导致无法构建，所以增加typescriptOpts使得用户可以定制该规则。

Close https://github.com/umijs/umi/issues/2263
