### PR TITLE
fix: original error stack should be preferred

### DIFF
--- a/packages/umi-build-dev/src/UserConfig.js
+++ b/packages/umi-build-dev/src/UserConfig.js
@@ -76,7 +76,7 @@ class UserConfig {
       const msg = `配置文件 "${file.replace(`${paths.cwd}/`, '')}" 解析出错，请检查语法。
 \r\n${e.toString()}`;
       this.printError(msg);
-      throw new Error(msg);
+      throw e;
     };
 
     config = getConfigByConfigFile(file, {


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

- output the original error stack instead of the cloaked error message
