### PR TITLE
feat(css-loader): css modules default support camelCase convent

### DIFF
--- a/packages/af-webpack/src/getWebpackConfig/css.js
+++ b/packages/af-webpack/src/getWebpackConfig/css.js
@@ -51,6 +51,7 @@ export default function(webpackConfig, opts) {
   };
   const cssModulesConfig = {
     modules: true,
+    localsConvention: 'camelCase',
     localIdentName:
       cssOpts.localIdentName ||
       (isDev ? '[name]__[local]___[hash:base64:5]' : '[local]___[hash:base64:5]'),


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- css modules default support camelCase convent

```file.css
.icon-class-name {
}
```

```file.jsx
import styles from 'file.css'

styles.iconClassName
styles['icon-class-name']
```

ref: https://github.com/webpack-contrib/css-loader#localsconvention
