### PR TITLE
fix: umi ssr dev when add independent entry

### DIFF
--- a/packages/umi-build-dev/src/getWebpackConfig.ts
+++ b/packages/umi-build-dev/src/getWebpackConfig.ts
@@ -76,6 +76,8 @@ export default function(service: IApi, opts: IOpts = {}) {
     webpackConfig.output.chunkFilename = '[name].server.async.js';
     webpackConfig.plugins.push(
       new (require('write-file-webpack-plugin'))({
+        // not only `umi.server.js`
+        // if addEntry across chainWebpack
         test: /\.server\.js/,
       }),
     );

--- a/packages/umi-build-dev/src/getWebpackConfig.ts
+++ b/packages/umi-build-dev/src/getWebpackConfig.ts
@@ -76,7 +76,7 @@ export default function(service: IApi, opts: IOpts = {}) {
     webpackConfig.output.chunkFilename = '[name].server.async.js';
     webpackConfig.plugins.push(
       new (require('write-file-webpack-plugin'))({
-        test: /umi\.server\.js/,
+        test: /\.server\.js/,
       }),
     );
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13595509/63219788-11485700-c1ac-11e9-8b61-c1dcaf0c1f33.png)


ssr dev should not only `umi.server.js` if using `config.entry` across `chainWebpack`