### PR TITLE
fix: window.g_initialData block render thread when ssr

### DIFF
--- a/packages/umi-build-dev/src/FilesGenerator.js
+++ b/packages/umi-build-dev/src/FilesGenerator.js
@@ -226,10 +226,14 @@ export default class FilesGenerator {
           },
           headScripts: [
             {
-              content: `
-window.g_useSSR=true;
-window.g_initialData = \${require('${winPath(require.resolve('serialize-javascript'))}')(props)};
-              `.trim(),
+              content: 'window.g_useSSR=true;'.trim(),
+            },
+          ],
+          scripts: [
+            {
+              content: `window.g_initialData = \${require('${winPath(
+                require.resolve('serialize-javascript'),
+              )}')(props)};`.trim(),
             },
           ],
         });

--- a/packages/umi-build-dev/src/plugins/commands/getHtmlGenerator.js
+++ b/packages/umi-build-dev/src/plugins/commands/getHtmlGenerator.js
@@ -3,7 +3,7 @@ import HtmlGenerator from '../../html/HTMLGenerator';
 
 export default (service, opts = {}) => {
   const { config, paths, webpackConfig, routes } = service;
-  const { chunksMap, headScripts } = opts;
+  const { chunksMap, headScripts, scripts } = opts;
   return new HtmlGenerator({
     config,
     paths,
@@ -47,7 +47,7 @@ export default (service, opts = {}) => {
     modifyScripts(memo, opts = {}) {
       const { route } = opts;
       return service.applyPlugins('addHTMLScript', {
-        initialValue: memo,
+        initialValue: [...(scripts || []), ...memo],
         args: { route },
       });
     },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

`window.g_initialData` 数据量很大时，会阻碍首屏渲染。提到 `body` 里，`umi.js` 前。

![image](https://user-images.githubusercontent.com/13595509/68720965-e4a9ad00-05eb-11ea-8a89-b7c849afc76b.png)


##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
