### PR TITLE
fix(umi-test): jest 兼容 tnpm 目录结构的正则表达式

### DIFF
--- a/packages/umi-test/src/index.js
+++ b/packages/umi-test/src/index.js
@@ -38,9 +38,9 @@ export default function(opts = {}) {
       '\\.svg$': require.resolve('./transformers/fileTransformer'),
     },
     transformIgnorePatterns: [
-      // 加 [^/]+? 是为了兼容 tnpm 的目录结构
+      // 加 [^/]*? 是为了兼容 tnpm 的目录结构
       // 比如：_umi-test@1.5.5@umi-test
-      `node_modules/(?!([^/]+?umi|[^/]+?umi-test|[^/]+?enzyme-adapter-react-16|${transformInclude.join(
+      `node_modules/(?!([^/]*?umi|[^/]*?umi-test|[^/]*?enzyme-adapter-react-16|${transformInclude.join(
         '|',
       )})/)`,
     ],


### PR DESCRIPTION
tnpm 的目录结构是 `_umi-test@1.5.5@umi-test`，npm 和 tnpm 兼容的正则表达式应该是 `[^/]*?` 而不是 `[^/]+?`.

修改正则表达式后可以修复：

- jest 单元测试中涉及到 Link及router时报错 #1862
- npm test时出现的错误，npm start没问题，不知道怎么纠正？ #2076