### PR TITLE
Fix chunk map

### DIFF
--- a/docs/plugin/umi-plugin-prerender.md
+++ b/docs/plugin/umi-plugin-prerender.md
@@ -19,6 +19,7 @@ Configured in `.umirc.js`:
 ```js
 export default {
   ssr: true,
+  manifest: {},
   plugins: [['umi-plugin-prerender']],
 };
 ```

--- a/docs/zh/plugin/umi-plugin-prerender.md
+++ b/docs/zh/plugin/umi-plugin-prerender.md
@@ -19,6 +19,7 @@ $ yarn add umi-plugin-prerender --dev
 ```js
 export default {
   ssr: true,
+  manifest: {},
   plugins: [['umi-plugin-prerender']],
 };
 ```

--- a/packages/umi-build-dev/src/FilesGenerator.js
+++ b/packages/umi-build-dev/src/FilesGenerator.js
@@ -190,12 +190,12 @@ export default class FilesGenerator {
       `Conflict keys found in [${validKeys.join(', ')}]`,
     );
 
-    const htmlTemplateMap = [];
+    let htmlTemplateMap = [];
     if (config.ssr) {
       assert(config.manifest, `manifest must be config when using ssr`);
       const isProd = process.env.NODE_ENV === 'production';
       const routePaths = getRoutePaths(this.RoutesManager.routes);
-      routePaths.forEach(routePath => {
+      htmlTemplateMap = routePaths.map(routePath => {
         let ssrHtml = '<></>';
         const hg = getHtmlGenerator(this.service, {
           chunksMap: {
@@ -219,7 +219,7 @@ window.g_initialData = \${require('${require.resolve('serialize-javascript')}')(
           `<div id="${config.mountElementId || 'root'}"></div>`,
           `<div id="${config.mountElementId || 'root'}">{ rootContainer }</div>`,
         );
-        htmlTemplateMap.push(`'${routePath}': (${ssrHtml}),`);
+        return `'${routePath}': (${ssrHtml}),`;
       });
     }
 

--- a/packages/umi-build-dev/src/FilesGenerator.js
+++ b/packages/umi-build-dev/src/FilesGenerator.js
@@ -192,13 +192,18 @@ export default class FilesGenerator {
 
     const htmlTemplateMap = [];
     if (config.ssr) {
+      assert(config.manifest, `manifest must be config when using ssr`);
+      const isProd = process.env.NODE_ENV === 'production';
       const routePaths = getRoutePaths(this.RoutesManager.routes);
       routePaths.forEach(routePath => {
         let ssrHtml = '<></>';
         const hg = getHtmlGenerator(this.service, {
-          // TODO: read from assets.json
           chunksMap: {
-            umi: ['umi.js', 'umi.css'],
+            // placeholder waiting manifest
+            umi: [
+              isProd ? '__UMI_SERVER__.js' : 'umi.js',
+              isProd ? '__UMI_SERVER__.css' : 'umi.css',
+            ],
           },
           headScripts: [
             {

--- a/packages/umi-build-dev/src/plugins/commands/build/index.js
+++ b/packages/umi-build-dev/src/plugins/commands/build/index.js
@@ -2,6 +2,7 @@ import rimraf from 'rimraf';
 import notify from 'umi-notify';
 import getRouteManager from '../getRouteManager';
 import getFilesGenerator from '../getFilesGenerator';
+import replaceChunkMaps from '../replaceChunkMaps';
 
 export default function(api) {
   const { service, debug, config } = api;
@@ -48,6 +49,11 @@ export default function(api) {
                 if (process.env.RM_TMPDIR !== 'none') {
                   debug(`Clean tmp dir ${service.paths.tmpDirPath}`);
                   rimraf.sync(paths.absTmpDirPath);
+                }
+                if (service.ssrWebpackConfig) {
+                  // replace using manifest
+                  // __UMI_SERVER__.js/css => umi.${hash}.js/css
+                  replaceChunkMaps(service);
                 }
                 service.applyPlugins('onBuildSuccess', {
                   args: {

--- a/packages/umi-build-dev/src/plugins/commands/replaceChunkMaps.js
+++ b/packages/umi-build-dev/src/plugins/commands/replaceChunkMaps.js
@@ -30,8 +30,8 @@ export default (service, opts = {}) => {
   const umiServer = getServerContent(umiServerPath);
 
   const result = umiServer
-    .replace(/\/__UMI_SERVER__\.js/g, manifest['umi.js'])
-    .replace(/\/__UMI_SERVER__\.css/g, manifest['umi.css']);
+    .replace(/__UMI_SERVER__\.js/g, manifest['umi.js'].split('/').pop())
+    .replace(/__UMI_SERVER__\.css/g, manifest['umi.css'].split('/').pop());
 
   writeFileSync(umiServerPath, result, 'utf-8');
 };

--- a/packages/umi-build-dev/src/plugins/commands/replaceChunkMaps.js
+++ b/packages/umi-build-dev/src/plugins/commands/replaceChunkMaps.js
@@ -1,0 +1,37 @@
+import { join } from 'path';
+import { readFileSync, existsSync, writeFileSync } from 'fs';
+
+export const getAssetsManifest = service => {
+  const { paths, config } = service;
+  const { fileName = 'asset-manifest.json' } = config.manifest;
+  const { absOutputPath } = paths;
+  const manifestPath = join(absOutputPath, fileName);
+  if (existsSync(manifestPath)) {
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+    return manifest;
+  }
+  return {};
+};
+
+export const getServerContent = umiServerPath => {
+  if (existsSync(umiServerPath)) {
+    const content = readFileSync(umiServerPath, 'utf-8');
+    return content;
+  }
+  return '';
+};
+
+export default (service, opts = {}) => {
+  const { paths } = service;
+  const { absOutputPath } = paths;
+  const manifest = getAssetsManifest(service);
+
+  const umiServerPath = join(absOutputPath, 'umi.server.js');
+  const umiServer = getServerContent(umiServerPath);
+
+  const result = umiServer
+    .replace(/\/__UMI_SERVER__\.js/g, manifest['umi.js'])
+    .replace(/\/__UMI_SERVER__\.css/g, manifest['umi.css']);
+
+  writeFileSync(umiServerPath, result, 'utf-8');
+};


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

背景 https://github.com/umijs/umi/pull/2543#issuecomment-502342760

方案是：
- webpack build 时，server 和 client 同时运行，`chunkMaps` 里的资源用占位符 `__UMI_SERVER__` 代替，server 的 map 是 `/__UMI_SERVER__.js/css`。
- server 和 client 构建完成后，执行 `replaceChunkMaps` 方法，将 `umi.server.js` 中的占位符里替换成 `manifest` 中正确的文件名


<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
