### PR TITLE
fix: locale detection for lang only locales

### DIFF
--- a/packages/umi-plugin-locale/examples/base/src/locale/sk.js
+++ b/packages/umi-plugin-locale/examples/base/src/locale/sk.js
@@ -1,0 +1,3 @@
+export default {
+  test: 'test sk {name}',
+};

--- a/packages/umi-plugin-locale/examples/base/src/page/temp/locale/sk.js
+++ b/packages/umi-plugin-locale/examples/base/src/page/temp/locale/sk.js
@@ -1,0 +1,3 @@
+export default {
+  test2: 'test sk {name}',
+};

--- a/packages/umi-plugin-locale/src/index.js
+++ b/packages/umi-plugin-locale/src/index.js
@@ -25,7 +25,7 @@ function getMomentLocale(lang, country) {
 
 // export for test
 export function getLocaleFileList(absSrcPath, absPagesPath, singular) {
-  const localeFileMath = /^([a-z]{2})-([A-Z]{2})\.(js|ts)$/;
+  const localeFileMath = /^([a-z]{2})-?([A-Z]{2})?\.(js|ts)$/;
   const localeFolder = singular ? 'locale' : 'locales';
   const localeFiles = globby
     .sync('*.{ts,js}', {
@@ -42,9 +42,12 @@ export function getLocaleFileList(absSrcPath, absPagesPath, singular) {
     .filter(p => localeFileMath.test(basename(p)))
     .map(fullname => {
       const fileName = basename(fullname);
-      const fileInfo = localeFileMath.exec(fileName);
+      const fileInfo = localeFileMath
+        .exec(fileName)
+        .slice(1, 3)
+        .filter(Boolean);
       return {
-        name: `${fileInfo[1]}-${fileInfo[2]}`,
+        name: fileInfo.join('-'),
         path: fullname,
       };
     });
@@ -54,9 +57,9 @@ export function getLocaleFileList(absSrcPath, absPagesPath, singular) {
     return {
       lang: fileInfo[0],
       name,
-      country: fileInfo[1],
+      country: fileInfo[1] || fileInfo[0].toUpperCase(),
       paths: groups[name].map(item => winPath(item.path)),
-      momentLocale: getMomentLocale(fileInfo[0], fileInfo[1]),
+      momentLocale: getMomentLocale(fileInfo[0], fileInfo[1] || ''),
     };
   });
 }

--- a/packages/umi-plugin-locale/test/index.test.js
+++ b/packages/umi-plugin-locale/test/index.test.js
@@ -75,6 +75,13 @@ describe('test func with singular true', () => {
         momentLocale: '',
       },
       {
+        lang: 'sk',
+        country: 'SK',
+        name: 'sk',
+        paths: [`${absSrcPath}/locale/sk.js`, `${absPagesPath}/temp/locale/sk.js`],
+        momentLocale: 'sk',
+      },
+      {
         lang: 'zh',
         country: 'CN',
         name: 'zh-CN',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

![image](https://user-images.githubusercontent.com/359450/62819840-22b1b380-bb5b-11e9-9d37-abdff8aa8c43.png)


##### Description of change

<!-- Provide a description of the change below this comment. -->

This PR is fix for incorrect locale detection for locales with language code only (like 'sk') as described in https://github.com/umijs/umi/issues/2972

- close https://github.com/umijs/umi/issues/2972
