### PR TITLE
fix: upperCamelCase block import identifier

### DIFF
--- a/packages/umi-build-dev/src/plugins/commands/block/insertComponent.js
+++ b/packages/umi-build-dev/src/plugins/commands/block/insertComponent.js
@@ -4,6 +4,7 @@ import generate from '@babel/generator';
 import * as t from '@babel/types';
 import prettier from 'prettier';
 import { findLastIndex } from 'lodash';
+import upperCamelCase from 'uppercamelcase';
 
 function insertComponentToRender(blockStatement, identifier) {
   // blockStatement: https://babeljs.io/docs/en/babel-types#blockstatement
@@ -17,9 +18,10 @@ function insertComponentToRender(blockStatement, identifier) {
 }
 
 function insertComponentToElement(element, identifier) {
+  // why use upperCamelCase: a react component name must be upperCamelCase
   // https://babeljs.io/docs/en/babel-types#jsxelement
   const newElement = t.jsxElement(
-    t.jsxOpeningElement(t.jsxIdentifier(identifier), [], true),
+    t.jsxOpeningElement(t.jsxIdentifier(upperCamelCase(identifier)), [], true),
     null,
     [],
     true,
@@ -40,7 +42,7 @@ export default function(content, { relativePath, identifier }) {
         return t.isImportDeclaration(item);
       });
       const newImport = t.ImportDeclaration(
-        [t.ImportDefaultSpecifier(t.identifier(identifier))],
+        [t.ImportDefaultSpecifier(t.identifier(upperCamelCase(identifier)))],
         t.stringLiteral(relativePath),
       );
       body.splice(lastImportSit + 1, 0, newImport);

--- a/packages/umi-build-dev/src/plugins/commands/block/insertComponent.test.js
+++ b/packages/umi-build-dev/src/plugins/commands/block/insertComponent.test.js
@@ -153,4 +153,29 @@ export default () => (
 );
 `);
   });
+
+  it('insert with upperCamelCase identifier', () => {
+    const code = `import React from 'react';
+import Demo1 from './Demo1';
+export default () => (
+  <React.Fragment>
+    <Demo />
+  </React.Fragment>
+);
+`;
+    const result = insert(code, {
+      relativePath: './folder-name',
+      identifier: 'folder-name',
+    });
+    expect(result).toEqual(`import React from 'react';
+import Demo1 from './Demo1';
+import FolderName from './folder-name';
+export default () => (
+  <React.Fragment>
+    <Demo />
+    <FolderName />
+  </React.Fragment>
+);
+`);
+  });
 });


### PR DESCRIPTION

##### Checklist

- [x] `npm test` passes
- [x] tests are included
- [x] commit message follows commit guidelines


##### Description of change

default set upperCamelCase for block import identifier for avoid react component grammar error.
