### PR TITLE
fix: insert new block element in redirect return function

### DIFF
--- a/packages/umi-build-dev/src/plugins/commands/block/insertComponent.js
+++ b/packages/umi-build-dev/src/plugins/commands/block/insertComponent.js
@@ -12,15 +12,19 @@ function insertComponentToRender(blockStatement, identifier) {
     return t.isReturnStatement(b);
   });
   if (t.isJSXElement(returnBlock.argument)) {
-    // https://babeljs.io/docs/en/babel-types#jsxelement
-    const newElement = t.jsxElement(
-      t.jsxOpeningElement(t.jsxIdentifier(identifier), [], true),
-      null,
-      [],
-      true,
-    );
-    returnBlock.argument.children.push(newElement);
+    insertComponentToElement(returnBlock.argument, identifier);
   }
+}
+
+function insertComponentToElement(element, identifier) {
+  // https://babeljs.io/docs/en/babel-types#jsxelement
+  const newElement = t.jsxElement(
+    t.jsxOpeningElement(t.jsxIdentifier(identifier), [], true),
+    null,
+    [],
+    true,
+  );
+  element.children.push(newElement);
 }
 
 export default function(content, { relativePath, identifier }) {
@@ -60,6 +64,8 @@ export default function(content, { relativePath, identifier }) {
       if (t.isArrowFunctionExpression(declaration) || t.isFunctionDeclaration(declaration)) {
         if (t.isBlockStatement(declaration.body)) {
           insertComponentToRender(declaration.body, identifier);
+        } else if (t.isJSXElement(declaration.body)) {
+          insertComponentToElement(declaration.body, identifier);
         }
       }
     },

--- a/packages/umi-build-dev/src/plugins/commands/block/insertComponent.test.js
+++ b/packages/umi-build-dev/src/plugins/commands/block/insertComponent.test.js
@@ -128,4 +128,29 @@ export default (props: TestPageProps) => {
 };
 `);
   });
+
+  it('can insert with component with return redirectly', () => {
+    const code = `import React from 'react';
+import Demo1 from './Demo1';
+export default () => (
+  <React.Fragment>
+    <Demo />
+  </React.Fragment>
+);
+`;
+    const result = insert(code, {
+      relativePath: './Demo2',
+      identifier: 'DemoName',
+    });
+    expect(result).toEqual(`import React from 'react';
+import Demo1 from './Demo1';
+import DemoName from './Demo2';
+export default () => (
+  <React.Fragment>
+    <Demo />
+    <DemoName />
+  </React.Fragment>
+);
+`);
+  });
 });


### PR DESCRIPTION

##### Checklist

- [x] `npm test` passes
- [x] tests are included
- [x] commit message follows commit guidelines
