### PR TITLE
chore: add outputPath blacklist

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -110,6 +110,8 @@ export default {
 
 Specifies the output path.
 
+> It is not allowed to set the contract directories such as `/src` 、 `/public` 、 `/pages` 、 `/mock` 、 `/config`
+
 ### base
 
 - Type: `String`

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -110,7 +110,7 @@ export default {
 
 Specifies the output path.
 
-> It is not allowed to set the contract directories such as `/src` 、 `/public` 、 `/pages` 、 `/mock` 、 `/config`
+> It is not allowed to set the contract directories such as `src` 、 `public` 、 `pages` 、 `mock` 、 `config`
 
 ### base
 

--- a/docs/zh/config/README.md
+++ b/docs/zh/config/README.md
@@ -112,7 +112,7 @@ export default {
 
 指定输出路径。
 
-> 不允许设置 `/src` 、 `/public` 、 `/pages` 、 `/mock` 、 `/config` 等约定目录
+> 不允许设置 `src` 、 `public` 、 `pages` 、 `mock` 、 `config` 等约定目录
 
 ### base
 

--- a/docs/zh/config/README.md
+++ b/docs/zh/config/README.md
@@ -112,6 +112,8 @@ export default {
 
 指定输出路径。
 
+> 不允许设置 `/src` 、 `/public` 、 `/pages` 、 `/mock` 、 `/config` 等约定目录
+
 ### base
 
 - 类型：`String`

--- a/packages/umi-build-dev/src/getConfig/configPlugins/outputPath.js
+++ b/packages/umi-build-dev/src/getConfig/configPlugins/outputPath.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-const blacklist = ['/src', '/public', '/pages', '/mock', '/config'];
+const blacklist = ['src', 'public', 'pages', 'mock', 'config'];
 
 export default function() {
   return {
@@ -10,8 +10,9 @@ export default function() {
         typeof val === 'string',
         `Configure item outputPath should be String, but got ${val}.`,
       );
+      assert(!val.startsWith('/'), `The outputPath config should not start with '/'`);
       assert(
-        !blacklist.includes(val.startsWith('/') ? val : `/${val}`),
+        !blacklist.includes(val),
         `The outputPath config is not allowed to be set to ${val}, ${val} is convention directory`,
       );
     },

--- a/packages/umi-build-dev/src/getConfig/configPlugins/outputPath.js
+++ b/packages/umi-build-dev/src/getConfig/configPlugins/outputPath.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-const blacklist = ['src', 'public', 'pages', 'mock', 'config'];
+const blacklist = ['src', 'public', 'pages', 'page', 'mock', 'config'];
 
 export default function() {
   return {
@@ -10,7 +10,10 @@ export default function() {
         typeof val === 'string',
         `Configure item outputPath should be String, but got ${val}.`,
       );
-      assert(!val.startsWith('/'), `The outputPath config should not start with '/'`);
+
+      // 可能有 break change，等 umi@3
+      // assert(!val.startsWith('/'), `The outputPath config should not start with '/'`);
+
       assert(
         !blacklist.includes(val),
         `The outputPath config is not allowed to be set to ${val}, ${val} is convention directory`,

--- a/packages/umi-build-dev/src/getConfig/configPlugins/outputPath.js
+++ b/packages/umi-build-dev/src/getConfig/configPlugins/outputPath.js
@@ -1,5 +1,7 @@
 import assert from 'assert';
 
+const blacklist = ['/src', '/public', '/pages', '/mock', '/config'];
+
 export default function() {
   return {
     name: 'outputPath',
@@ -7,6 +9,10 @@ export default function() {
       assert(
         typeof val === 'string',
         `Configure item outputPath should be String, but got ${val}.`,
+      );
+      assert(
+        !blacklist.includes(val.slice(0) === '/' ? val : `/${val}`),
+        `The outputPath config is not allowed to be set to ${val}, ${val} is convention directory`,
       );
     },
     group: 'deploy',

--- a/packages/umi-build-dev/src/getConfig/configPlugins/outputPath.js
+++ b/packages/umi-build-dev/src/getConfig/configPlugins/outputPath.js
@@ -11,7 +11,7 @@ export default function() {
         `Configure item outputPath should be String, but got ${val}.`,
       );
       assert(
-        !blacklist.includes(val.slice(0) === '/' ? val : `/${val}`),
+        !blacklist.includes(val.startsWith('/') ? val : `/${val}`),
         `The outputPath config is not allowed to be set to ${val}, ${val} is convention directory`,
       );
     },

--- a/packages/umi-build-dev/src/getConfig/test/outputPath.test.js
+++ b/packages/umi-build-dev/src/getConfig/test/outputPath.test.js
@@ -5,4 +5,7 @@ test('validate', () => {
   expect(() => {
     outputPath().validate(1);
   }).toThrow(/Configure item outputPath should be String/);
+  expect(() => {
+    outputPath().validate('src');
+  }).toThrow(/The outputPath config is not allowed to be set to src/);
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->
当设置 `outputPath` 为约定的目录时，会有很多意想不到的错误。
比如 设置 `outputPath:public`，会导致再次dev的时候，都失效。因为这时候的 `index.html` 被生成后的 `index.html` 覆盖，这与约定 `public` 下的文件会被原样拷贝有关。
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->


- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL


-----
[View rendered docs/config/README.md](https://github.com/umijs/umi/blob/outputPath-blacklist/docs/config/README.md)
[View rendered docs/zh/config/README.md](https://github.com/umijs/umi/blob/outputPath-blacklist/docs/zh/config/README.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/umi/3527)
<!-- Reviewable:end -->
