### PR TITLE
fix(umi-library): theme path problem in windows

### DIFF
--- a/packages/umi-library/src/doczrc.ts
+++ b/packages/umi-library/src/doczrc.ts
@@ -26,7 +26,7 @@ const isTypescript = existsSync(join(cwd, 'tsconfig.json'));
 export default {
   typescript: isTypescript,
   repository: false,
-  theme: require.resolve('docz-theme-umi'),
+  theme: require.resolve('docz-theme-umi').replace(/\\/g, '/'),
   ...userConfig.doc,
   modifyBabelRc(babelrc, args) {
     if (typeof userConfig.doc.modifyBabelRc === 'function') {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

修复windows环境下 umi-lib doc dev 生成的docz 主题路径错误的问题

修复前路径bug：

![QQ图片20190430211624](https://user-images.githubusercontent.com/18549980/56964307-82c4b100-6b8d-11e9-85cb-758efcc2f5dd.png)

![QQ图片20190430211629](https://user-images.githubusercontent.com/18549980/56964272-72143b00-6b8d-11e9-8620-ffa7b291a91e.png)

修复后：

![QQ图片20190430211624](https://user-images.githubusercontent.com/18549980/56964748-607f6300-6b8e-11e9-9598-d0c93e338209.png)


## ISSUES

Close https://github.com/umijs/umi-plugin-library/issues/95