### PR TITLE
serverRender 使用 activeRoute.path 替换 pathname 作为 htmlTemplateMap 数组的索引

### DIFF
--- a/packages/umi-build-dev/template/entry.js.tpl
+++ b/packages/umi-build-dev/template/entry.js.tpl
@@ -78,7 +78,7 @@ if (!__IS_BROWSER) {
       {{{ htmlTemplateMap }}}
     };
     return {
-      htmlElement: htmlTemplateMap[pathname],
+      htmlElement: htmlTemplateMap[activeRoute.path],
       rootContainer,
     };
   }


### PR DESCRIPTION
# fix: The index of htmlTemplateMap should be activeRoute.path rather than pathname
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change
在服务端渲染时，动态的路由的 ```pathname``` 往往和  ```route``` 配置的不一致 ```path```（eg.: route 配置为```account/:id```, 实际匹配的路径```pathname```可能为 ```account/12```）导致serverRender 方法返回的 ```htmlElement``` 为 undefined。 导致服务端渲染失败。

ref issue: https://github.com/umijs/umi/issues/2770