### PR TITLE
fix: highestPort should always higher than basePort

### DIFF
--- a/packages/af-webpack/src/getPort.js
+++ b/packages/af-webpack/src/getPort.js
@@ -8,8 +8,8 @@ export default async port => {
     return parseInt(process.env.PORT, 10);
   }
 
-  portfinder.basePort = process.env.BASE_PORT || 8000;
-  portfinder.highestPort = 9000;
+  portfinder.basePort = parseInt(process.env.BASE_PORT) || 8000;
+  portfinder.highestPort = portfinder.basePort + 1000;
 
   return portfinder.getPortPromise();
 };


### PR DESCRIPTION
Fix `Provided options.stopPort is less than options.startPort`

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- ❌ tests are included
- ❌ documentation is changed or added
- [ ] commit message follows commit guidelines **←我没找到这个**

##### Description of change

- close https://github.com/umijs/umi/3586

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/umi/3587)
<!-- Reviewable:end -->
