### PR TITLE
fix: IBeforeDevServerFunc and IAfterDevServerFunc type errors

### DIFF
--- a/packages/umi-types/index.d.ts
+++ b/packages/umi-types/index.d.ts
@@ -187,11 +187,16 @@ interface ICompatDirname<T = any> {
  * https://umijs.org/plugin/develop.html#event-class-api
  */
 export interface IBeforeDevServerFunc {
-  (args: { service: any }): void;
+  (args: { server: any }): void;
 }
 
 export interface IAfterDevServerFunc {
-  (args: { service: any }): void;
+  (
+    args: {
+      server: any;
+      devServerPort: number;
+    },
+  ): void;
 }
 
 export interface IBeforeBlockWritingFunc {


### PR DESCRIPTION
##### Checklist

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

- [umi-types](https://github.com/umijs/umi/blob/master/packages/umi-types/index.d.ts#L189)：`IBeforeDevServerFunc` 和 `IAfterDevServerFunc` 类型错误。钩子[`beforeDevServer`](https://github.com/umijs/umi/blob/master/packages/umi-build-dev/src/plugins/commands/dev/index.js#L139) 和 [`afterDevServer`](https://github.com/umijs/umi/blob/master/packages/umi-build-dev/src/plugins/commands/dev/index.js#L144) 在 `umi-build-dev`内传递的参数和`umi-types`定义的类型不一致。
