### PR TITLE
fix: set correct MiniCssExtractPlugin publicPath in Dev mode

### DIFF
--- a/packages/af-webpack/src/getWebpackConfig/css.js
+++ b/packages/af-webpack/src/getWebpackConfig/css.js
@@ -83,7 +83,7 @@ export default function(webpackConfig, opts) {
           .use('extract-css-loader')
           .loader(require('mini-css-extract-plugin').loader)
           .options({
-            publicPath: isDev ? '/' : opts.cssPublicPath,
+            publicPath: isDev ? './' : opts.cssPublicPath,
             hmr: isDev,
           });
       }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/umi/3549)
<!-- Reviewable:end -->
