### PR TITLE
同步service-worker 方法 && 补充相关文档说明

### DIFF
--- a/docs/plugin/umi-plugin-react.md
+++ b/docs/plugin/umi-plugin-react.md
@@ -194,6 +194,13 @@ window.addEventListener('sw.updated', () => {
 });
 ```
 
+```js
+window.addEventListener('sw.registered', e => {
+  // e.detail.update()  // trigger a manual update
+  // Configure the appropriate polling and match the sw.updated event, without the user refreshing or opening a new tab to update.
+});
+```
+
 You can also react to network environment changes, such as offline/online:
 
 ```js
@@ -201,6 +208,8 @@ window.addEventListener('sw.offline', () => {
   // make some components gray
 });
 ```
+
+`sw.*` Events are synchronized with events in [register-service-worker] (https://www.npmjs.com/package/register-service-worker). For more usage, please refer to the link above.
 
 ### hd
 

--- a/docs/plugin/umi-plugin-react.md
+++ b/docs/plugin/umi-plugin-react.md
@@ -209,7 +209,7 @@ window.addEventListener('sw.offline', () => {
 });
 ```
 
-`sw.*` Events are synchronized with events in [register-service-worker] (https://www.npmjs.com/package/register-service-worker). For more usage, please refer to the link above.
+`sw.*` Events are synchronized with events in [register-service-worker](https://www.npmjs.com/package/register-service-worker). For more usage, please refer to the link above.
 
 ### hd
 

--- a/docs/zh/plugin/umi-plugin-react.md
+++ b/docs/zh/plugin/umi-plugin-react.md
@@ -85,7 +85,7 @@ export default {
 启用后自动配置 [babel-plugin-import](https://github.com/ant-design/babel-plugin-import) 实现 antd, antd-mobile 和 antd-pro 的按需编译，并且内置 antd, antd-mobile 依赖，无需手动在项目中安装。
 
 ::: warning
- 如果项目中有 antd 或者 antd-mobile 依赖，则优先使用项目中的依赖。 
+如果项目中有 antd 或者 antd-mobile 依赖，则优先使用项目中的依赖。 
 :::
 
 ### routes

--- a/docs/zh/plugin/umi-plugin-react.md
+++ b/docs/zh/plugin/umi-plugin-react.md
@@ -85,7 +85,7 @@ export default {
 启用后自动配置 [babel-plugin-import](https://github.com/ant-design/babel-plugin-import) 实现 antd, antd-mobile 和 antd-pro 的按需编译，并且内置 antd, antd-mobile 依赖，无需手动在项目中安装。
 
 ::: warning
-如果项目中有 antd 或者 antd-mobile 依赖，则优先使用项目中的依赖。 
+如果项目中有 antd 或者 antd-mobile 依赖，则优先使用项目中的依赖。
 :::
 
 ### routes

--- a/docs/zh/plugin/umi-plugin-react.md
+++ b/docs/zh/plugin/umi-plugin-react.md
@@ -85,7 +85,7 @@ export default {
 启用后自动配置 [babel-plugin-import](https://github.com/ant-design/babel-plugin-import) 实现 antd, antd-mobile 和 antd-pro 的按需编译，并且内置 antd, antd-mobile 依赖，无需手动在项目中安装。
 
 ::: warning
-如果项目中有 antd 或者 antd-mobile 依赖，则优先使用项目中的依赖。
+ 如果项目中有 antd 或者 antd-mobile 依赖，则优先使用项目中的依赖。 
 :::
 
 ### routes
@@ -203,6 +203,13 @@ window.addEventListener('sw.updated', () => {
 });
 ```
 
+```js
+window.addEventListener('sw.registered', e => {
+  // e.detail.update() 可触发手动更新。
+  // 配置适当的轮询并配合 sw.updated 事件, 无需用户刷新或打开新选项卡即可更新。
+});
+```
+
 另外，当网络环境发生改变时，也可以给予用户显式反馈：
 
 ```js
@@ -210,6 +217,8 @@ window.addEventListener('sw.offline', () => {
   // 置灰某些组件
 });
 ```
+
+最后 `sw.*` 事件与 [register-service-worker](https://www.npmjs.com/package/register-service-worker) 中的事件同步，更多使用方法请参考上述链接。
 
 ### hd
 

--- a/packages/umi-plugin-react/src/plugins/pwa/registerServiceWorker.js
+++ b/packages/umi-plugin-react/src/plugins/pwa/registerServiceWorker.js
@@ -24,12 +24,26 @@ function dispatchServiceWorkerEvent(eventName, eventData) {
 
 export default function(swDest) {
   register(`${process.env.BASE_URL}${swDest}`, {
+    ready(registration) {
+      dispatchServiceWorkerEvent('sw.ready', registration);
+    },
+    registered(registration) {
+      dispatchServiceWorkerEvent('sw.registered', registration);
+    },
+    cached(registration) {
+      dispatchServiceWorkerEvent('sw.cached', registration);
+    },
+    updatefound(registration) {
+      dispatchServiceWorkerEvent('sw.updatefound', registration);
+    },
     updated(registration) {
       dispatchServiceWorkerEvent('sw.updated', registration);
     },
-
     offline() {
       dispatchServiceWorkerEvent('sw.offline', {});
+    },
+    error(error) {
+      dispatchServiceWorkerEvent('sw.error', error);
     },
   });
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

 documentation is changed or added



##### Description of change
pwa 的配置中只使用 `updated` 及 `offline` 事件，由于用户可能有其他需求，比如监听 `registered` 进行更新的轮询等，所以将 [register-service-worker](https://www.npmjs.com/package/register-service-worker) 中所有事件一下子都同步了过来，并更新了文档。
同步service-worker 方法 && 补充相关文档说明


-----
[View rendered docs/zh/plugin/umi-plugin-react.md](https://github.com/cnahliu/umi/blob/sync-sw-event/docs/zh/plugin/umi-plugin-react.md)