### PR TITLE
fix: avoid transfor entry file to js when add a new block

### DIFF
--- a/packages/umi-build-dev/src/plugins/commands/block/addBlock.ts
+++ b/packages/umi-build-dev/src/plugins/commands/block/addBlock.ts
@@ -300,9 +300,13 @@ async function add(
 
   // 调用 sylvanas 转化 ts
   if (js) {
+    // 区块需要拼接一下 blockName，避免把路由入口文件也转换了
+    const relayPath = generator.isPageBlock
+      ? generator.blockFolderPath
+      : `${generator.blockFolderPath}/${generator.blockName}`;
     opts.remoteLog('🤔  TypeScript to JavaScript');
     spinner.start('🤔  TypeScript to JavaScript');
-    require('./tsTojs').default(generator.blockFolderPath);
+    require('./tsTojs').default(relayPath);
     spinner.succeed();
   }
 


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

添加区块的时候不应该把要添加到的入口文件也转换为 JS，否则添加区块引入的时候会找不到入口文件。通过 UI 添加的时候没这个问题，把相关逻辑也补充到命令行添加。

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/umi/3589)
<!-- Reviewable:end -->
