### PR TITLE
refactor(Umi UI): api.intl.* to mount intlApi

### DIFF
--- a/docs/plugin/umi-ui.md
+++ b/docs/plugin/umi-ui.md
@@ -323,13 +323,30 @@ export default (api) => {
 };
 ```
 
-### api.intl()
+### api.intl.*
 
-使用国际化，使用 [api.addLocale](#api-addlocales) 添加国际化字段后，可以在组件里使用 `api.intl` 使用国际化。
+使用国际化，使用 [api.addLocale](#api-addlocales) 添加国际化字段后，可以在组件里使用 `api.intl.*` 处理国际化。
 
-参数：
+提供的国际化方法如下：
 
-`api.intl` 与 [formatMessage](https://github.com/formatjs/react-intl/blob/1c7b6f87d5cc49e6ef3f5133cacf8b066df53bde/docs/API.md#formatmessage) 参数一致。
+```ts
+type PickIntl = Pick<typeof intl,
+  'FormattedDate' |
+  'FormattedTime' |
+  'FormattedRelative' |
+  'FormattedNumber' |
+  'FormattedPlural' |
+  'FormattedMessage' |
+  'FormattedHTMLMessage' |
+  'formatMessage' |
+  'formatHTMLMessage' |
+  'formatDate' |
+  'formatTime' |
+  'formatRelative' |
+  'formatNumber' |
+  'formatPlural'
+>
+```
 
 例如：
 
@@ -338,40 +355,30 @@ export default (api) => {
 import React from 'react';
 
 export default (api) => {
+  // 用法 api 参考 https://github.com/formatjs/react-intl/blob/1c7b6f87d5cc49e6ef3f5133cacf8b066df53bde/docs/API.md
+  const {
+    FormattedMessage,
+    formatMessage,
+  } = api.intl;
+  const Component = (
+    <div>
+      <p>{formatMessage({ id: 'org.sorrycc.react.home' })}</p>
+      <FormattedMessage id="org.sorrycc.react.foo" />
+      <p>api.intl alias `api.intl.formatMessage`: {api.intl({ id: 'org.sorrycc.react.name' })}</p>
+    </div>
+  )
   api.addPanel({
     title: '插件模板',
     path: '/plugin-bar',
     icon: 'environment',
-    component: <div>{api.intl({ id: 'org.sorrycc.react.name' })}</div>,
+    component: ,
   });
 };
 ```
 
