### PR TITLE
feat: set stats report file path to process.cwd()

### DIFF
--- a/packages/af-webpack/package.json
+++ b/packages/af-webpack/package.json
@@ -75,7 +75,7 @@
     "typescript": "3.3.3",
     "uglifyjs-webpack-plugin": "1.3.0",
     "umi-url-pnp-loader": "1.1.2",
-    "umi-webpack-bundle-analyzer": "3.3.2",
+    "umi-webpack-bundle-analyzer": "^3.3.3",
     "webpack": "4.28.4",
     "webpack-chain": "5.2.0",
     "webpack-dev-server": "3.2.0",

--- a/packages/af-webpack/src/getConfig/index.js
+++ b/packages/af-webpack/src/getConfig/index.js
@@ -322,6 +322,7 @@ export default function(opts) {
           analyzerMode: 'disabled',  // 关闭 analyzer server
           generateReportFile: true,  // 开启报告生成功能
           reportDepth: 2,            // 裁剪深度 2
+          reportDir: process.cwd(),
           statsFilename: process.env.ANALYZE_DUMP || 'bundlestats.json' // 默认生成到 bundlestats.json
         }
     ]);

--- a/packages/af-webpack/test/build.test.js
+++ b/packages/af-webpack/test/build.test.js
@@ -90,7 +90,9 @@ describe('analyze report', () => {
         if (err) {
           done(err);
         }
-        expect(existsSync(join(root, 'dist/bundlestats.json')));
+        const statsFile = join(process.cwd(), 'bundlestats.json');
+        expect(existsSync(statsFile)).toBeTruthy();
+        rimraf.sync(statsFile);
         done();
       },
     );


### PR DESCRIPTION

##### Checklist

- [x] `npm test` passes
- [x] tests are included
- [x] commit message follows commit guidelines

- To preventing publish, `bundleStats.json` will generate to `process.cwd()` like `speedmesure.json`,