### PR TITLE
Revert "fix: LocaleProvider warning after antd@3.21 (#2941)"

### DIFF
--- a/packages/umi-plugin-locale/template/wrapper.jsx.tpl
+++ b/packages/umi-plugin-locale/template/wrapper.jsx.tpl
@@ -33,7 +33,7 @@ const baseNavigator = {{{baseNavigator}}};
 const useLocalStorage = {{{useLocalStorage}}};
 
 {{#antd}}
-import { ConfigProvider, LocaleProvider, version } from 'antd';
+import { LocaleProvider } from 'antd';
 import moment from 'moment';
 {{#defaultMomentLocale}}
 import 'moment/locale/{{defaultMomentLocale}}';
@@ -122,14 +122,9 @@ class LocaleWrapper extends React.Component{
     </IntlProvider>)
     {{/localeList.length}}
     {{#antd}}
-     const [major, minor] = `${version || ''}`.split('.');
-     // antd 3.21.0 use ConfigProvider not LocaleProvider
-     const isConfigProvider = Number(major) > 3 || (Number(major) >= 3 && Number(minor) >= 21);
-     const AntdProvider = isConfigProvider ? ConfigProvider : LocaleProvider;
-
-     return (<AntdProvider locale={appLocale.antd ? (appLocale.antd.default || appLocale.antd) : defaultAntd}>
+     return (<LocaleProvider locale={appLocale.antd ? (appLocale.antd.default || appLocale.antd) : defaultAntd}>
       {ret}
-    </AntdProvider>);
+    </LocaleProvider>);
     {{/antd}}
     return ret;
   }

--- a/packages/umi-plugin-locale/test/index.test.js
+++ b/packages/umi-plugin-locale/test/index.test.js
@@ -38,7 +38,7 @@ describe('test plugin', () => {
 
     const ret = readFileSync(wrapperFile, 'utf-8');
 
-    expect(ret).toEqual(expect.stringContaining('<AntdProvider'));
+    expect(ret).toEqual(expect.stringContaining('<LocaleProvider'));
     expect(ret).toEqual(expect.stringContaining('<IntlProvider'));
     expect(ret).toEqual(expect.stringContaining('<IntlProvider'));
     expect(ret).toEqual(expect.stringContaining('antd/lib/locale-provider/en_US'));
@@ -56,7 +56,7 @@ test('antd is false', () => {
 
   const ret = readFileSync(wrapperFile, 'utf-8');
 
-  expect(ret).not.toEqual(expect.stringContaining('<ConfigProvider'));
+  expect(ret).not.toEqual(expect.stringContaining('<LocaleProvider'));
   expect(ret).toEqual(expect.stringContaining('<IntlProvider'));
   expect(ret).not.toEqual(expect.stringContaining('antd/lib/locale-provider/zh_CN'));
   expect(ret).not.toEqual(expect.stringContaining('moment/locale/zh-cn'));


### PR DESCRIPTION
This reverts commit e35aaaa25c60a8a9f30871c7751565a073648014.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
