### PR TITLE
fix: findRoute can't match when next router has routes

### DIFF
--- a/packages/umi-build-dev/src/findRoute.js
+++ b/packages/umi-build-dev/src/findRoute.js
@@ -1,11 +1,19 @@
 export default function findRoute(routes, path) {
-  let activeRoute;
-  routes.map(route => {
-    if (route.routes) {
-      activeRoute = findRoute(route.routes, path);
-    } else if (require('react-router-dom').matchPath(path, route)) {
-      activeRoute = route;
+  const flatRoutes = [];
+  const getFlatRoutes = list => {
+    if (!list) {
+      return;
     }
-  });
-  return activeRoute;
+    list.forEach(item => {
+      if (item.routes) {
+        getFlatRoutes(item.routes);
+      }
+      if (item.path && !flatRoutes.includes(item.path)) {
+        const { routes, ...itemRest } = item;
+        flatRoutes.push(itemRest);
+      }
+    });
+  };
+  getFlatRoutes(routes);
+  return flatRoutes.find(route => require('react-router-dom').matchPath(path, route));
 }

--- a/packages/umi-build-dev/src/findRoute.js
+++ b/packages/umi-build-dev/src/findRoute.js
@@ -8,7 +8,7 @@ export default function findRoute(routes, path) {
       if (item.routes) {
         getFlatRoutes(item.routes);
       }
-      if (item.path && !flatRoutes.includes(item.path)) {
+      if (item.path && !flatRoutes.find(r => r.path === item.path)) {
         const { routes, ...itemRest } = item;
         flatRoutes.push(itemRest);
       }

--- a/packages/umi-build-dev/src/findRoute.test.js
+++ b/packages/umi-build-dev/src/findRoute.test.js
@@ -7,13 +7,122 @@ test('normal', () => {
         {
           path: '/',
           component: 'layout',
-          routes: [{ path: '/', component: 'Home' }, { path: '/users', component: 'Users' }],
+          routes: [
+            {
+              path: '/',
+              component: 'Home',
+              exact: true,
+            },
+            { path: '/users', exact: true, component: 'Users' },
+          ],
         },
       ],
       '/users',
     ),
   ).toEqual({
     path: '/users',
+    exact: true,
     component: 'Users',
+  });
+});
+
+test('normal2', () => {
+  expect(
+    findRoute(
+      [
+        {
+          path: '/',
+          component: 'layout',
+          routes: [
+            {
+              path: '/',
+              component: 'Home',
+              exact: true,
+            },
+            {
+              path: '/about',
+              component: 'AboutLayout',
+              routes: [
+                {
+                  component: 'AboutIndex',
+                  path: '/about',
+                  exact: true,
+                },
+              ],
+            },
+            {
+              path: '/users',
+              component: 'Users',
+              // test here
+              routes: [
+                {
+                  path: '/users/test',
+                  component: 'UserTest',
+                  exact: true,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      '/about',
+    ),
+  ).toEqual({
+    path: '/about',
+    exact: true,
+    component: 'AboutIndex',
+  });
+});
+
+test('normal3 /about/:id', () => {
+  expect(
+    findRoute(
+      [
+        {
+          path: '/',
+          component: 'layout',
+          routes: [
+            {
+              path: '/',
+              component: 'Home',
+              exact: true,
+            },
+            {
+              path: '/about',
+              component: 'AboutLayout',
+              routes: [
+                {
+                  component: 'AboutIndex',
+                  path: '/about',
+                  exact: true,
+                },
+                {
+                  component: 'AboutDetail',
+                  path: '/about/:id',
+                  exact: true,
+                },
+              ],
+            },
+            {
+              path: '/users',
+              component: 'Users',
+              // test here
+              routes: [
+                {
+                  path: '/users/test',
+                  component: 'UserTest',
+                  exact: true,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      '/about/1',
+    ),
+  ).toEqual({
+    component: 'AboutDetail',
+    path: '/about/:id',
+    exact: true,
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

之前的写法，不支持后面一个路由有 `routes` ，需要改下。 #2543

@zhangyuang

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
