### PR TITLE
feat: addPanel add renderTitle attribute for user custom

### DIFF
--- a/packages/umi-build-dev/src/plugins/commands/block/ui/client/index.tsx
+++ b/packages/umi-build-dev/src/plugins/commands/block/ui/client/index.tsx
@@ -26,7 +26,7 @@ export default (api: IUiApi) => {
 
   api.addPanel({
     title: 'org.umi.ui.blocks.content.title',
-    titleComponent: () => <TitleTab />,
+    headerTitle: <TitleTab />,
     provider: ({ children, ...restProps }) => (
       <Container.Provider initialState={{ api }} {...restProps}>
         {children}

--- a/packages/umi-types/ui.d.ts
+++ b/packages/umi-types/ui.d.ts
@@ -85,6 +85,10 @@ declare namespace IUI {
     icon: IconType | string;
     actions?: IPanelAction;
     beta?: boolean;
+    /** header title, default use `title` */
+    headerTitle?: ReactNode;
+    /** custom title Component */
+    renderTitle?: (title: string) => ReactNode;
   }
 
   interface IService {

--- a/packages/umi-ui/client/src/layouts/Dashboard.tsx
+++ b/packages/umi-ui/client/src/layouts/Dashboard.tsx
@@ -132,6 +132,7 @@ export default withRouter(props => {
           );
 
           const MenuItem = ({ panel, ...restProps }) => {
+            const { renderTitle } = panel;
             const renderIcon = () => {
               const icon = typeof panel.icon === 'string' ? { type: panel.icon } : panel.icon;
 
@@ -145,6 +146,9 @@ export default withRouter(props => {
               return <Icon {...icon} />;
             };
 
+            const titleText = renderLocaleText(panel.title);
+            const titleNode = renderTitle ? renderTitle(titleText) : titleText;
+
             return (
               <Menu.Item
                 key={panel.path}
@@ -156,9 +160,9 @@ export default withRouter(props => {
                 <NavLink exact to={`${panel.path}${search}`}>
                   {renderIcon()}
                   {isMini ? (
-                    <p className={styles.menuText}>{renderLocaleText(panel.title)}</p>
+                    <p className={styles.menuText}>{titleNode}</p>
                   ) : (
-                    <span className={styles.menuItem}>{renderLocaleText(panel.title)}</span>
+                    <span className={styles.menuItem}>{titleNode}</span>
                   )}
                 </NavLink>
               </Menu.Item>
@@ -330,7 +334,7 @@ export default withRouter(props => {
                       <div key="header" className={styles.header}>
                         <h1>
                           {activePanel &&
-                            (activePanel.titleComponent ? activePanel.titleComponent() : title)}
+                            (activePanel.headerTitle ? activePanel.headerTitle : title)}
                         </h1>
                         {Array.isArray(actions) && actions.length > 0 && (
                           <Row type="flex" className={styles['header-actions']}>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Usage

```diff
  api.addPanel({
    title: 'org.umi.ui.tasks.title',
+   renderTitle: (title) => <span style={{ letterSpacing: -3 }}>{title}</span>,
    path: '/tasks',
    icon: {
      type: 'project',
      theme: 'filled',
    },
    component: api.connect(state => ({ taskManager: state[model.namespace] }))(TasksView),
  });
```

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
