### PR TITLE
doc: autoprefixer

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -265,7 +265,7 @@ such as:
 chainWebpack(config, { webpack }) {
   // Set alias
   config.resolve.alias.set('a', 'path/to/a');
-  
+
   // Delete progress bar plugin
   config.plugins.delete('progress');
 }
@@ -456,7 +456,7 @@ Additional configuration items for [css-loader](https://github.com/webpack-contr
 Configuration for [autoprefixer](https://github.com/postcss/autoprefixer#options) .
 
 - Type: `Object`
-- Default: `{ browserslist, flexbox: 'no-2019' }`
+- Default: `{ browsers: DEFAULT_BROWSERS, flexbox: 'no-2019' }`
 
 If you want to be compatible with older versions of iOS Safari's flexbox, try to configure `flexbox: true`.
 

--- a/docs/zh/config/README.md
+++ b/docs/zh/config/README.md
@@ -267,7 +267,7 @@ export default {
 chainWebpack(config, { webpack }) {
   // 设置 alias
   config.resolve.alias.set('a', 'path/to/a');
-  
+
   // 删除进度条插件
   config.plugins.delete('progress');
 }
@@ -447,7 +447,7 @@ const config = {
 
 ### lessLoaderOptions
 
-给 [less-loader](https://github.com/webpack-contrib/less-loader) 的额外配置项。 
+给 [less-loader](https://github.com/webpack-contrib/less-loader) 的额外配置项。
 
 ### cssLoaderOptions
 
@@ -458,7 +458,7 @@ const config = {
 配置传给 [autoprefixer](https://github.com/postcss/autoprefixer#options) 的配置项。
 
 * 类型：`Object`
-* 默认：`{ browserslist, flexbox: 'no-2019' }`
+* 默认：`{ browsers: DEFAULT_BROWSERS, flexbox: 'no-2019' }`
 
 如果你想兼容旧版本 iOS Safari 的 flexbox，应该需要配置上 `flexbox: true`。
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

可能后面 umi 内部升级 `autoprefixer >= 9.6.0` 版本时，要把 `browsers` 改成 `overrideBrowserslist`。
[autoprefixer.js#L11](https://github.com/postcss/autoprefixer/blob/7980d0ac3ebb0d1adbbe6a75d248ca3702b2d5f3/lib/autoprefixer.js#L11)


<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
