### PR TITLE
fix: open editor feature when click on error overlay

### DIFF
--- a/packages/af-webpack/src/errorOverlayMiddleware.js
+++ b/packages/af-webpack/src/errorOverlayMiddleware.js
@@ -4,7 +4,9 @@ import launchEditorEndpoint from 'react-dev-utils/launchEditorEndpoint';
 export default function createLaunchEditorMiddleware() {
   return function launchEditorMiddleware(req, res, next) {
     if (req.url.startsWith(launchEditorEndpoint)) {
-      launchEditor(req.query.fileName, req.query.lineNumber);
+      const lineNumber = parseInt(req.query.lineNumber, 10) || 1;
+
+      launchEditor(req.query.fileName, lineNumber);
       res.end();
     } else {
       next();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines


##### Description of change

修复点击报错代码打开编辑器功能。

![open-editor](https://user-images.githubusercontent.com/4370770/59019430-9fce5d00-887a-11e9-95e1-5c694b072a93.gif)

https://github.com/facebook/create-react-app/blob/a98337c257677bad0c7b235886d5dd6776c3c374/packages/react-dev-utils/launchEditor.js#L283-L285

```javascript
  if (!(Number.isInteger(lineNumber) && lineNumber > 0)) {
    return;
  }
```

`react-dev-utils/launchEditor.js` 中校验了 `lineNumber` 参数的类型，直接传入的话是个字符串，导致启动编辑器功能失败。

这里没有直接用 `react-dev-utils/errorOverlayMiddleware.js` 不知是出于什么考虑？二者并没有区别。

