### PR TITLE
fix(umi-build-dev): make moduleBeforeRendererPromises available for entry code

### DIFF
--- a/packages/umi-build-dev/template/entry.js.tpl
+++ b/packages/umi-build-dev/template/entry.js.tpl
@@ -28,9 +28,9 @@ let clientRender = async () => {
 };
 const render = plugins.compose('render', { initialValue: clientRender });
 
+const moduleBeforeRendererPromises = [];
 // client render
 if (__IS_BROWSER) {
-  const moduleBeforeRendererPromises = [];
   {{# moduleBeforeRenderer }}
   if (typeof {{ specifier }} === 'function') {
     const promiseOf{{ specifier }} = {{ specifier }}();


### PR DESCRIPTION
umi-plugin-qiankun 会添加 entryCode，而 entryCode 内容依赖 moduleBeforeRendererPromises 
see https://github.com/umijs/umi-plugin-qiankun/blob/master/src/plugins/slave/index.ts#L59