### PR TITLE
fix: css module id conflicts when use dll plugin

### DIFF
--- a/packages/af-webpack/src/getConfig/css.js
+++ b/packages/af-webpack/src/getConfig/css.js
@@ -72,13 +72,23 @@ export default function(webpackConfig, opts) {
 
   function applyCSSRules(rule, { cssModules, less, sass }) {
     if (!opts.ssr) {
-      rule
-        .use('extract-css-loader')
-          .loader(require('mini-css-extract-plugin').loader)
+      if (opts.styleLoader) {
+        rule
+          .use('style-loader')
+          .loader(require.resolve('style-loader'))
           .options({
-            publicPath: isDev ? '/' : opts.cssPublicPath,
-            hmr: isDev,
+            base: opts.styleLoader.base || 0,
+            convertToAbsoluteUrls: true,
           });
+      } else {
+        rule
+          .use('extract-css-loader')
+            .loader(require('mini-css-extract-plugin').loader)
+            .options({
+              publicPath: isDev ? '/' : opts.cssPublicPath,
+              hmr: isDev,
+            });
+      }
     }
     // https://github.com/webpack-contrib/mini-css-extract-plugin/issues/90
     let cssLoader = opts.cssLoaderVersion === 2
@@ -246,7 +256,7 @@ export default function(webpackConfig, opts) {
   );
 
   const hash = !isDev && opts.hash ? '.[contenthash:8]' : '';
-  if (!opts.ssr) {
+  if (!opts.ssr && !opts.styleLoader) {
     webpackConfig.plugin('extract-css').use(require('mini-css-extract-plugin'), [
       {
         filename: `[name]${hash}.css`,

--- a/packages/umi-plugin-dll/src/buildDll.js
+++ b/packages/umi-plugin-dll/src/buildDll.js
@@ -52,6 +52,9 @@ export default function(opts = {}) {
       disableBabelTransform: true,
       alias: {},
       babel: {},
+      styleLoader: {
+        base: 1000,
+      },
     },
   });
   const afWebpackConfig = require(_resolveDeps('af-webpack/getConfig')).default(afWebpackOpts);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

![111](https://user-images.githubusercontent.com/35128/59997473-c0c2ea80-968f-11e9-8cc5-9ea62eeb8c6b.gif)

- 修复 id 冲突问题，但在 dev 时且开启 dll 之后初始加载会闪一下（css 有个动态加载的过程）
- close https://github.com/ant-design/ant-design-pro/issues/4537
