### PR TITLE
fix: webpack dev server sock port

### DIFF
--- a/packages/af-webpack/src/dev.js
+++ b/packages/af-webpack/src/dev.js
@@ -134,6 +134,7 @@ export default function dev({
         historyApiFallback: false,
         overlay: false,
         host: HOST,
+        sockPort: port,
         proxy,
         https: !!process.env.HTTPS,
         cert: CERT,


### PR DESCRIPTION
ref: https://github.com/webpack/webpack-dev-server/pull/1792

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

修复 webpack dev server 的 socket 端口，socket port 指定使用 wds 的端口

相关：https://github.com/webpack/webpack-dev-server/pull/1792