-### api.FormattedMessage
+> `api.intl()` 与 [formatMessage](https://github.com/formatjs/react-intl/blob/1c7b6f87d5cc49e6ef3f5133cacf8b066df53bde/docs/API.md#formatmessage) 参数一致，`api.intl()` 与 `api.intl.formatMessage()` 等价。
 
-国际化组件，前提也是通过 [api.addLocale](#api-addlocales) 添加国际化字段。
-
-
-参数：
-
-`api.FormattedMessage` 与 [FormattedMessage](https://github.com/formatjs/react-intl/blob/1c7b6f87d5cc49e6ef3f5133cacf8b066df53bde/docs/Components.md#formattedmessage) 参数一致。
-
-示例：
-
-```js
-// ui.(jsx|tsx)
-import React from 'react';
-
-export default (api) => {
-  const { FormattedMessage } = api;
-  api.addPanel({
-    title: '插件模板',
-    path: '/plugin-bar',
-    icon: 'environment',
-    component: <FormattedMessage id="org.sorrycc.react.name" />,
-  });
-};
-```
+![image](https://user-images.githubusercontent.com/13595509/66404196-9288d100-ea1a-11e9-9ada-1204744018d2.png)
 
 ### api.getLocale()
 

--- a/docs/zh/plugin/umi-ui.md
+++ b/docs/zh/plugin/umi-ui.md
@@ -322,13 +322,30 @@ export default (api) => {
 };
 ```
 
-### api.intl()
+### api.intl.*
 
-使用国际化，使用 [api.addLocale](#api-addlocales) 添加国际化字段后，可以在组件里使用 `api.intl` 使用国际化。
+使用国际化，使用 [api.addLocale](#api-addlocales) 添加国际化字段后，可以在组件里使用 `api.intl.*` 处理国际化。
 
-参数：
+提供的国际化方法如下：
 
-`api.intl` 与 [formatMessage](https://github.com/formatjs/react-intl/blob/1c7b6f87d5cc49e6ef3f5133cacf8b066df53bde/docs/API.md#formatmessage) 参数一致。
+```ts
+type PickIntl = Pick<typeof intl,
+  'FormattedDate' |
+  'FormattedTime' |
+  'FormattedRelative' |
+  'FormattedNumber' |
+  'FormattedPlural' |
+  'FormattedMessage' |
+  'FormattedHTMLMessage' |
+  'formatMessage' |
+  'formatHTMLMessage' |
+  'formatDate' |
+  'formatTime' |
+  'formatRelative' |
+  'formatNumber' |
+  'formatPlural'
+>
+```
 
 例如：
 
@@ -337,40 +354,31 @@ export default (api) => {
 import React from 'react';
 
 export default (api) => {
+  // 用法 api 参考 https://github.com/formatjs/react-intl/blob/1c7b6f87d5cc49e6ef3f5133cacf8b066df53bde/docs/API.md
+  const {
+    FormattedMessage,
+    formatMessage,
+  } = api.intl;
+  const Component = (
+    <div>
+      <p>{formatMessage({ id: 'org.sorrycc.react.home' })}</p>
+      <FormattedMessage id="org.sorrycc.react.foo" />
+      <p>api.intl alias `api.intl.formatMessage`: {api.intl({ id: 'org.sorrycc.react.name' })}</p>
+    </div>
+  )
   api.addPanel({
     title: '插件模板',
     path: '/plugin-bar',
     icon: 'environment',
-    component: <div>{api.intl({ id: 'org.sorrycc.react.name' })}</div>,
+    component: ,
   });
 };
 ```
 
-### api.FormattedMessage
+> `api.intl()` 与 [formatMessage](https://github.com/formatjs/react-intl/blob/1c7b6f87d5cc49e6ef3f5133cacf8b066df53bde/docs/API.md#formatmessage) 参数一致，`api.intl()` 与 `api.intl.formatMessage()` 等价。
 
-国际化组件，前提也是通过 [api.addLocale](#api-addlocales) 添加国际化字段。
+![image](https://user-images.githubusercontent.com/13595509/66404196-9288d100-ea1a-11e9-9ada-1204744018d2.png)
 
-
-参数：
-
-`api.FormattedMessage` 与 [FormattedMessage](https://github.com/formatjs/react-intl/blob/1c7b6f87d5cc49e6ef3f5133cacf8b066df53bde/docs/Components.md#formattedmessage) 参数一致。
-
-示例：
-
-```js
-// ui.(jsx|tsx)
-import React from 'react';
-
-export default (api) => {
-  const { FormattedMessage } = api;
-  api.addPanel({
-    title: '插件模板',
-    path: '/plugin-bar',
-    icon: 'environment',
-    component: <FormattedMessage id="org.sorrycc.react.name" />,
-  });
-};
-```
 
 ### api.getLocale()
 

--- a/packages/umi-plugin-ui/src/plugins/configuration/ui.tsx
+++ b/packages/umi-plugin-ui/src/plugins/configuration/ui.tsx
@@ -6,7 +6,8 @@ import zhCN from './locales/zh-CN';
 import enUS from './locales/en-US';
 
 export default (api: IUiApi) => {
-  const { FormattedMessage } = api;
+  const { intl } = api;
+  const { FormattedMessage } = intl;
   const ConfigAction = () => (
     <Button
       onClick={() => {

--- a/packages/umi-plugin-ui/src/plugins/dashboard/ui.tsx
+++ b/packages/umi-plugin-ui/src/plugins/dashboard/ui.tsx
@@ -6,7 +6,8 @@ import zhCN from './locales/zh-CN';
 import enUS from './locales/en-US';
 
 export default (api: IUiApi) => {
-  const { FormattedMessage } = api;
+  const { intl } = api;
+  const { FormattedMessage } = intl;
   const ConfigAction = () => (
     <Button
       onClick={() => {

--- a/packages/umi-plugin-ui/src/plugins/dashboard/ui/index.tsx
+++ b/packages/umi-plugin-ui/src/plugins/dashboard/ui/index.tsx
@@ -16,7 +16,8 @@ const DashboardUI: React.FC<IProps> = props => {
   const isClosed = window.localStorage.getItem('umi_ui_dashboard_welcome') || false;
   const [closed, setClosed] = useState<boolean>(!!isClosed);
   const { api } = props;
-  const { redirect, currentProject, _, intl, FormattedMessage } = api;
+  const { redirect, currentProject, _, intl } = api;
+  const { FormattedMessage } = intl;
   const actionCardCls = cls(styles.card, styles['card-action']);
   const welcomeCardCls = cls(styles.card, styles.welcome);
 

--- a/packages/umi-types/ui.d.ts
+++ b/packages/umi-types/ui.d.ts
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { Debugger } from 'debug';
 import { ReactNode, Context, FC, FunctionComponent } from 'react';
 import { Terminal as XTerminal, ITerminalOptions } from 'xterm';
-import { formatMessage, FormattedMessage, setLocale } from './locale';
+import * as intl from './locale';
 import { IRoute } from './';
 
 declare namespace IUI {
@@ -174,8 +174,9 @@ declare namespace IUI {
   type ICallRemote<T = unknown, P = unknown> = IApiActionFactory<T, P>;
   type IListenRemote = IApiActionFactory<{}, () => void>;
   type ISend = IApiActionFactory<{}, void>;
-  type IIntl = typeof formatMessage;
-  type IFormattedMessage = typeof FormattedMessage;
+  type IFormatMessage = typeof intl.formatMessage;
+  type IIntl<T = typeof intl> = { [key in keyof T]: T[key] } & typeof intl.formatMessage;
+  type IFormattedMessage = typeof intl.FormattedMessage;
   type IGetCwd = () => Promise<string>;
 
   interface INotifyParams {
@@ -233,9 +234,9 @@ declare namespace IUI {
     theme: ITheme;
     locale: ILang;
     currentProject?: ICurrentProject;
-    formatMessage: IIntl;
+    formatMessage: typeof intl.formatMessage;
     FormattedMessage: IFormattedMessage;
-    setLocale: typeof setLocale;
+    setLocale: typeof intl.setLocale;
     setTheme: (theme: ITheme) => void;
     /** open footer log panel */
     showLogPanel: IShowLogPanel;

--- a/packages/umi-types/ui.d.ts
+++ b/packages/umi-types/ui.d.ts
@@ -175,8 +175,24 @@ declare namespace IUI {
   type IListenRemote = IApiActionFactory<{}, () => void>;
   type ISend = IApiActionFactory<{}, void>;
   type IFormatMessage = typeof intl.formatMessage;
-  type IIntl<T = typeof intl> = { [key in keyof T]: T[key] } & typeof intl.formatMessage;
-  type IFormattedMessage = typeof intl.FormattedMessage;
+  type PickIntl = Pick<
+    typeof intl,
+    | 'FormattedDate'
+    | 'FormattedTime'
+    | 'FormattedRelative'
+    | 'FormattedNumber'
+    | 'FormattedPlural'
+    | 'FormattedMessage'
+    | 'FormattedHTMLMessage'
+    | 'formatMessage'
+    | 'formatHTMLMessage'
+    | 'formatDate'
+    | 'formatTime'
+    | 'formatRelative'
+    | 'formatNumber'
+    | 'formatPlural'
+  >;
+  type IIntl<T = PickIntl> = { [key in keyof T]: T[key] } & typeof intl.formatMessage;
   type IGetCwd = () => Promise<string>;
 
   interface INotifyParams {
@@ -235,7 +251,7 @@ declare namespace IUI {
     locale: ILang;
     currentProject?: ICurrentProject;
     formatMessage: typeof intl.formatMessage;
-    FormattedMessage: IFormattedMessage;
+    FormattedMessage: typeof intl.FormattedMessage;
     setLocale: typeof intl.setLocale;
     setTheme: (theme: ITheme) => void;
     /** open footer log panel */
@@ -265,8 +281,6 @@ declare namespace IUI {
     isMini: () => boolean;
     /** intl, formatMessage */
     intl: IIntl;
-    /** FormattedMessage Component  */
-    FormattedMessage: IFormattedMessage;
     /** add plugin Panel */
     addPanel: IAddPanel;
     /** register dva model Panel */

--- a/packages/umi-types/ui.d.ts
+++ b/packages/umi-types/ui.d.ts
@@ -177,7 +177,7 @@ declare namespace IUI {
   type IFormatMessage = typeof intl.formatMessage;
   type PickIntl = Pick<
     typeof intl,
-    | 'FormattedDate'
+    'FormattedDate'
     | 'FormattedTime'
     | 'FormattedRelative'
     | 'FormattedNumber'

--- a/packages/umi-ui/client/src/PluginAPI.ts
+++ b/packages/umi-ui/client/src/PluginAPI.ts
@@ -6,7 +6,6 @@ import history from '@tmp/history';
 import * as intl from 'umi-plugin-react/locale';
 import { FC } from 'react';
 import { IUi } from 'umi-types';
-import pick from 'lodash/pick';
 import { send, callRemote, listenRemote } from './socket';
 import event, { MESSAGES } from '@/message';
 import { pluginDebug } from '@/debug';
@@ -83,7 +82,6 @@ export default class PluginAPI {
     Object.keys(proxyIntl).forEach(intlApi => {
       this.intl[intlApi] = intl[intlApi];
     });
-    debugger;
   }
 
   addConfigSection(section) {

--- a/packages/umi-ui/client/src/PluginAPI.ts
+++ b/packages/umi-ui/client/src/PluginAPI.ts
@@ -3,9 +3,10 @@ import { connect } from 'dva';
 import lodash from 'lodash';
 import history from '@tmp/history';
 // eslint-disable-next-line no-multi-assign
-import { formatMessage, FormattedMessage } from 'umi-plugin-react/locale';
+import * as intl from 'umi-plugin-react/locale';
 import { FC } from 'react';
 import { IUi } from 'umi-types';
+import pick from 'lodash/pick';
 import { send, callRemote, listenRemote } from './socket';
 import event, { MESSAGES } from '@/message';
 import { pluginDebug } from '@/debug';
@@ -51,6 +52,38 @@ export default class PluginAPI {
     this.bigfish = !!window.g_bigfish;
     this.connect = connect as IUi.IConnect;
     this.mini = isMiniUI();
+
+    const proxyIntl = new Proxy(intl, {
+      get: (target, prop: any) => {
+        if (
+          [
+            'FormattedDate',
+            'FormattedTime',
+            'FormattedRelative',
+            'FormattedNumber',
+            'FormattedPlural',
+            'FormattedMessage',
+            'FormattedHTMLMessage',
+            'formatMessage',
+            'formatHTMLMessage',
+            'formatDate',
+            'formatTime',
+            'formatRelative',
+            'formatNumber',
+            'formatPlural',
+          ].includes(prop)
+        ) {
+          return intl[prop];
+        }
+        return undefined;
+      },
+    });
+
+    // mount react-intl API∂
+    Object.keys(proxyIntl).forEach(intlApi => {
+      this.intl[intlApi] = intl[intlApi];
+    });
+    debugger;
   }
 
   addConfigSection(section) {
@@ -147,8 +180,8 @@ export default class PluginAPI {
     return cwd;
   };
 
-  intl: IUi.IIntl = formatMessage;
-  FormattedMessage = FormattedMessage;
+  intl: IUi.IIntl = intl.formatMessage;
+  FormattedMessage = intl.FormattedMessage;
 
   getLocale: IUi.IGetLocale = () => {
     return window.g_lang;

--- a/packages/umi-ui/client/src/PluginAPI.ts
+++ b/packages/umi-ui/client/src/PluginAPI.ts
@@ -179,7 +179,6 @@ export default class PluginAPI {
   };
 
   intl: IUi.IIntl = intl.formatMessage;
-  FormattedMessage = intl.FormattedMessage;
 
   getLocale: IUi.IGetLocale = () => {
     return window.g_lang;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

将所有 intl api ，统一挂在 `api.intl.*` 上，便于后续国际化扩展及 api 收敛 [docs](https://umi-26krv3a04.now.sh/plugin/umi-ui.html#api-intl)：

![image](https://user-images.githubusercontent.com/13595509/66404196-9288d100-ea1a-11e9-9ada-1204744018d2.png)

同时兼容之前的 `api.intl({ id:  })` 写法：

![image](https://user-images.githubusercontent.com/13595509/66404546-425e3e80-ea1b-11e9-86c8-9d668bc73447.png)


##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL


-----
[View rendered docs/plugin/umi-ui.md](https://github.com/umijs/umi/blob/feat-ui-intl-proxy/docs/plugin/umi-ui.md)
[View rendered docs/zh/plugin/umi-ui.md](https://github.com/umijs/umi/blob/feat-ui-intl-proxy/docs/zh/plugin/umi-ui.md)