### PR TITLE
docs: debug umi dev in local

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,15 +97,16 @@ $ y doc:deploy
 Debug `umi ui` in local.
 
 ```bash
+# First, run umi dev --watch to start static dev server: http://localhost:8002/
 $ y ui:build --watch
 
 # Then run umi ui under a umi project.
-$ umi ui
+$ LOCAL_DEBUG=1 umi ui
 
 # if want to debug for more defail, using
-$ DEBUG=umiui:UmiUI* umi ui
+$ LOCAL_DEBUG=1 DEBUG=umiui:UmiUI* umi ui
 
-# Or
+# Or Run `umi dev --ui` in examples/func-test.
 $ umi dev --ui
 ```
 


### PR DESCRIPTION
y ui:build --watch 只是启动 webpack dev server，尚未完成构建；启动UIServer进行本地开发调试，需要设置环境 LOCAL_DEBUG 或者切换到 examples/func-test 目录运行 umi dev --ui 命令

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- Update CONTRIBUTING.md how to debug umi ui in local.


-----
[View rendered CONTRIBUTING.md](https://github.com/billfeller/umi/blob/patch-1/CONTRIBUTING.md)