### PR TITLE
feat: expose internal "styleLoader" option.

### DIFF
--- a/packages/af-webpack/src/getUserConfig/configs/styleLoader.js
+++ b/packages/af-webpack/src/getUserConfig/configs/styleLoader.js
@@ -1,0 +1,14 @@
+import assert from 'assert';
+import { isPlainObject } from 'lodash';
+
+export default function() {
+  return {
+    name: 'styleLoader',
+    validate(val) {
+      assert(
+        isPlainObject(val),
+        `The styleLoader config must be Plain Object, but got ${val}`,
+      );
+    },
+  };
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature? 

Giving the ability for users to quickly leverage `style-loader` instead of `mini-extract-css-plugin`.

Users'll have 3 ways to enable and modify the options of `style-loader` without using `chanWebpack`:

### 1 `.umirc.js`

```js
module.exports = {
   styleLoader: {}
}
```

### 2 Plugin API - modifyAFWebpackOpts

```js
api.modifyAFWebpackOpts(memo => {
  return Object.assign(memo, {
    styleLoader: {}
  })
})
```

### 3 Plugin API - modifyDefaultConfig

```js
api.modifyDefaultConfig(memo => {
  return Object.assign(memo, {
    styleLoader: {}
  })
})
```

---

### Why umi configurations can be used for `af-webpack` ？

https://github.com/umijs/umi/blob/5e1b507e8916e6d5cca23bd30b7eca089eeef824/packages/umi-build-dev/src/plugins/afwebpack-config/index.js#L135-L137

---

### Related to https://github.com/umijs/umi/2320

Since `style-loader` has reach [1.0.0](https://github.com/webpack-contrib/style-loader/blob/master/CHANGELOG.md#100-2019-08-06):

> The `style-loader/useable` loader was removed in favor injectType option (look the documentation about the injectType option)

Once we upgrade to 1.0.0, for #2320 we can just configure like this:

```js
module.exports = {
   styleLoader: {
       injectType: 'lazyStyleTag'
   }
}
```

But it isn't a good practice (at least for me.), for more details please head [style-loader > lazyStyleTag](https://github.com/webpack-contrib/style-loader#lazystyletag)
