### PR TITLE
feat: do not exit process when build is under watch mode

### DIFF
--- a/packages/af-webpack/src/build.js
+++ b/packages/af-webpack/src/build.js
@@ -35,7 +35,12 @@ export default function build(opts = {}) {
       if (onFail) {
         onFail({ err, stats });
       }
-      if (!process.env.UMI_TEST) {
+      
+      const isWatch = isPlainObject(webpackConfig)
+        ? webpackConfig.watch
+        : webpackConfig.some(config => config.watch) /* array */
+
+      if (!process.env.UMI_TEST && !isWatch) {
         process.exit(1);
       }
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?

`umi` shouldn't exit current build process when users enable `watch` under build.

- close https://github.com/umijs/umi/ISSUE_URL
