### PR TITLE
fix: eslint's react version warning and babel-eslint dep lost

### DIFF
--- a/packages/af-webpack/package.json
+++ b/packages/af-webpack/package.json
@@ -16,6 +16,7 @@
     "address": "1.1.0",
     "assert": "1.4.1",
     "autoprefixer": "9.6.0",
+    "babel-eslint": "10.0.2",
     "babel-loader": "8.0.6",
     "babel-plugin-dynamic-import-node": "2.2.0",
     "babel-plugin-named-asset-import": "0.3.2",

--- a/packages/af-webpack/yarn.lock
+++ b/packages/af-webpack/yarn.lock
@@ -221,7 +221,7 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.4.4", "@babel/parser@^7.4.5":
+"@babel/parser@^7.0.0", "@babel/parser@^7.4.4", "@babel/parser@^7.4.5":
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.5.tgz#04af8d5d5a2b044a2a1bffacc1e5e6673544e872"
   integrity sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==
@@ -702,7 +702,7 @@
     "@babel/parser" "^7.4.4"
     "@babel/types" "^7.4.4"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.4.4", "@babel/traverse@^7.4.5":
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.4.4", "@babel/traverse@^7.4.5":
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.5.tgz#4e92d1728fd2f1897dafdd321efbff92156c3216"
   integrity sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==
@@ -1301,6 +1301,18 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     chalk "^1.1.3"
     esutils "^2.0.2"
     js-tokens "^3.0.2"
+
+babel-eslint@10.0.2:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.2.tgz#182d5ac204579ff0881684b040560fdcc1558456"
+  integrity sha512-UdsurWPtgiPgpJ06ryUnuaSXC2s0WoSZnQmEpbAH65XZSdwowgN5MvyP7e88nW07FYXv72erVtpBkxyDVKhH1Q==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    eslint-scope "3.7.1"
+    eslint-visitor-keys "^1.0.0"
 
 babel-loader@8.0.6:
   version "8.0.6"
@@ -2973,6 +2985,14 @@ eslint-plugin-react@7.13.0:
     object.fromentries "^2.0.0"
     prop-types "^15.7.2"
     resolve "^1.10.1"
+
+eslint-scope@3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  integrity sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
 
 eslint-scope@^4.0.0, eslint-scope@^4.0.3:
   version "4.0.3"

--- a/packages/eslint-config-umi/src/index.js
+++ b/packages/eslint-config-umi/src/index.js
@@ -10,4 +10,9 @@ export default {
     'react/react-in-jsx-scope': [0],
     'no-useless-escape': [0],
   },
+  settings: {
+    react: {
+      version: '16.8',
+    },
+  },
 };

--- a/packages/umi-core/src/error.js
+++ b/packages/umi-core/src/error.js
@@ -31,7 +31,7 @@ export function printUmiError(e, opts = {}) {
   if (!code) {
     for (const c of Object.keys(errorCodeMap)) {
       const { test } = errorCodeMap[c];
-      if (test({ error: e, context })) {
+      if (test && test({ error: e, context })) {
         code = c;
       }
     }

--- a/scripts/startDevServers.js
+++ b/scripts/startDevServers.js
@@ -6,11 +6,12 @@ const DEV_SCRIPT = join(__dirname, '../packages/umi/bin/umi.js');
 function startDevServer(opts = {}) {
   const { port, cwd } = opts;
   return new Promise(resolve => {
+    console.log(`Start dev server for ${cwd}`);
     const child = fork(DEV_SCRIPT, ['dev', '--port', port, '--cwd', cwd], {
       env: {
         ...process.env,
-        CLEAR_CONSOLE: 'none',
         BROWSER: 'none',
+        PROGRESS: 'none',
         UMI_DIR: dirname(require.resolve('../packages/umi/package')),
       },
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- react version 警告
- babel-eslint 丢失
- eslint 报错后不能显示到浏览器里
