### PR TITLE
fix: dynamic locale change won’t trigger re-render

### DIFF
--- a/packages/umi-plugin-locale/template/wrapper.jsx.tpl
+++ b/packages/umi-plugin-locale/template/wrapper.jsx.tpl
@@ -110,7 +110,7 @@ class LocaleWrapper extends React.Component{
     };
     let ret = this.props.children;
     {{#localeList.length}}
-    ret = (<IntlProvider locale={appLocale.locale} messages={appLocale.messages}>
+    ret = (<IntlProvider locale={appLocale.locale} key={appLocale.locale} messages={appLocale.messages}>
       <InjectedWrapper>
         <LangContext.Provider value={LangContextValue}>
           <LangContext.Consumer>{(value) => {


### PR DESCRIPTION
**场景**
1. `yarn create umi` + ant-design-pro 初始化项目
2. 使用 `umi block list` 添加 ant-design-pro 基础表单组件
2. 使用 `umi-plugin-locale` 插件进行国际化

**问题**

动态切换语言时，父组件的语言改变了，但子组件不会改变。（未触发重渲染）

**解决方法**

查阅 react-intl 官方文档后，发现有对这种情况的说明：[dynamic-language-selection](https://github.com/formatjs/react-intl/blob/master/docs/Components.md#dynamic-language-selection)

即：要触发子组件的重渲染，在 `<IntlProvider />` 上添加个 key 即可。（ key 的变化会触发重渲染）

改动很简单：


```diff
# umi-plugin-locale/template/wrapper.jsx.tpl

- <IntlProvider locale={localeProp} messages={messagesProp}>
+ <IntlProvider locale={localeProp} key={localeProp} messages={messagesProp}>
  <App />
</IntlProvider>
```

- [x]  npm test passes
- [x]  tests are included
- [x]  documentation is changed or added
- [x]  commit message follows commit guidelines