### PR TITLE
feat: pass port to api.afterDevServer

### DIFF
--- a/docs/plugin/develop.md
+++ b/docs/plugin/develop.md
@@ -304,6 +304,13 @@ Before dev server start.
 
 After dev server start.
 
+```js
+api.afterDevServer(({serve, devServerPort}) => {
+  // You can get the actual port number of the service monitor here.
+  console.log(devServerPort);
+});
+```
+
 ### onStart
 
 Triggered when `umi dev` or `umi build` start.
@@ -373,7 +380,7 @@ api.onPatchRoute({ route } => {
   // route:
   // {
   //   path: '/xxx',
-  //   Routes: [] 
+  //   Routes: []
   // }
 })
 ```

--- a/docs/zh/plugin/develop.md
+++ b/docs/zh/plugin/develop.md
@@ -304,6 +304,13 @@ dev server 启动之前。
 
 dev server 启动之后。
 
+```js
+api.afterDevServer(({serve, devServerPort}) => {
+  // 你可以在这里取到服务监听的实际端口号
+  console.log(devServerPort);
+});
+```
+
 ### onStart
 
 `umi dev` 或者 `umi build` 开始时触发。
@@ -373,7 +380,7 @@ api.onPatchRoute({ route } => {
   // route:
   // {
   //   path: '/xxx',
-  //   Routes: [] 
+  //   Routes: []
   // }
 })
 ```

--- a/packages/af-webpack/src/dev.js
+++ b/packages/af-webpack/src/dev.js
@@ -156,7 +156,7 @@ export default function dev({
         console.log(chalk.cyan('Starting the development server...\n'));
         send({ type: STARTING });
         if (afterServer) {
-          afterServer(server);
+          afterServer(server, port);
         }
       });
     })

--- a/packages/umi-build-dev/src/plugins/commands/dev/index.js
+++ b/packages/umi-build-dev/src/plugins/commands/dev/index.js
@@ -22,6 +22,7 @@ export default function(api) {
       RoutesManager.fetchRoutes();
 
       const { port } = args;
+
       process.env.NODE_ENV = 'development';
       service.applyPlugins('onStart');
       service._applyPluginsAsync('onStartAsync').then(() => {
@@ -116,9 +117,12 @@ export default function(api) {
                   args: { server: devServer },
                 });
               },
-              afterServer(devServer) {
+              afterServer(devServer, devServerPort) {
                 service.applyPlugins('afterDevServer', {
-                  args: { server: devServer },
+                  args: {
+                    server: devServer,
+                    devServerPort,
+                  },
                 });
                 startWatch();
               },


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->
在cordova支持，或者其他需要再另起一个服务器时，需要获取到umi启动的端口号

