### PR TITLE
fix: lang 正则匹配问题

### DIFF
--- a/packages/umi-plugin-locale/src/locale.js
+++ b/packages/umi-plugin-locale/src/locale.js
@@ -5,7 +5,7 @@ const React = require('react');
 let localeContext;
 
 function setLocale(lang, realReload = true) {
-  if (lang !== undefined && !/^([a-z]{2})-([A-Z]{2})$/.test(lang)) {
+  if (lang !== undefined && !/^([a-z]{2})(-([A-Z]{2})|)$/.test(lang)) {
     // for reset when lang === undefined
     throw new Error('setLocale lang format error');
   }


### PR DESCRIPTION
有时候需求语言就是de,fr，而不是en-US的这种，并不需要精确到国家，这种需求 react-intl 也是支持的

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->
有时候需求语言就是de,fr，而不是en-US的这种，并不需要精确到国家，这种需求 react-intl 也是支持的
- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
