### PR TITLE
fix(umi-ui): init path redirect in server

### DIFF
--- a/packages/umi-ui/client/.umirc.ts
+++ b/packages/umi-ui/client/.umirc.ts
@@ -19,7 +19,7 @@ const uglifyJSOptions =
     : {};
 
 const config: IConfig = {
-  history: 'hash',
+  history: 'browser',
   hash: NODE_ENV === 'production',
   treeShaking: true,
   uglifyJSOptions,

--- a/packages/umi-ui/client/src/app.ts
+++ b/packages/umi-ui/client/src/app.ts
@@ -64,18 +64,6 @@ export async function render(oldRender) {
     miniKey = qs.key;
   }
 
-  // 不同路由在渲染前的初始化逻辑
-  if (history.location.pathname === '/') {
-    const { data } = await callRemote({ type: '@@project/list' });
-    if (miniKey || data.currentProject) {
-      history.replace('/dashboard');
-    } else {
-      history.replace('/project/select');
-    }
-    window.location.reload();
-    return;
-  }
-
   if (history.location.pathname.startsWith('/project/')) {
     // console.log("It's Project Manager");
   }

--- a/packages/umi-ui/src/UmiUI.ts
+++ b/packages/umi-ui/src/UmiUI.ts
@@ -765,10 +765,8 @@ export default class UmiUI {
         );
       }
 
-      app.all('/', async (req, res) => {
+      app.get('/', async (req, res) => {
         const isMini = !!req.query.mini;
-        console.log('isMini', isMini);
-        console.log('req.path', req.path);
         const { data } = this.config;
         if (isMini || data.currentProject) {
           return res.status(302).redirect('/dashboard');

--- a/packages/umi-ui/src/scripts.ts
+++ b/packages/umi-ui/src/scripts.ts
@@ -81,7 +81,7 @@ const deer = `
   });
   Tracert.call('before', 'logPv', function() {
     Tracert.set({
-      fullURL: 'http://ui.bigfish.com/' + location.hash,
+      fullURL: 'http://ui.bigfish.com/' + location.pathname,
     });
   });
 </script>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

Why：

- 初始化 URL 跳转到 `/project/select` 还是 `/dashboard` 的逻辑放在服务端，避免在 `mini` 时页面会闪烁。
- 客户端路由改成 `browser` ，更好的判断 `isMini` 等参数。 

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
