### PR TITLE
fix getLocale() return undefined

### DIFF
--- a/packages/umi-plugin-locale/src/locale.js
+++ b/packages/umi-plugin-locale/src/locale.js
@@ -30,7 +30,7 @@ function setLocale(lang, realReload = true) {
 
 function getLocale() {
   const lang = window.localStorage.getItem('umi_locale');
-  return lang || window.g_lang;
+  return lang || window.g_lang || navigator.language;
 }
 
 const LangContext = React.createContext({


### PR DESCRIPTION
在第一次进入页面时，`getLocale()` 会返回 `undefined`。