### PR TITLE
feat: support UI flag component from umi

### DIFF
--- a/docs/guide/develop-umi-ui-plugin.md
+++ b/docs/guide/develop-umi-ui-plugin.md
@@ -277,6 +277,35 @@ api.onUISocket(async () => {
 api.addUIPlugin(require.resolve('../ui/dist/index.umd.js'));
 ```
 
+### Custom Block Slots
+
+The `UmiUIFlag` component exported from `umi` can be used as a placeholder when the block is inserted. After the block is added, `UmiUIFlag` will be automatically deleted.
+
+```jsx
+import React from 'react';
+import { UmiUIFlag } from 'umi';
+
+import { Button } from 'antd';
+
+export default () => (
+  <div>Hello
+    <div>
+      <p>World</p>
+      <UmiUIFlag />
+      <p>
+        aaaaa
+        <div>
+          <UmiUIFlag inline />Hello Inline<UmiUIFlag inline />
+        </div>
+      </p>
+    </div>
+    <Button type="primary">World</Button>
+  </div>
+);
+```
+
+![](https://gw.alipayobjects.com/zos/antfincdn/9EfCMj46tx/f8a08273-4d19-46c0-91fc-fac2a5e9b4f0.png)
+
 ### Use Umi UI theme
 
 Umi UI provides a set of antd theme variables that third-party component libraries can use to develop plug-ins in non-Umi UI runtime environments.

--- a/docs/zh/guide/develop-umi-ui-plugin.md
+++ b/docs/zh/guide/develop-umi-ui-plugin.md
@@ -279,6 +279,35 @@ api.onUISocket(async () => {
 api.addUIPlugin(require.resolve('../ui/dist/index.umd.js'));
 ```
 
+### 自定义区块插槽
+
+从 umi 中导出 `UmiUIFlag` 组件，在区块插入时可用于占位，区块添加完成后，会自动删除 `UmiUIFlag`。
+
+```jsx
+import React from 'react';
+import { UmiUIFlag } from 'umi';
+
+import { Button } from 'antd';
+
+export default () => (
+  <div>Hello
+    <div>
+      <p>World</p>
+      <UmiUIFlag />
+      <p>
+        aaaaa
+        <div>
+          <UmiUIFlag inline />Hello Inline<UmiUIFlag inline />
+        </div>
+      </p>
+    </div>
+    <Button type="primary">World</Button>
+  </div>
+);
+```
+
+![](https://gw.alipayobjects.com/zos/antfincdn/9EfCMj46tx/f8a08273-4d19-46c0-91fc-fac2a5e9b4f0.png)
+
 ### 使用 Umi UI 主题
 
 Umi UI 提供了一套 antd 主题变量，可供第三方组件库在非 Umi UI 运行环境下，开发插件。

--- a/packages/umi-build-dev/src/plugins/commands/block/appendBlockToContainer.js
+++ b/packages/umi-build-dev/src/plugins/commands/block/appendBlockToContainer.js
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { dirname, join } from 'path';
 import insertComponent from './sdk/insertComponent';
-import { INSERT_BLOCK_PLACEHOLDER, UmiUIFlag } from './sdk/constants';
+import { INSERT_BLOCK_PLACEHOLDER, UMI_UI_FLAG_PLACEHOLDER } from './sdk/constants';
 
 const debug = require('debug')('umi-build-dev:appendBlockToContainer');
 
@@ -24,7 +24,8 @@ export default ({ entryPath, blockFolderName, dryRun, index }) => {
     relativePath: `./${blockFolderName}`,
     absolutePath,
     isExtractBlock:
-      blockContent.includes(INSERT_BLOCK_PLACEHOLDER) || blockContent.includes(UmiUIFlag),
+      blockContent.includes(INSERT_BLOCK_PLACEHOLDER) ||
+      blockContent.includes(UMI_UI_FLAG_PLACEHOLDER),
     index,
   });
 

--- a/packages/umi-build-dev/src/plugins/commands/block/appendBlockToContainer.js
+++ b/packages/umi-build-dev/src/plugins/commands/block/appendBlockToContainer.js
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { dirname, join } from 'path';
 import insertComponent from './sdk/insertComponent';
-import { INSERT_BLOCK_PLACEHOLDER } from './sdk/constants';
+import { INSERT_BLOCK_PLACEHOLDER, UmiUIFlag } from './sdk/constants';
 
 const debug = require('debug')('umi-build-dev:appendBlockToContainer');
 
@@ -23,7 +23,8 @@ export default ({ entryPath, blockFolderName, dryRun, index }) => {
     identifier: blockFolderName,
     relativePath: `./${blockFolderName}`,
     absolutePath,
-    isExtractBlock: blockContent.includes(INSERT_BLOCK_PLACEHOLDER),
+    isExtractBlock:
+      blockContent.includes(INSERT_BLOCK_PLACEHOLDER) || blockContent.includes(UmiUIFlag),
     index,
   });
 

--- a/packages/umi-build-dev/src/plugins/commands/block/sdk/constants.ts
+++ b/packages/umi-build-dev/src/plugins/commands/block/sdk/constants.ts
@@ -1,2 +1,3 @@
 export const BLOCK_LAYOUT_PREFIX = 'l-';
 export const INSERT_BLOCK_PLACEHOLDER = 'INSERT_BLOCK_PLACEHOLDER';
+export const UMI_UI_FLAG_PLACEHOLDER = 'UmiUIFlag';

--- a/packages/umi-build-dev/src/plugins/commands/block/sdk/flagBabelPlugin/GUmiUIFlag.tsx
+++ b/packages/umi-build-dev/src/plugins/commands/block/sdk/flagBabelPlugin/GUmiUIFlag.tsx
@@ -87,7 +87,10 @@ export default class GUmiUIFlag extends React.Component<GUmiUIFlagProps, GUmiUIF
           onClick={this.clickHandler}
           style={{
             ...(inline
-              ? {}
+              ? {
+                  display: 'inline-block',
+                  verticalAlign: 'middle',
+                }
               : {
                   margin: '10px 0',
                   height: '60px',

--- a/packages/umi-build-dev/src/plugins/commands/block/sdk/flagBabelPlugin/fixtures/ibp-component-flag/expected.js
+++ b/packages/umi-build-dev/src/plugins/commands/block/sdk/flagBabelPlugin/fixtures/ibp-component-flag/expected.js
@@ -8,6 +8,11 @@ export default function() {
       <div><GUmiUIFlag filename="/tmp/origin.js" index="l-1" />foo</div>
       <div><GUmiUIFlag filename="/tmp/origin.js" index="l-2" />bar</div>
       <div><GUmiUIFlag filename="/tmp/origin.js" index="l-3" /></div>
+      <div>
+        <GUmiUIFlag filename="/tmp/origin.js" index="l-4" inline="true" />
+        Hello
+        <GUmiUIFlag filename="/tmp/origin.js" index="l-5" inline="true" />
+      </div>
     </Step>
   );
 }

--- a/packages/umi-build-dev/src/plugins/commands/block/sdk/flagBabelPlugin/fixtures/ibp-component-flag/expected.js
+++ b/packages/umi-build-dev/src/plugins/commands/block/sdk/flagBabelPlugin/fixtures/ibp-component-flag/expected.js
@@ -1,0 +1,14 @@
+import { UmiUIFlag } from 'umi';
+import { Step } from 'antd';
+
+export default function() {
+  return (
+    <Step>
+      <div><GUmiUIFlag filename="/tmp/origin.js" index="l-0" /></div>
+      <div><GUmiUIFlag filename="/tmp/origin.js" index="l-1" />foo</div>
+      <div><GUmiUIFlag filename="/tmp/origin.js" index="l-2" />bar</div>
+      <div><GUmiUIFlag filename="/tmp/origin.js" index="l-3" /></div>
+    </Step>
+  );
+}
+

--- a/packages/umi-build-dev/src/plugins/commands/block/sdk/flagBabelPlugin/fixtures/ibp-component-flag/origin.js
+++ b/packages/umi-build-dev/src/plugins/commands/block/sdk/flagBabelPlugin/fixtures/ibp-component-flag/origin.js
@@ -8,6 +8,11 @@ export default function() {
       <div><UmiUIFlag />foo</div>
       <div><UmiUIFlag />bar</div>
       <div><UmiUIFlag /></div>
+      <div>
+        <UmiUIFlag inline />
+        Hello
+        <UmiUIFlag inline />
+      </div>
     </Step>
   );
 }

--- a/packages/umi-build-dev/src/plugins/commands/block/sdk/flagBabelPlugin/fixtures/ibp-component-flag/origin.js
+++ b/packages/umi-build-dev/src/plugins/commands/block/sdk/flagBabelPlugin/fixtures/ibp-component-flag/origin.js
@@ -1,0 +1,13 @@
+import { UmiUIFlag } from 'umi';
+import { Step } from 'antd';
+
+export default function() {
+  return (
+    <Step>
+      <div><UmiUIFlag /></div>
+      <div><UmiUIFlag />foo</div>
+      <div><UmiUIFlag />bar</div>
+      <div><UmiUIFlag /></div>
+    </Step>
+  );
+}

--- a/packages/umi-build-dev/src/plugins/commands/block/sdk/flagBabelPlugin/index.ts
+++ b/packages/umi-build-dev/src/plugins/commands/block/sdk/flagBabelPlugin/index.ts
@@ -10,7 +10,11 @@ import {
   haveChildren,
   isChildFunc,
 } from '../util';
-import { BLOCK_LAYOUT_PREFIX, INSERT_BLOCK_PLACEHOLDER } from '../constants';
+import {
+  BLOCK_LAYOUT_PREFIX,
+  INSERT_BLOCK_PLACEHOLDER,
+  UMI_UI_FLAG_PLACEHOLDER,
+} from '../constants';
 
 export default () => {
   function buildGUmiUIFlag(opts) {
@@ -241,7 +245,7 @@ export default () => {
             name: 'createElement',
           }) &&
           t.isIdentifier(args[0]) &&
-          args[0].name === 'UmiUIFlag'
+          args[0].name === UMI_UI_FLAG_PLACEHOLDER
         ) {
           if (!layoutIndexByFilename[filename]) {
             layoutIndexByFilename[filename] = 0;

--- a/packages/umi-build-dev/src/plugins/commands/block/sdk/flagBabelPlugin/index.ts
+++ b/packages/umi-build-dev/src/plugins/commands/block/sdk/flagBabelPlugin/index.ts
@@ -234,6 +234,46 @@ export default () => {
 
           layoutIndexByFilename[filename] += 1;
         }
+        // _react.default.createElement(_umi.UmiUIFlag, null)
+        if (
+          t.isMemberExpression(callee) &&
+          t.isIdentifier(callee.property, {
+            name: 'createElement',
+          }) &&
+          t.isIdentifier(args[0]) &&
+          args[0].name === 'UmiUIFlag'
+        ) {
+          if (!layoutIndexByFilename[filename]) {
+            layoutIndexByFilename[filename] = 0;
+          }
+
+          const index = layoutIndexByFilename[filename];
+
+          let content = null;
+          // TODO: inline
+          // let inline = false;
+          // if (t.isObjectExpression(args[1])
+          //   && args[1].properties.some(
+          //     property => t.isProperty(property)
+          //       && property.key?.name === 'inline'
+          //       && property.key?.value === true
+          //     )
+          // ) {
+          //   inline = true;
+          // }
+
+          path.replaceWith(
+            buildGUmiUIFlag({
+              index: `${BLOCK_LAYOUT_PREFIX}${index}`,
+              filename: winPath(filename),
+              jsx: false,
+              inline: false,
+              content,
+            }),
+          );
+
+          layoutIndexByFilename[filename] += 1;
+        }
       },
     },
   };

--- a/packages/umi-build-dev/src/plugins/commands/block/sdk/flagBabelPlugin/index.ts
+++ b/packages/umi-build-dev/src/plugins/commands/block/sdk/flagBabelPlugin/index.ts
@@ -250,24 +250,25 @@ export default () => {
           const index = layoutIndexByFilename[filename];
 
           let content = null;
-          // TODO: inline
-          // let inline = false;
-          // if (t.isObjectExpression(args[1])
-          //   && args[1].properties.some(
-          //     property => t.isProperty(property)
-          //       && property.key?.name === 'inline'
-          //       && property.key?.value === true
-          //     )
-          // ) {
-          //   inline = true;
-          // }
+          let inline = false;
+          if (
+            t.isObjectExpression(args[1]) &&
+            args[1].properties.some(
+              property =>
+                t.isProperty(property) &&
+                property.key?.name === 'inline' &&
+                property.value?.value === true,
+            )
+          ) {
+            inline = true;
+          }
 
           path.replaceWith(
             buildGUmiUIFlag({
               index: `${BLOCK_LAYOUT_PREFIX}${index}`,
               filename: winPath(filename),
               jsx: false,
-              inline: false,
+              inline,
               content,
             }),
           );

--- a/packages/umi-build-dev/src/plugins/commands/block/sdk/insertComponent/index.ts
+++ b/packages/umi-build-dev/src/plugins/commands/block/sdk/insertComponent/index.ts
@@ -112,23 +112,25 @@ export default (content, opts) => {
     const targetIndex = parseInt(index.replace(BLOCK_LAYOUT_PREFIX, ''), 10);
     let currIndex = 0;
     traverse(ast, {
-      // remove import { UmiUIFlag } from 'umi'
-      // remove import { UmiUIFlag, AAA } from 'umi' => import { AAA } from 'umi'
-      ImportDeclaration(path) {
-        const { node } = path;
-        const specifierIndex = node.specifiers.findIndex(
-          specify =>
-            t.isImportSpecifier(specify) && specify.imported.name === UMI_UI_FLAG_PLACEHOLDER,
-        );
-        if (specifierIndex > -1) {
-          if (node.specifiers.length === 1) {
-            // import { UmiUIFlag } from 'umi'
-            path.remove();
-          } else {
-            path.get(`specifiers.${specifierIndex}`).remove();
-          }
-        }
-      },
+      // TODO: remove import { UmiUIFlag } from 'umi'
+      // TODO: remove import { UmiUIFlag, AAA } from 'umi' => import { AAA } from 'umi'
+      // ImportDeclaration: {
+      //   exit(path) {
+      //     const { node } = path;
+      //     const specifierIndex = node.specifiers.findIndex(
+      //       specify =>
+      //         t.isImportSpecifier(specify) && specify.imported.name === UMI_UI_FLAG_PLACEHOLDER,
+      //     );
+      //     if (specifierIndex > -1) {
+      //       if (node.specifiers.length === 1) {
+      //         // import { UmiUIFlag } from 'umi'
+      //         path.remove();
+      //       } else {
+      //         path.get(`specifiers.${specifierIndex}`).remove();
+      //       }
+      //     }
+      //   },
+      // },
       // support <UmiUIFlag inline={} />
       JSXElement(path) {
         const { node } = path;

--- a/packages/umi-build-dev/src/plugins/commands/block/sdk/insertComponent/index.ts
+++ b/packages/umi-build-dev/src/plugins/commands/block/sdk/insertComponent/index.ts
@@ -20,7 +20,11 @@ import {
   combineImportNodes,
   getValidStylesName,
 } from '../util';
-import { BLOCK_LAYOUT_PREFIX, INSERT_BLOCK_PLACEHOLDER } from '../constants';
+import {
+  BLOCK_LAYOUT_PREFIX,
+  INSERT_BLOCK_PLACEHOLDER,
+  UMI_UI_FLAG_PLACEHOLDER,
+} from '../constants';
 
 export default (content, opts) => {
   const {
@@ -108,6 +112,48 @@ export default (content, opts) => {
     const targetIndex = parseInt(index.replace(BLOCK_LAYOUT_PREFIX, ''), 10);
     let currIndex = 0;
     traverse(ast, {
+      // remove import { UmiUIFlag } from 'umi'
+      // remove import { UmiUIFlag, AAA } from 'umi' => import { AAA } from 'umi'
+      ImportDeclaration(path) {
+        const { node } = path;
+        const specifierIndex = node.specifiers.findIndex(
+          specify =>
+            t.isImportSpecifier(specify) && specify.imported.name === UMI_UI_FLAG_PLACEHOLDER,
+        );
+        if (specifierIndex > -1) {
+          if (node.specifiers.length === 1) {
+            // import { UmiUIFlag } from 'umi'
+            path.remove();
+          } else {
+            path.get(`specifiers.${specifierIndex}`).remove();
+          }
+        }
+      },
+      // support <UmiUIFlag inline={} />
+      JSXElement(path) {
+        const { node } = path;
+        const { openingElement } = node;
+        if (
+          t.isJSXIdentifier(openingElement.name) &&
+          openingElement.name.name === UMI_UI_FLAG_PLACEHOLDER
+        ) {
+          if (targetIndex === currIndex) {
+            // 添加过之后无需提示
+            const id = uppercamelcase(identifier);
+            addImport(path.findParent(p => p.isProgram()).node, id);
+            const newNode = t.jsxElement(
+              t.jsxOpeningElement(t.jsxIdentifier(id), [], true),
+              null,
+              [],
+              true,
+            );
+            path.parent.children.push(newNode);
+            // remove <UmiUIFlag />
+            path.remove();
+          }
+          currIndex += 1;
+        }
+      },
       JSXText(path) {
         const { node } = path;
         const { value } = node;

--- a/packages/umi-build-dev/src/plugins/commands/block/ui/server/core/Flow.ts
+++ b/packages/umi-build-dev/src/plugins/commands/block/ui/server/core/Flow.ts
@@ -55,6 +55,7 @@ class Flow extends EventEmitter {
         await task(this.ctx, args);
         this.setStepState(name, StepState.SUCCESS);
       } catch (e) {
+        console.error('Execute task error', e);
         hasBreak = true;
         /**
          * 抛错有两种情况

--- a/packages/umi/.fatherrc.js
+++ b/packages/umi/.fatherrc.js
@@ -2,7 +2,7 @@ export default {
   target: 'node',
   cjs: { type: 'babel', lazy: true },
   esm: 'rollup',
-  disableTypeCheck: true,
+  // disableTypeCheck: true,
   browserFiles: [
     'src/createHistory.js',
     'src/dynamic.js',
@@ -15,6 +15,7 @@ export default {
     'src/router.js',
     'src/runtimePlugin.js',
     'src/utils.js',
+    'src/UmiUIFlag.tsx',
     'src/withRouter.js',
   ],
   extraExternals: ['@@', 'react-router-dom', 'react'],

--- a/packages/umi/UmiUIFlag.d.ts
+++ b/packages/umi/UmiUIFlag.d.ts
@@ -2,15 +2,8 @@
  * A component that provides points for umi ui
  */
 import React from 'react';
-
 export interface UmiUIFlagProps {
   inline?: boolean;
 }
-
-const UmiUIFlag: React.FunctionComponent = () => {
-  return <></>;
-};
-
-UmiUIFlag.displayName = 'INSERT_BLOCK_PLACEHOLDER';
-
+declare const UmiUIFlag: React.FunctionComponent<UmiUIFlagProps>;
 export default UmiUIFlag;

--- a/packages/umi/index.d.ts
+++ b/packages/umi/index.d.ts
@@ -9,5 +9,7 @@ export { default as withRouter } from './withRouter';
 
 export { default as RouterTypes } from './routerTypes';
 
+export { default as UmiUIFlag } from './UmiUIFlag';
+
 // @ts-ignore
 export * from '@@/umiExports';

--- a/packages/umi/src/UmiUIFlag.tsx
+++ b/packages/umi/src/UmiUIFlag.tsx
@@ -1,0 +1,12 @@
+/**
+ * A component that provides points for umi ui
+ */
+import React from 'react';
+
+const UmiUIFlag: React.FunctionComponent = () => {
+  return <></>;
+};
+
+UmiUIFlag.displayName = 'INSERT_BLOCK_PLACEHOLDER';
+
+export default UmiUIFlag;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

```jsx
import React from 'react';
import { UmiUIFlag } from 'umi';

import { Button } from 'antd';

export default () => (
  <div>Hello
    <div>
      <p>World</p>
      <UmiUIFlag />
      <p>
        aaaaa
        <div>
          <UmiUIFlag inline />Hello Inline<UmiUIFlag inline />
        </div>
      </p>
    </div>
    <Button type="primary">World</Button>
  </div>
);
```

![image](https://user-images.githubusercontent.com/13595509/72066917-c1b22580-331c-11ea-931b-e958973e6895.png)


##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
