### PR TITLE
feat: add env CLEAR_OUTPUT

### DIFF
--- a/docs/guide/env-variables.md
+++ b/docs/guide/env-variables.md
@@ -149,6 +149,10 @@ $ BROWSER=none umi dev
 
 The default is cleared. If the value is none, the screen is not cleared.
 
+### CLEAR_OUTPUT
+
+The output directory will be removed by default before each build, you can set it to `"none"` to avoid it to be removed.
+
 ### HMR
 
 The HMR is enabled by default, the value is disabled when none, and the value is refreshed when the file changes when reload.

--- a/docs/zh/guide/env-variables.md
+++ b/docs/zh/guide/env-variables.md
@@ -147,6 +147,10 @@ $ BROWSER=none umi dev
 
 默认清屏，值为 none 时不清屏。
 
+### CLEAR_OUTPUT
+
+默认情况下，输出目录会在每次构建之前被清除，当此值为 `none` 时则不会执行此操作。
+
 ### HMR
 
 默认开启 HMR，值为 none 时禁用，值为 reload 时文件有变化时刷新浏览器。

--- a/packages/af-webpack/src/build.js
+++ b/packages/af-webpack/src/build.js
@@ -23,9 +23,11 @@ export default function build(opts = {}) {
   );
 
   // 清理 output path
-  const outputPath = getOutputPath(webpackConfig);
-  debug(`Clean output path ${outputPath.replace(`${cwd}/`, '')}`);
-  rimraf.sync(outputPath);
+  if (process.env.CLEAR_OUTPUT !== 'none') {
+    const outputPath = getOutputPath(webpackConfig);
+    debug(`Clean output path ${outputPath.replace(`${cwd}/`, '')}`);
+    rimraf.sync(outputPath);
+  }
 
   debug('build start');
   webpack(webpackConfig, (err, stats) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?

Add a new env `UMI_DO_NOT_CLEAN_OUTPUT` to make is possible to tell `build` process not to remove the dist files.

- close https://github.com/umijs/umi/issues/2448
