### PR TITLE
fix: default build absolute path

### DIFF
--- a/packages/babel-preset-umi/src/index.js
+++ b/packages/babel-preset-umi/src/index.js
@@ -1,4 +1,3 @@
-import { dirname } from 'path';
 
 export default function(context, opts = {}) {
   const nodeEnv = process.env.NODE_ENV;
@@ -11,9 +10,7 @@ export default function(context, opts = {}) {
   const transformRuntime =
     'transformRuntime' in opts
       ? opts.transformRuntime
-      : {
-          absoluteRuntime: dirname(require.resolve('../package')),
-        };
+      : {};
   const exclude = [
     'transform-typeof-symbol',
     'transform-unicode-regex',


### PR DESCRIPTION
默认不 build 绝对路径，像 [babel-plugin-import](https://github.com/ant-design/babel-plugin-import) 升级 umi-tools 后，不去掉 pkg 中的 babel，就会 build 出绝对路径。

![image](https://user-images.githubusercontent.com/13595509/58105096-842b4b80-7c18-11e9-9736-51df91078e0d.png)


##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
