### PR TITLE
fix: 修复windows 平台，Mock文件不能热更新的问题

### DIFF
--- a/packages/umi-mock/package.json
+++ b/packages/umi-mock/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "body-parser": "1.19.0",
     "chokidar": "3.0.2",
+    "clear-module": "^4.0.0",
     "glob": "7.1.4",
     "multer": "^1.4.1",
     "path-to-regexp": "1.7.0",

--- a/packages/umi-mock/src/createMiddleware.js
+++ b/packages/umi-mock/src/createMiddleware.js
@@ -2,6 +2,7 @@ import { basename, join } from 'path';
 import chokidar from 'chokidar';
 import signale from 'signale';
 import { winPath } from 'umi-utils';
+import clearModule from 'clear-module';
 import matchMock from './matchMock';
 import getMockData from './getMockData';
 import getPaths from './getPaths';
@@ -32,22 +33,10 @@ export default function(opts = {}) {
     watcher.on('all', (event, file) => {
       debug(`[${event}] ${file}, reload mock data`);
       errors.splice(0, errors.length);
-      cleanRequireCache();
+      clearModule(file);
       fetchMockData();
       if (!errors.length) {
         signale.success(`Mock files parse success`);
-      }
-    });
-  }
-
-  function cleanRequireCache() {
-    Object.keys(require.cache).forEach(file => {
-      if (
-        paths.some(path => {
-          return file.indexOf(path) > -1;
-        })
-      ) {
-        delete require.cache[file];
       }
     });
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

发现module cache 在 Windows 和 Linux 平台有些不同，所以导致文件更改后，mock文件并没有重新加载。因不知这种如何写测试，所以自己在两平台手动测试了。 close [#2796](https://github.com/umijs/umi/issues/2796)
