### PR TITLE
feat: locale intellisense

### DIFF
--- a/packages/umi-plugin-locale/index.d.ts
+++ b/packages/umi-plugin-locale/index.d.ts
@@ -5,6 +5,7 @@
  *   - expose interfaces from `IntlShape`
  */
 import * as React from 'react';
+import zh_CN from '@/locales/zh-CN';
 // Basic types and interfaces
 export declare type DateSource = Date | string | number;
 export declare type MessageValue = string | number | boolean | Date | null | undefined;
@@ -12,7 +13,7 @@ export declare interface DateTimeFormatProps extends Intl.DateTimeFormatOptions 
   format?: string;
 }
 export interface MessageDescriptor {
-  id: string;
+  id: keyof typeof zh_CN;
   description?: string;
   defaultMessage?: string;
 }

--- a/packages/umi-plugin-locale/index.d.ts
+++ b/packages/umi-plugin-locale/index.d.ts
@@ -5,15 +5,19 @@
  *   - expose interfaces from `IntlShape`
  */
 import * as React from 'react';
-import zh_CN from '@/locales/zh-CN';
+import locales_zh_CN from '@/locales/zh-CN';
+import locale_zh_CN from '@/locale/zh-CN';
 // Basic types and interfaces
 export declare type DateSource = Date | string | number;
 export declare type MessageValue = string | number | boolean | Date | null | undefined;
 export declare interface DateTimeFormatProps extends Intl.DateTimeFormatOptions {
   format?: string;
 }
+
+type LiteralBase = undefined | null | boolean | number | string;
+type zh_CN = (keyof typeof locales_zh_CN) & (keyof typeof locale_zh_CN);
 export interface MessageDescriptor {
-  id: typeof zh_CN extends object ? keyof typeof zh_CN : string;
+  id: zh_CN extends LiteralBase ? zh_CN : string;
   description?: string;
   defaultMessage?: string;
 }

--- a/packages/umi-plugin-locale/index.d.ts
+++ b/packages/umi-plugin-locale/index.d.ts
@@ -5,8 +5,10 @@
  *   - expose interfaces from `IntlShape`
  */
 import * as React from 'react';
-import locales_zh_CN from '@/locales/zh-CN';
-import locale_zh_CN from '@/locale/zh-CN';
+// @ts-ignore
+import locales_zh_CN from '../../src/locales/zh-CN';
+// @ts-ignore
+import locale_zh_CN from '../../src/locale/zh-CN';
 // Basic types and interfaces
 export declare type DateSource = Date | string | number;
 export declare type MessageValue = string | number | boolean | Date | null | undefined;

--- a/packages/umi-plugin-locale/index.d.ts
+++ b/packages/umi-plugin-locale/index.d.ts
@@ -6,9 +6,9 @@
  */
 import * as React from 'react';
 // @ts-ignore
-import locales_zh_CN from '../../src/locales/zh-CN';
+import locales_zh_CN from '@/locales/zh-CN';
 // @ts-ignore
-import locale_zh_CN from '../../src/locale/zh-CN';
+import locale_zh_CN from '@/locale/zh-CN';
 // Basic types and interfaces
 export declare type DateSource = Date | string | number;
 export declare type MessageValue = string | number | boolean | Date | null | undefined;

--- a/packages/umi-plugin-locale/index.d.ts
+++ b/packages/umi-plugin-locale/index.d.ts
@@ -13,7 +13,7 @@ export declare interface DateTimeFormatProps extends Intl.DateTimeFormatOptions 
   format?: string;
 }
 export interface MessageDescriptor {
-  id: keyof typeof zh_CN;
+  id: typeof zh_CN extends object ? keyof typeof zh_CN : string;
   description?: string;
   defaultMessage?: string;
 }

--- a/packages/umi-plugin-locale/index.d.ts
+++ b/packages/umi-plugin-locale/index.d.ts
@@ -14,10 +14,9 @@ export declare interface DateTimeFormatProps extends Intl.DateTimeFormatOptions 
   format?: string;
 }
 
-type LiteralBase = undefined | null | boolean | number | string;
 type zh_CN = (keyof typeof locales_zh_CN) & (keyof typeof locale_zh_CN);
 export interface MessageDescriptor {
-  id: zh_CN extends LiteralBase ? zh_CN : string;
+  id: zh_CN extends string ? zh_CN : string;
   description?: string;
   defaultMessage?: string;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->
默认读取 `locales/zh-CN.js` 的所有 `keys`，`formatMessage` 与 `FormattedMessage` 时开发者无感知，可使用智能提示。

试了下即使没 `locales/zh-CN.js` 文件，编译和开发时也不会报错。


![image](https://user-images.githubusercontent.com/13595509/58258299-13fe0080-7da5-11e9-9d7f-3740addecb08.png)



##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
