### PR TITLE
feat: support ERROR_OVERLAY env

### DIFF
--- a/docs/guide/env-variables.md
+++ b/docs/guide/env-variables.md
@@ -163,7 +163,11 @@ The output directory will be removed by default before each build, you can set i
 
 ### HMR
 
-The HMR is enabled by default, the value is disabled when none, and the value is refreshed when the file changes when reload.
+The HMR is enabled by default, the value is disabled when `none`, and the value is refreshed when the file changes when reload.
+
+### ERROR_OVERLAY
+
+The ERROR_OVERLAY is enabled by default, the value is disabled when `none`, the `react-error-overlay` won't display overlay whenever disabled.
 
 ### BABELRC
 

--- a/docs/zh/guide/env-variables.md
+++ b/docs/zh/guide/env-variables.md
@@ -145,7 +145,7 @@ $ COMPRESS=none umi build
 
 ### BROWSER
 
-默认自动开浏览器，值为 none 时不自动打开，dev 时有效。比如：
+默认自动开浏览器，值为 `none` 时不自动打开，dev 时有效。比如：
 
 ```bash
 $ BROWSER=none umi dev
@@ -161,7 +161,11 @@ $ BROWSER=none umi dev
 
 ### HMR
 
-默认开启 HMR，值为 none 时禁用，值为 reload 时文件有变化时刷新浏览器。
+默认开启 HMR，值为 `none` 时禁用，值为 `reload` 时文件有变化时刷新浏览器。
+
+### ERROR_OVERLAY
+
+默认开启 ERROR_OVERLAY，值为 `none` 时禁用，禁用后则`react-error-overlay`不会弹出错误遮罩层。
 
 ### BABELRC
 

--- a/packages/af-webpack/src/getWebpackConfig/resolveDefine.js
+++ b/packages/af-webpack/src/getWebpackConfig/resolveDefine.js
@@ -1,10 +1,12 @@
 /* eslint-disable guard-for-in */
 const prefixRE = /^UMI_APP_/;
 
+const ENV_SHOULD_PASS = ['NODE_ENV', 'HMR', 'SOCKET_SERVER', 'ERROR_OVERLAY'];
+
 export default function(opts) {
   const env = {};
   Object.keys(process.env).forEach(key => {
-    if (prefixRE.test(key) || key === 'NODE_ENV' || key === 'HMR' || key === 'SOCKET_SERVER') {
+    if (prefixRE.test(key) || ENV_SHOULD_PASS.includes(key)) {
       env[key] = process.env[key];
     }
   });

--- a/packages/af-webpack/src/webpackHotDevClient.js
+++ b/packages/af-webpack/src/webpackHotDevClient.js
@@ -45,8 +45,24 @@ var hadRuntimeError = false;
 ErrorOverlay.startReportingRuntimeErrors({
   onError: function() {
     hadRuntimeError = true;
+
+    // workaround since react-error-overlay doesn't provide any option to suppress overlay.
+    // we still need runtime error notification because of the recovery process
+    if (process.env.ERROR_OVERLAY === 'none') {
+      suppressErrorOverlay();
+    }
   },
 });
+
+function suppressErrorOverlay() {
+  setTimeout(() => {
+    if (document.querySelector('iframe')) {
+      ErrorOverlay.dismissBuildError();
+      ErrorOverlay.dismissRuntimeErrors();
+      return;
+    }
+  });
+}
 
 if (module.hot && typeof module.hot.dispose === 'function') {
   module.hot.dispose(function() {
@@ -192,7 +208,9 @@ function handleErrors(errors) {
   });
 
   // Only show the first error.
-  ErrorOverlay.reportBuildError(formatted.errors[0]);
+  if (process.env.ERROR_OVERLAY !== 'none') {
+    ErrorOverlay.reportBuildError(formatted.errors[0]);
+  }
 
   // Also log them to the console.
   if (typeof console !== 'undefined' && typeof console.error === 'function') {

--- a/packages/af-webpack/src/webpackHotDevClient.js
+++ b/packages/af-webpack/src/webpackHotDevClient.js
@@ -208,9 +208,7 @@ function handleErrors(errors) {
   });
 
   // Only show the first error.
-  if (process.env.ERROR_OVERLAY !== 'none') {
-    ErrorOverlay.reportBuildError(formatted.errors[0]);
-  }
+  ErrorOverlay.reportBuildError(formatted.errors[0]);
 
   // Also log them to the console.
   if (typeof console !== 'undefined' && typeof console.error === 'function') {


### PR DESCRIPTION
因为`react-error-overlay`没有提供禁用overlay的api，但我们又需要`startReportingRuntimeErrors`的回调来做错误后恢复刷新的提醒，所以采用了一些workaround

##### Checklist

- [x] `npm test` passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

- `UMI_APP_ERROR_OVERLAY` supported for [3093](https://github.com/umijs/umi/issues/3093)
- Close #3093

-----
[View rendered docs/guide/env-variables.md](https://github.com/leftstick/umi/blob/master/docs/guide/env-variables.md)
[View rendered docs/zh/guide/env-variables.md](https://github.com/leftstick/umi/blob/master/docs/zh/guide/env-variables.md)