### PR TITLE
fix:  umi-plugin-locale ssr node env module bug

### DIFF
--- a/packages/umi-plugin-locale/template/wrapper.jsx.tpl
+++ b/packages/umi-plugin-locale/template/wrapper.jsx.tpl
@@ -7,7 +7,7 @@ import {
   intlShape,
   LangContext,
   _setLocaleContext
-} from 'umi-plugin-locale';
+} from 'umi-plugin-locale/lib/locale';
 
 const InjectedWrapper = (() => {
   let sfc = (props, context) => {

--- a/packages/umi-plugin-react/locale/index.js
+++ b/packages/umi-plugin-react/locale/index.js
@@ -1,1 +1,1 @@
-module.exports = require('umi-plugin-locale');
+module.exports = require('umi-plugin-locale/lib/locale');

--- a/packages/umi-plugin-react/locale/index.js
+++ b/packages/umi-plugin-react/locale/index.js
@@ -1,1 +1,3 @@
-module.exports = require('umi-plugin-locale/lib/locale');
+module.exports =
+  require('umi-plugin-locale/lib/locale').default ||
+  require('umi-plugin-locale/lib/locale').default;

--- a/packages/umi-plugin-react/locale/index.js
+++ b/packages/umi-plugin-react/locale/index.js
@@ -1,3 +1,3 @@
 module.exports =
   require('umi-plugin-locale/lib/locale').default ||
-  require('umi-plugin-locale/lib/locale').default;
+  require('umi-plugin-locale/lib/locale');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

umi SSR target 改成 node 后 #3491 不兼容 umi-plugin-locale 插件。

看了下 umi-plugin-locale 插件实现，在 browser 时，引入 `./lib/locale`，node 端引用 `./lib/index` 给 `umi-plugin-react` 组装 locale 插件。

但 ssr 中改成 node 后，会引用到 `./lib/index` ，自然导致 `locale`  api  undefined。

Close https://github.com/umijs/umi-server/issues/19.

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
