### PR TITLE
Update deploy.md

### DIFF
--- a/docs/guide/deploy.md
+++ b/docs/guide/deploy.md
@@ -18,7 +18,7 @@ I often have students asking this question:
 
 > Why is my local development good, no response after deployment, and no error?
 
-**No error!** This is a typical phenomenon where an application is deployed on a non-root path. Why do you have this problem? Because the route does not match, for example, if you deploy the application under `/xxx/` and then access `/xxx/hello`, and the code matches `/hello`, then it will not match, but there is no definition. A fallback route, such as 404, will display a blank page.
+**No error!** This is a typical phenomenon where an application is deployed on a non-root path. Why do you have this problem? Because the route does not match, for example, if you deploy the application under `/xxx/` and then access `/xxx/hello`, and the code matches `/hello`, then it will not match, but there is no definition of a fallback route such as 404,  it will display a blank page.
 
 How to deal with it?
 


### PR DESCRIPTION
纠正英文翻译里的一点小瑕疵。

中文：“又没有定义 fallback 的路由，比如 404，那就会显示空白页。”
翻译成英文，应该是 “there is no definition of a fallback route such as 404,  it will display a blank page.”

因为没有定义404，才会显示空白页。


原来的英文译文“ A fallback route, such as 404, will display a blank page.”
对应的中文意思是： “一个fallback的路由，比如404，会显示空白页”。
404的路由显示空白页，这意思不对。

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL


-----
[View rendered docs/guide/deploy.md](https://github.com/vegan2019/umi/blob/patch-2/docs/guide/deploy.md)