### PR TITLE
refactor: skip lock core-js plugin if possible

### DIFF
--- a/packages/umi-build-dev/src/plugins/afwebpack-config/index.js
+++ b/packages/umi-build-dev/src/plugins/afwebpack-config/index.js
@@ -144,6 +144,11 @@ export default function(api) {
           return `${key} >= ${targets[key]}`;
         });
 
+    const plugins = [];
+    if (process.env.BABEL_POLYFILL !== 'none') {
+      plugins.push(require.resolve('./lockCoreJSVersionPlugin'));
+    }
+
     return {
       ...memo,
       ...config,
@@ -166,7 +171,7 @@ export default function(api) {
             },
           ],
         ],
-        plugins: [require.resolve('./lockCoreJSVersionPlugin')],
+        plugins,
       },
       define: {
         'process.env.BASE_URL': config.base || '/',

--- a/packages/umi-build-dev/src/plugins/targets.js
+++ b/packages/umi-build-dev/src/plugins/targets.js
@@ -38,26 +38,25 @@ export default function(api) {
     writeTmpFile();
   });
 
-  api.addEntryPolyfillImports(() => {
-    if (process.env.BABEL_POLYFILL !== 'none') {
+  if (process.env.BABEL_POLYFILL !== 'none') {
+    api.addEntryPolyfillImports(() => {
       return [
         {
           source: './polyfills',
         },
       ];
-    } else {
-      log.warn(
-        chalk.yellow(
-          `Since you have configured the environment variable ${chalk.bold(
-            'BABEL_POLYFILL',
-          )} to none, no patches will be included.`,
-        ),
-      );
-      return [];
-    }
-  });
+    });
 
-  api.chainWebpackConfig(config => {
-    config.resolve.alias.set('@babel/polyfill', require.resolve('@babel/polyfill'));
-  });
+    api.chainWebpackConfig(config => {
+      config.resolve.alias.set('@babel/polyfill', require.resolve('@babel/polyfill'));
+    });
+  } else {
+    log.warn(
+      chalk.yellow(
+        `Since you have configured the environment variable ${chalk.bold(
+          'BABEL_POLYFILL',
+        )} to none, no patches will be included.`,
+      ),
+    );
+  }
 }


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [ ] tests are included
- [x] commit message follows commit guidelines

##### Description of change

If user decides to turn of auto inclusion of `@babel/polyfill` with `BABEL_POLYIFLL=none`, skip the `lockCoreJSVersionPlugin.js` too.