### PR TITLE
doc update: 补充指南文档中「约定式路由」可能因配置式路由失效的提醒。

### DIFF
--- a/docs/guide/router.md
+++ b/docs/guide/router.md
@@ -33,6 +33,7 @@ Then, umi will automatically generate the routing configuration as follows:
   { path: '/users/list', component: './pages/users/list.js' },
 ]
 ```
+> Note：If router in file `.umirc.(ts|js) ` or `config/config.(ts|js)` is configured, basic routing will be invalid and new page you create will not be compiled automatically，Umi will use [Configuration Routing](#configuration-routing)。
 
 ### Dynamic Routing
 

--- a/docs/zh/guide/router.md
+++ b/docs/zh/guide/router.md
@@ -33,6 +33,7 @@ umi 会根据 `pages` 目录自动生成路由配置。
   { path: '/users/list', component: './pages/users/list.js' },
 ]
 ```
+> 注意：若 `.umirc.(ts|js) ` 或 `config/config.(ts|js)` 文件中对 router 进行了配置，约定式路由将失效、新添的页面不会自动被 umi 编译，umi 将使用[配置式路由](#配置式路由)。
 
 ### 动态路由
 


### PR DESCRIPTION


-----
[View rendered docs/zh/guide/router.md](https://github.com/Xiphap/umi/blob/master/docs/zh/guide/router.md)