### PR TITLE
feat: support dump error info to file

### DIFF
--- a/packages/af-webpack/src/build.js
+++ b/packages/af-webpack/src/build.js
@@ -36,7 +36,7 @@ export default function build(opts = {}) {
 
     if (err || stats.hasErrors()) {
       if (onFail) {
-        onFail({ err, stats });
+        onFail(getErrorInfo(err, stats));
       }
 
       const isWatch = isPlainObject(webpackConfig)
@@ -65,4 +65,22 @@ export default function build(opts = {}) {
       onSuccess({ stats });
     }
   });
+}
+
+function getErrorInfo(err, stats) {
+  if (!stats.stats) {
+    return {
+      err: err || (stats.compilation && stats.compilation.errors && stats.compilation.errors[0]),
+      stats,
+      rawStats: stats,
+    };
+  }
+  const [curStats] = stats.stats;
+  return {
+    err:
+      err ||
+      (curStats.compilation && curStats.compilation.errors && curStats.compilation.errors[0]),
+    stats: curStats,
+    rawStats: stats,
+  };
 }

--- a/packages/umi-core/src/error.js
+++ b/packages/umi-core/src/error.js
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import signale from 'signale';
 import marked from 'marked';
 import TerminalRenderer from 'marked-terminal';
+import { existsSync, writeFileSync } from 'fs';
 
 marked.setOptions({
   renderer: new TerminalRenderer(),
@@ -68,5 +69,24 @@ export function printUmiError(e, opts = {}) {
         .slice(1)
         .join('\n')}`,
     );
+  }
+
+  // 将错误信息输出到文件
+  if (process.env.DUMP_ERROR_PATH) {
+    try {
+      if (existsSync(process.env.DUMP_ERROR_PATH)) {
+        return;
+      }
+      writeFileSync(
+        process.env.DUMP_ERROR_PATH,
+        JSON.stringify({
+          code,
+          message,
+          stack: e.stack,
+        }),
+      );
+    } catch (_) {
+      //
+    }
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->


1. 修复 MultiStats 时 error 校验的 bug。现在 umi 链路中基本都是 MultiStats，对 MultiStats 的操作与单个 Stats 是不同的
2. 支持通过开启环境变量 DUMP_ERROR_PATH 将 umi 探测到的 error 进行 dump。适用于上层框架通过 fork 使用的 umi 的情况
