### PR TITLE
fix: mock parse error when there are multiple spaces between method a…

### DIFF
--- a/packages/umi-mock/src/fixtures/mock-files/with-method.js
+++ b/packages/umi-mock/src/fixtures/mock-files/with-method.js
@@ -1,0 +1,6 @@
+export default {
+  'get /api/get': { key: 'get' },
+  'GET  /api/get2': { key: 'get2' },
+  'POST  /api/samepath': { key: 'postpath' },
+  'GET  /api/samepath': { key: 'getpath' },
+}

--- a/packages/umi-mock/src/getMockData.js
+++ b/packages/umi-mock/src/getMockData.js
@@ -65,8 +65,8 @@ export function normalizeConfig(config) {
 function parseKey(key) {
   let method = 'get';
   let path = key;
-  if (key.indexOf(' ') > -1) {
-    const splited = key.split(' ');
+  if (/\s+/.test(key)) {
+    const splited = key.split(/\s+/);
     method = splited[0].toLowerCase();
     path = splited[1]; // eslint-disable-line
   }

--- a/packages/umi-mock/src/getMockData.test.js
+++ b/packages/umi-mock/src/getMockData.test.js
@@ -111,6 +111,21 @@ describe('umi-mock:getMockData', () => {
       expect(typeof config[0].handler).toEqual('function');
     });
 
+    it('with method', () => {
+      const config = normalizeConfig(
+        getMockConfigFromFiles([`${fixtures}/mock-files/with-method.js`]),
+      );
+      expect(config.length).toEqual(4);
+      expect(config[0].method).toEqual('get');
+      expect(config[0].path).toEqual('/api/get');
+      expect(config[1].method).toEqual('get');
+      expect(config[1].path).toEqual('/api/get2');
+      expect(config[2].method).toEqual('post');
+      expect(config[2].path).toEqual('/api/samepath');
+      expect(config[3].method).toEqual('get');
+      expect(config[3].path).toEqual('/api/samepath');
+    });
+
     it('conflicts', () => {
       const config = normalizeConfig(
         getMockConfigFromFiles([


### PR DESCRIPTION

##### Checklist

- [x] `npm test` passes
- [x] tests are included
- [x] commit message follows commit guidelines


##### Description of change

fix: mock parse error when there are multiple spaces between method and path
