### PR TITLE
fix: refactoring dva dependencies import

### DIFF
--- a/packages/umi-plugin-dva/src/index.js
+++ b/packages/umi-plugin-dva/src/index.js
@@ -159,14 +159,18 @@ app.use(require('${winPath(require.resolve('dva-immer'))}')());
     generateInitDva();
   });
 
-  api.modifyRouterRootComponent(`require('dva/router').routerRedux.ConnectedRouter`);
+  const importFromDva = ['routerRedux'];
 
   if (shouldImportDynamic) {
-    api.addRouterImport({
-      source: 'dva/dynamic',
-      specifier: '_dvaDynamic',
-    });
+    importFromDva.push('dynamic as _dvaDynamic');
   }
+
+  api.addRouterImport({
+    source: 'dva',
+    specifier: `{ ${importFromDva.join(', ')} }`,
+  });
+
+  api.modifyRouterRootComponent(`routerRedux.ConnectedRouter`);
 
   if (shouldImportDynamic) {
     api.modifyRouteComponent((memo, args) => {

--- a/packages/umi-plugin-dva/src/index.js
+++ b/packages/umi-plugin-dva/src/index.js
@@ -69,10 +69,12 @@ function isEsmVersion(version) {
 
 function handleDvaDependencyImport(api, { dvaVersion, shouldImportDynamic }) {
   let modifyRouterRootComponentValue = `require('dva/router').routerRedux.ConnectedRouter`;
-  let addRouterImportValue = {
-    source: 'dva/dynamic',
-    specifier: '_dvaDynamic',
-  };
+  let addRouterImportValue = shouldImportDynamic
+    ? {
+        source: 'dva/dynamic',
+        specifier: '_dvaDynamic',
+      }
+    : null;
 
   // esm 版本
   if (isEsmVersion(dvaVersion)) {
@@ -90,7 +92,9 @@ function handleDvaDependencyImport(api, { dvaVersion, shouldImportDynamic }) {
     modifyRouterRootComponentValue = `routerRedux.ConnectedRouter`;
   }
 
-  api.addRouterImport(addRouterImportValue);
+  if (addRouterImportValue) {
+    api.addRouterImport(addRouterImportValue);
+  }
 
   api.modifyRouterRootComponent(modifyRouterRootComponentValue);
 }


### PR DESCRIPTION
Close #2672 
Close #2753 

重构 dva 的依赖项导入处理

fix ``` Please use `require("dva").xxx` instead of `require("dva/xxx")` ```

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->
- close https://github.com/umijs/umi/issues/2672
- close https://github.com/umijs/umi/issues/2753
