### PR TITLE
fix: umi block add 命令支持添加 window 环境下包的绝对路径

### DIFF
--- a/packages/umi-build-dev/src/plugins/commands/block/download.js
+++ b/packages/umi-build-dev/src/plugins/commands/block/download.js
@@ -101,7 +101,7 @@ export function getParsedData(url, blockConfig) {
   } else if (/^[\w]+[\w\-\/]*$/.test(url)) {
     realUrl = `${defaultGitUrl}/tree/master/${url}`;
     debug(`will use ${realUrl} as the block url`);
-  } else if (/^[\.\/]|^[a-zA-Z]:/.test(url)) {
+  } else if (/^[\.\/]|^[c-zC-Z]:/.test(url)) { // ^[c-zC-Z]:  目的是为了支持window下的绝对路径，比如 `C:\\Project\\umi`
     // locale path for test
     const sourcePath = resolve(process.cwd(), url);
     debug(`will use ${sourcePath} as the block url`);

--- a/packages/umi-build-dev/src/plugins/commands/block/download.js
+++ b/packages/umi-build-dev/src/plugins/commands/block/download.js
@@ -101,7 +101,7 @@ export function getParsedData(url, blockConfig) {
   } else if (/^[\w]+[\w\-\/]*$/.test(url)) {
     realUrl = `${defaultGitUrl}/tree/master/${url}`;
     debug(`will use ${realUrl} as the block url`);
-  } else if (/^[\.\/]/.test(url)) {
+  } else if (/^[\.\/]|^[a-zA-Z]:/.test(url)) {
     // locale path for test
     const sourcePath = resolve(process.cwd(), url);
     debug(`will use ${sourcePath} as the block url`);


### PR DESCRIPTION
修正了在window环境中使用“umi block add”命令添加绝对路径错误的问题
Fix an issue with adding an absolute path error using the 'umi block add' command in a window environment
