### PR TITLE
fix(umi-build-dev): unlisten the history listener automatically while app unmount

### DIFF
--- a/packages/umi-build-dev/template/router.js.tpl
+++ b/packages/umi-build-dev/template/router.js.tpl
@@ -15,23 +15,37 @@ window.g_routes = routes;
 const plugins = require('umi/_runtimePlugin');
 plugins.applyForEach('patchRoutes', { initialValue: routes });
 
-// route change handler
-function routeChangeHandler(location, action) {
-  plugins.applyForEach('onRouteChange', {
-    initialValue: {
-      routes,
-      location,
-      action,
-    },
-  });
-}
-history.listen(routeChangeHandler);
-routeChangeHandler(history.location);
-
 export { routes };
 
-export default function RouterWrapper(props = {}) {
-  return (
-{{{ routerContent }}}
-  );
+export default class RouterWrapper extends React.Component {
+
+  unListen = () => {};
+
+  constructor(props) {
+    super(props);
+
+    // route change handler
+    function routeChangeHandler(location, action) {
+      plugins.applyForEach('onRouteChange', {
+        initialValue: {
+          routes,
+          location,
+          action,
+        },
+      });
+    }
+    this.unListen = history.listen(routeChangeHandler);
+    routeChangeHandler(history.location);
+  }
+
+  componentWillUnmount() {
+    this.unListen();
+  }
+
+  render() {
+    const props = this.props || {};
+    return (
+      {{{ routerContent }}}
+    );
+  }
 }


### PR DESCRIPTION
开启 disableGlobalVariables 后由于没有 window.g_history，导致 qiankun 的 history 监听失效，从而不能正确的卸载 history

合理的做法应该是 Router 卸载后自动 unlisten 掉相应的监听