### PR TITLE
fix: module not found for umi dev when global install via cnpm

### DIFF
--- a/packages/umi-build-dev/src/plugins/afwebpack-config/index.js
+++ b/packages/umi-build-dev/src/plugins/afwebpack-config/index.js
@@ -65,7 +65,8 @@ export default function(api) {
         ),
       )
       .set('@', paths.absSrcPath)
-      .set('@tmp', paths.absTmpDirPath);
+      .set('@tmp', paths.absTmpDirPath)
+      .set('umi', process.env.UMI_DIR);
   });
 
   /* eslint-disable import/no-dynamic-require */


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- umi@2.8 后全局安装 umi 时出现
- 试过 cnpm/tnpm 复现，yarn 未复现，npm 未尝试
- close #2791
