### PR TITLE
fix: Cannot read property 'startsWith' of undefined when use umi ui d…

### DIFF
--- a/packages/umi-build-dev/src/plugins/commands/block/ui/client/Adder/index.tsx
+++ b/packages/umi-build-dev/src/plugins/commands/block/ui/client/Adder/index.tsx
@@ -307,19 +307,21 @@ const Adder: React.FC<AdderProps> = props => {
           .validateFields()
           .then(async (values: any) => {
             setAddStatus('log');
-            const params: AddBlockParams = {
-              ...values,
-              url: block.url,
-              path: await getPathFromFilename(api, values.path),
-              routePath: blockType === 'template' ? values.routePath : undefined,
-              page: blockType === 'template',
-              // support: l-${index} or ${index}
-              index: values.index.startsWith('l-')
-                ? values.index
-                : parseInt(values.index || '0', 10),
-              name: blockType === 'template' ? block.name : values.name,
-            };
             try {
+              const params: AddBlockParams = {
+                ...values,
+                url: block.url,
+                path: await getPathFromFilename(api, values.path),
+                routePath: blockType === 'template' ? values.routePath : undefined,
+                page: blockType === 'template',
+                // support: l-${index} or ${index}
+                index:
+                  values.index && values.index.startsWith('l-')
+                    ? values.index
+                    : parseInt(values.index || '0', 10),
+                name: blockType === 'template' ? block.name : values.name,
+              };
+
               addBlock(api, params);
               localStorage.setItem('umi-ui-block-removeLocale', values.uni18n);
               onAddBlockChange(block);


### PR DESCRIPTION
fix: Cannot read property 'startsWith' of undefined when use `umi ui` directly. and message.error when fail.

Window环境直接使用 `umi ui` 抛异常问题修复：

```
VM564:37 TypeError: Cannot read property 'startsWith' of undefined
    at _callee4$ (eval at _callee2$ (app.ts:52), <anonymous>:46790:49)
    at tryCatch (runtime.js:45)
    at Generator.invoke [as _invoke] (runtime.js:271)
    at Generator.prototype.<computed> [as next] (runtime.js:97)
    at asyncGeneratorStep (eval at _callee2$ (app.ts:52), <anonymous>:40059:26)
    at _next (eval at _callee2$ (app.ts:52), <anonymous>:40081:11)
```

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- fix: Cannot read property 'startsWith' of undefined when use `umi ui` directly. and message.error when fail.