### PR TITLE
fix: TS 项目下 addUmiExports 缺乏 API 类型推导的问题

### DIFF
--- a/packages/umi-build-dev/src/plugins/importFromUmi.js
+++ b/packages/umi-build-dev/src/plugins/importFromUmi.js
@@ -68,5 +68,6 @@ export default function(api) {
       })
       .map(generateExports);
     api.writeTmpFile('umiExports.js', umiExports.join('\n'));
+    api.writeTmpFile('umiExports.d.ts', umiExports.join('\n'));
   };
 }


### PR DESCRIPTION
#### 说明

此改动不能直接修复问题，但为修复该问题的前置条件

余下需要在 ts 项目中 tsconfig.json 中增加对 `@tmp` 目录的 paths 配置

```json
{
  "compilerOptions": {
      "paths": {
        "@tmp/*": ["src/pages/.umi/*"]
      }
  }
}
```

[create-umi](https://github.com/umijs/create-umi) 与此问题的协作 PR ：https://github.com/umijs/create-umi/pull/93

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/umi/3600)
<!-- Reviewable:end -->
