### PR TITLE
fix: generate wrong dev url when history is hash

### DIFF
--- a/packages/af-webpack/src/dev.js
+++ b/packages/af-webpack/src/dev.js
@@ -14,6 +14,8 @@ const isInteractive = process.stdout.isTTY;
 const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 8000;
 const HOST = process.env.HOST || '0.0.0.0';
 const PROTOCOL = process.env.HTTPS ? 'https' : 'http';
+// get the history type
+const HISTORY = process.env.HISTORY ? process.env.HISTORY.split(',')[0] : 'browser';
 const CERT = process.env.HTTPS && process.env.CERT ? fs.readFileSync(process.env.CERT) : '';
 const KEY = process.env.HTTPS && process.env.KEY ? fs.readFileSync(process.env.KEY) : '';
 const noop = () => {};
@@ -46,7 +48,7 @@ export default function dev({
       let isFirstCompile = true;
       const IS_CI = !!process.env.CI;
       const SILENT = !!process.env.SILENT;
-      const urls = prepareUrls(PROTOCOL, HOST, port, base);
+      const urls = prepareUrls(PROTOCOL, HOST, port, base, HISTORY);
       compiler.hooks.done.tap('af-webpack dev', stats => {
         if (stats.hasErrors()) {
           // make sound

--- a/packages/af-webpack/src/dev.js
+++ b/packages/af-webpack/src/dev.js
@@ -14,8 +14,6 @@ const isInteractive = process.stdout.isTTY;
 const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 8000;
 const HOST = process.env.HOST || '0.0.0.0';
 const PROTOCOL = process.env.HTTPS ? 'https' : 'http';
-// get the history type
-const HISTORY = process.env.HISTORY ? process.env.HISTORY.split(',')[0] : 'browser';
 const CERT = process.env.HTTPS && process.env.CERT ? fs.readFileSync(process.env.CERT) : '';
 const KEY = process.env.HTTPS && process.env.KEY ? fs.readFileSync(process.env.KEY) : '';
 const noop = () => {};
@@ -33,6 +31,7 @@ export default function dev({
   onCompileDone = noop,
   proxy,
   port,
+  history,
   base,
   serverConfig: serverConfigFromOpts = {},
 }) {
@@ -48,7 +47,7 @@ export default function dev({
       let isFirstCompile = true;
       const IS_CI = !!process.env.CI;
       const SILENT = !!process.env.SILENT;
-      const urls = prepareUrls(PROTOCOL, HOST, port, base, HISTORY);
+      const urls = prepareUrls(PROTOCOL, HOST, port, base, history);
       compiler.hooks.done.tap('af-webpack dev', stats => {
         if (stats.hasErrors()) {
           // make sound

--- a/packages/af-webpack/src/prepareUrls.js
+++ b/packages/af-webpack/src/prepareUrls.js
@@ -3,20 +3,29 @@ import address from 'address';
 import url from 'url';
 import chalk from 'chalk';
 
-export default function prepareUrls(protocol, host, port, pathname) {
+export default function prepareUrls(protocol, host, port, pathname, history) {
+
+  // if history type is hash, add the base to hash part rather than pathname.
+  const baseInfo = history === 'hash' ? {
+    protocol,
+    pathname: '/',
+    hash: pathname || '',
+  } : {
+    protocol,
+    pathname: pathname || '/',
+  };
+
   const formatUrl = hostname =>
     url.format({
-      protocol,
+      ...baseInfo,
       hostname,
       port,
-      pathname: pathname || '/',
     });
   const prettyPrintUrl = hostname =>
     url.format({
-      protocol,
+      ...baseInfo,
       hostname,
       port: chalk.bold(port),
-      pathname: pathname || '/',
     });
 
   const isUnspecifiedHost = host === '0.0.0.0' || host === '::';

--- a/packages/umi-build-dev/src/Service.js
+++ b/packages/umi-build-dev/src/Service.js
@@ -48,6 +48,8 @@ export default class Service {
 
     // resolve paths
     this.paths = getPaths(this);
+    // put the history type into env
+    process.env.HISTORY = this.config.history;
   }
 
   resolvePlugins() {

--- a/packages/umi-build-dev/src/Service.js
+++ b/packages/umi-build-dev/src/Service.js
@@ -48,8 +48,6 @@ export default class Service {
 
     // resolve paths
     this.paths = getPaths(this);
-    // put the history type into env
-    process.env.HISTORY = this.config.history;
   }
 
   resolvePlugins() {

--- a/packages/umi-build-dev/src/plugins/commands/dev/index.js
+++ b/packages/umi-build-dev/src/plugins/commands/dev/index.js
@@ -84,9 +84,11 @@ export default function(api) {
           ._applyPluginsAsync('_beforeDevServerAsync')
           .then(() => {
             debug('start dev server with af-webpack/dev');
+            const { history = 'browser' } = service.config;
             require('af-webpack/dev').default({
               cwd,
               port,
+              history: typeof history === 'string' ? history : history[0],
               base: service.config.base,
               webpackConfig: service.webpackConfig,
               proxy: service.config.proxy || {},


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

Fix the problem that umi dev generate wrong url when the history type is hash and the base is set. 
base value should be in hash part of the url rather than the pathname.
