### PR TITLE
chore: add prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "trailingComma": "all",
+  "singleQuote": true
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "lint-staged": {
     "*.(t|j)s": [
-      "prettier --trailing-comma all --single-quote --write",
+      "prettier --write",
       "git add"
     ]
   },


### PR DESCRIPTION
虽然在 commit 时会有 prettier 去格式化，但是在本地开发时，没有 prettier config 导致保存时格式不统一导致 eslint 一片红。添加一个本地的 prettierrc 方便开发。配置与 lint-staged 阶段一致。