### PR TITLE
fix: don't tamper the original opts.extraBabelIncludes

### DIFF
--- a/packages/af-webpack/src/getConfig/index.js
+++ b/packages/af-webpack/src/getConfig/index.js
@@ -199,8 +199,7 @@ export default function(opts) {
 
   // module -> extraBabelIncludes
   // suport es5ImcompatibleVersions
-  const extraBabelIncludes = opts.extraBabelIncludes || [];
-  extraBabelIncludes.push(a => {
+  const extraBabelIncludes = (opts.extraBabelIncludes || []).concat(a => {
     if (!a.includes('node_modules')) return false;
     const pkgPath = getPkgPath(a);
     return shouldTransform(pkgPath);


### PR DESCRIPTION
...because the generated config is gonna be compared against the new version if use modifies config.

##### Checklist

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

create new copy of `opts.extraBabelIncludes` when adding custom include function to prevent false alarm on `extraBabelIncludes` when config change.
