### PR TITLE
[WIP] Local import from umi

### DIFF
--- a/packages/umi-plugin-locale/README.md
+++ b/packages/umi-plugin-locale/README.md
@@ -41,16 +41,16 @@ export const locale = {
 
 ```
 .
-├── dist/                          
-├── mock/                         
-└── src/                          
-    ├── layouts/index.js          
-    ├── pages/                    
+├── dist/
+├── mock/
+└── src/
+    ├── layouts/index.js
+    ├── pages/
     └── locales               // 多语言文件存放目录，里面的文件会被umi自动读取
         ├── zh-CN.js
-        └── en-US.js               
-├── .umirc.js                     
-├── .env                          
+        └── en-US.js
+├── .umirc.js
+├── .env
 └── package.json
 ```
 
@@ -87,6 +87,7 @@ export default {
 
 ```javascript
 import { formatMessage, setLocale, getLocale, FormattedMessage } from 'umi-plugin-locale';
+// import { formatMessage, setLocale, getLocale, FormattedMessage } from 'umi';
 
 // 获取指定文字的多语言版本
 const formatedText = formatMessage({

--- a/packages/umi-plugin-locale/index.d.ts
+++ b/packages/umi-plugin-locale/index.d.ts
@@ -115,5 +115,5 @@ export declare function now(): number;
 export declare function onError(error: string): void;
 
 // umi-plugin-locale
-export declare function setLocale(lang: string): void;
+export declare function setLocale(lang: string, realReload: boolean): void;
 export declare function getLocale(): string;

--- a/packages/umi-plugin-locale/src/index.js
+++ b/packages/umi-plugin-locale/src/index.js
@@ -104,7 +104,7 @@ export default function(api, options = {}) {
   api.addUmiExports([
     {
       exportAll: true,
-      source: 'umi-plugin-locale/locale',
+      source: 'umi-plugin-locale',
     },
   ]);
 

--- a/packages/umi-plugin-locale/src/index.js
+++ b/packages/umi-plugin-locale/src/index.js
@@ -100,6 +100,14 @@ export default function(api, options = {}) {
       source: 'intl',
     });
   }
+
+  api.addUmiExports([
+    {
+      exportAll: true,
+      source: 'umi-plugin-locale/locale',
+    },
+  ]);
+
   api.addRuntimePluginKey('locale');
 
   api.addPageWatcher(join(paths.absSrcPath, config.singular ? 'locale' : 'locales'));

--- a/packages/umi-plugin-locale/test/index.test.js
+++ b/packages/umi-plugin-locale/test/index.test.js
@@ -11,6 +11,7 @@ const api = {
   addRendererWrapperWithComponent(func) {
     wrapperFile = func();
   },
+  addUmiExports() {},
   addPageWatcher() {},
   onOptionChange() {},
   addRuntimePluginKey() {},

--- a/packages/umi/test/fixtures/build/locale-runtime/src/page/index.js
+++ b/packages/umi/test/fixtures/build/locale-runtime/src/page/index.js
@@ -5,7 +5,7 @@ import {
   FormattedMessage,
   formatTime,
   formatDate,
-} from 'umi-plugin-locale';
+} from 'umi';
 import { DatePicker } from 'antd';
 import 'antd/lib/date-picker/style';
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change
## 现状
在js中，使用locals
```js
import { formatMessage, setLocale, getLocale, FormattedMessage } from 'umi-plugin-locale';
```
在ts中使用locals
```js
import { formatMessage, setLocale, getLocale, FormattedMessage } from 'umi-plugin-react/locale';
```
感觉都有点奇怪。
## 修改后
```js
import { formatMessage, setLocale, getLocale, FormattedMessage } from 'umi';
```
## 注意事项
typescript中，tsconfig.json需要设置
```json
"paths": {
      "@tmp/*": ["./src/pages/.umi/*"]
}
```
<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
