### PR TITLE
doc: add intro for `umi:command not found`

### DIFF
--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -32,6 +32,8 @@ $ yarn global add umi
 $ umi -v
 2.0.0
 ```
+有些同学报错 umi:command not found，[点击这里查看解决方法。](https://yewills.github.io/2019/05/19/dva_umi/)
+
 
 ## 脚手架
 

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -47,7 +47,6 @@ C:\Users\Administrator\AppData\Local\Yarn\bin
 # 复制上面的 global bin 的路径，添加到系统环境变量 PATH。
 ```
 
-
 ## 脚手架
 
 先找个地方建个空目录。

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -32,7 +32,19 @@ $ yarn global add umi
 $ umi -v
 2.0.0
 ```
-有些同学报错 umi:command not found，[点击这里查看解决方法。](https://yewills.github.io/2019/05/19/dva_umi/)
+> FAQ：如果提示 **umi: command not found**，你需要将`yarn global bin`路径配置到环境变量中，方法如下：
+```bash
+# mac系统:
+$ sudo vi ~/.bash_profile
+# 在.bash_profile中添加下面一行：
+export PATH="$PATH:`yarn global bin`"
+
+# windows系统:
+# 获取 global bin 的路径
+$ yarn global bin
+C:\Users\Administrator\AppData\Local\Yarn\bin
+# 复制上面的global bin 的路径，添加到系统环境变量 PATH。
+```
 
 
 ## 脚手架

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -32,18 +32,19 @@ $ yarn global add umi
 $ umi -v
 2.0.0
 ```
-> FAQ：如果提示 **umi: command not found**，你需要将`yarn global bin`路径配置到环境变量中，方法如下：
+
+> FAQ：如果提示 **umi: command not found**，你需要将 `yarn global bin` 路径配置到环境变量中，方法如下：
 ```bash
-# mac系统:
+# mac 系统:
 $ sudo vi ~/.bash_profile
-# 在.bash_profile中添加下面一行：
+# 在 .bash_profile 中添加下面一行：
 export PATH="$PATH:`yarn global bin`"
 
 # windows系统:
 # 获取 global bin 的路径
 $ yarn global bin
 C:\Users\Administrator\AppData\Local\Yarn\bin
-# 复制上面的global bin 的路径，添加到系统环境变量 PATH。
+# 复制上面的 global bin 的路径，添加到系统环境变量 PATH。
 ```
 
 


### PR DESCRIPTION
按照文档操作时，报错umi:command not found，虽然与umi无关，是yarn环境配置导致，不过对于一个umi新手，会产生各种怀疑，因此在这里附带一个解决方法