### PR TITLE
修复  cssModulesExcludes 为正则时通不过 extname 的 string 类型 aseerts 的问题

### DIFF
--- a/packages/af-webpack/src/getConfig/css.js
+++ b/packages/af-webpack/src/getConfig/css.js
@@ -145,6 +145,7 @@ export default function(webpackConfig, opts) {
           return filePath.indexOf(exclude) > -1;
         }
       });
+      exclude = exclude.toString();
       const ext = extname(exclude).toLowerCase();
       applyCSSRules(config, {
         less: ext === '.less',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
