### PR TITLE
feat: support all history options for each history type

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -93,15 +93,26 @@ export default {
 - Type: `String | [String, Object]`
 - Default: `browser`
 
-Specify the history type, including `browser`, `hash` and `memory`.
+Specify the history type and options, type could be `browser`, `hash` and `memory`.
+
+Options for each type can be found at [history's doc](https://github.com/ReactTraining/history/blob/master/docs/GettingStarted.md#basic-usage).
 
 e.g.
 
 ```js
 export default {
-  history: 'hash',
+  history: [
+    'hash',
+    {
+      basename: '',
+      hashType: 'noslash'
+      getUserConfirmation: './components/LeavePrompt',  // method or method path
+    }
+  ],
 };
 ```
+
+> `basename` will be overridden if [base](#base) is configured.
 
 ### outputPath
 

--- a/docs/zh/config/README.md
+++ b/docs/zh/config/README.md
@@ -95,15 +95,26 @@ export default {
 - 类型：`String | [String, Object]`
 - 默认值：`browser`
 
-指定 history 类型，可选 `browser`、`hash` 和 `memory`。
+指定 history 类型和参数，类型可选 `browser`、`hash` 和 `memory`。
+
+数组第二项可配置 [对应类型 history 的参数](https://github.com/ReactTraining/history/blob/master/docs/GettingStarted.md#basic-usage)。
 
 比如：
 
 ```js
 export default {
-  history: 'hash',
+  history: [
+    'hash',
+    {
+      basename: '',
+      hashType: 'noslash'
+      getUserConfirmation: './components/LeavePrompt',  // 指定getUserConfirmation方法或方法路径
+    }
+  ],
 };
 ```
+
+> options 中的 `basename` 会被 [base](#base) 覆盖
 
 ### outputPath
 

--- a/packages/umi-build-dev/src/FilesGenerator.js
+++ b/packages/umi-build-dev/src/FilesGenerator.js
@@ -284,17 +284,18 @@ export default class FilesGenerator {
   generateHistory() {
     const { paths, config } = this.service;
     const tpl = readFileSync(paths.defaultHistoryTplPath, 'utf-8');
-    const initialHistory = `
-require('umi/lib/createHistory').default({
-  basename: window.routerBase,
-})
-    `.trim();
+
     let history = this.service.applyPlugins('modifyEntryHistory', {
-      initialValue: initialHistory,
+      initialValue: '',
+      args: { ssr: false },
     });
     if (config.ssr) {
+      const browserHistory = this.service.applyPlugins('modifyEntryHistory', {
+        initialValue: '',
+        args: { ssr: true },
+      });
       history = `
-__IS_BROWSER ? ${initialHistory} : require('history').createMemoryHistory({
+__IS_BROWSER ? ${browserHistory} : require('history').createMemoryHistory({
   // for history object in dva
   initialEntries: [global.req ? global.req.url : '/']
 })

--- a/packages/umi-build-dev/src/plugins/history.js
+++ b/packages/umi-build-dev/src/plugins/history.js
@@ -1,9 +1,32 @@
 import assert from 'assert';
 import { existsSync, unlinkSync } from 'fs';
 import { join } from 'path';
+import isPlainObject from 'lodash/isPlainObject';
+import { winPath } from 'umi-utils';
 
 function getHistoryConfig(val) {
   return Array.isArray(val) ? val : [val];
+}
+
+export function getHistoryConfigString(opts, absSrcPath, extra = []) {
+  let ret = Object.keys(opts).map(key => {
+    let valueStr = `${opts[key]}`;
+    if (typeof opts[key] === 'string') valueStr = `'${opts[key]}'`;
+    if (typeof opts[key] === 'object') valueStr = JSON.stringify(opts[key]);
+
+    if (key === 'getUserConfirmation') {
+      if (typeof opts[key] === 'string' && /^\.{1,2}\//.test(opts[key])) {
+        valueStr = `require('${winPath(join(absSrcPath, opts.getUserConfirmation))}').default`;
+      } else if (typeof opts[key] === 'function') {
+        valueStr = `${opts[key].toString()}`;
+      } else {
+        valueStr = 'undefined';
+      }
+    }
+    return `${key}: ${valueStr}`;
+  });
+  if (extra) ret = ret.concat(extra);
+  return `{${ret.join(',\r\n')}}`;
 }
 
 export default function(api) {
@@ -14,11 +37,17 @@ export default function(api) {
       return {
         name: 'history',
         validate(val) {
-          const [historyType] = getHistoryConfig(val);
+          const [historyType, opts] = getHistoryConfig(val);
           assert(
             ['browser', 'hash', 'memory'].includes(historyType),
             `history should be browser or hash, but got ${historyType}`,
           );
+          if (opts) {
+            assert(
+              isPlainObject(opts),
+              `history options should be plain object, but got ${typeof opts}`,
+            );
+          }
         },
         onChange() {
           // regenerate dll file
@@ -45,16 +74,33 @@ export default function(api) {
     };
   });
 
-  api.modifyEntryHistory(memo => {
-    const [historyType, opts] = getHistoryConfig(config.history);
-
-    if (historyType === 'hash') {
-      const hashOpts = JSON.stringify({ basename: config.base || '/', ...opts } || {});
-      return `require('history/createHashHistory').default(${hashOpts})`;
-    } else if (historyType === 'memory') {
-      return `require('history/createMemoryHistory').default({ initialEntries: window.g_initialEntries })`;
+  api.modifyEntryHistory((memo, { ssr }) => {
+    const [historyType, opts = {}] = getHistoryConfig(config.history);
+    // use browserHistory by default or ssr is on
+    let extra = [];
+    if (config.exportStatic && config.exportStatic.dynamicRoot) {
+      extra = ['basename: window.routerBase'];
     }
-    return memo;
+    const browserOpts = getHistoryConfigString(
+      { ...opts, basename: config.base || opts.basename || '/' },
+      paths.absSrcPath,
+      extra,
+    );
+    let history = `require('umi/lib/createHistory').default(${browserOpts})`;
+    if (ssr) return history;
+    if (historyType === 'hash') {
+      const hashOpts = getHistoryConfigString(
+        { ...opts, basename: config.base || opts.basename || '/' },
+        paths.absSrcPath,
+      );
+      history = `require('history').createHashHistory(${hashOpts})`;
+    } else if (historyType === 'memory') {
+      const memoryOpts = getHistoryConfigString({ ...opts }, paths.absSrcPath, [
+        'initialEntries: window.g_initialEntries',
+      ]);
+      history = `require('history').createMemoryHistory(${memoryOpts})`;
+    }
+    return history;
   });
 
   api.addHTMLHeadScript((memo, { route }) => {

--- a/packages/umi-build-dev/src/plugins/history.test.js
+++ b/packages/umi-build-dev/src/plugins/history.test.js
@@ -1,0 +1,65 @@
+import { getHistoryConfigString } from './history';
+
+it('string', () => {
+  const optString = getHistoryConfigString({
+    basename: '/app',
+  });
+  expect(optString).toBe("{basename: '/app'}");
+});
+
+it('strings', () => {
+  const optString = getHistoryConfigString({
+    basename: '/app',
+    hashType: 'slash',
+  });
+  expect(optString).toMatch(/{basename: '\/app',(\s)*hashType: 'slash'}/);
+});
+
+it('number and bool', () => {
+  const optString = getHistoryConfigString({
+    forceRefresh: false,
+    keyLength: 6,
+  });
+  // not: {forceRefresh: 'false',keyLength: "6"}
+  expect(optString).toMatch(/{forceRefresh: false,(\s)*keyLength: 6}/);
+});
+
+it('function', () => {
+  const optString = getHistoryConfigString({
+    getUserConfirmation: () => {},
+  });
+  // not: {getUserConfirmation: "() => {}"} or {getUserConfirmation: "function getUserConfirmation() {}"}
+  expect(optString).toBe('{getUserConfirmation: function getUserConfirmation() {}}');
+});
+
+it('getUserConformation', () => {
+  const optString = getHistoryConfigString(
+    {
+      getUserConfirmation: './componets/LeavePrompt',
+    },
+    '$(absSrcPath)',
+  );
+  expect(optString).toBe(
+    "{getUserConfirmation: require('$(absSrcPath)/componets/LeavePrompt').default}",
+  );
+});
+
+it('other', () => {
+  const optString = getHistoryConfigString(
+    {
+      initialEntries: ['/'],
+      getUserConfirmation: null,
+    },
+    '$(absSrcPath)',
+  );
+  // not: {initialEntries: "['/']", getUserConfirmation: null} or {initialEntries: "/", getUserConfirmation: null}
+  expect(optString).toMatch(/{initialEntries: \["\/"\],(\s)*getUserConfirmation: undefined}/);
+});
+
+it('extra', () => {
+  const optString = getHistoryConfigString({}, '$(absSrcPath)', [
+    'initialEntries: window.g_initialEntries',
+  ]);
+  // not: {initialEntries: 'window.g_initialEntries'}
+  expect(optString).toBe('{initialEntries: window.g_initialEntries}');
+});

--- a/packages/umi-types/index.d.ts
+++ b/packages/umi-types/index.d.ts
@@ -378,6 +378,10 @@ export interface IAddImportOpts {
   specifier?: string;
 }
 
+interface modifyEntryHistoryArgs {
+  ssr: boolean;
+}
+
 interface IModifyRouteComponentArgs {
   importPath: string;
   webpackChunkName: string;
@@ -524,7 +528,7 @@ export interface IApi {
   addRendererWrapperWithComponent: IAdd<string, () => string>;
   addRendererWrapperWithModule: IAdd<string>;
   modifyEntryRender: IModify<string>;
-  modifyEntryHistory: IModify<string>;
+  modifyEntryHistory: IModify<string, modifyEntryHistoryArgs>;
   modifyRouteComponent: IModify<string, IModifyRouteComponentArgs>;
   modifyRouterRootComponent: IModify<string>;
   modifyWebpackConfig: IModify<IWebpack.Configuration>;

--- a/packages/umi/src/createHistory.js
+++ b/packages/umi/src/createHistory.js
@@ -1,8 +1,8 @@
-import createHistory from 'history/createBrowserHistory';
+import { createBrowserHistory } from 'history';
 import { normalizePath } from './utils';
 
 export default function(opts) {
-  const history = createHistory(opts);
+  const history = createBrowserHistory(opts);
   if (__UMI_HTML_SUFFIX) {
     const oldPush = history.push;
     const oldReplace = history.replace;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- history 配置支持数组传入 history [支持的所有 options](https://github.com/ReactTraining/history/blob/master/docs/GettingStarted.md#basic-usage)

  可以通过传入getUserConfirmation函数或函数路径实现自定义的 confirmation。

  https://github.com/umijs/umi/issues/2503
  https://github.com/umijs/umi/issues/2337
  https://github.com/umijs/umi/issues/1688

  使用示例

  ```js
  // .umirc.js
  export default {
    history: [
      'hash',
      {
        basename: '',
        hashType: 'noslash'
        getUserConfirmation: './components/LeavePrompt', 
      }
    ],
  };
  ```

  ```js
  // /src/components/LeavePrompt.js
  import { Modal } from 'antd';
  export default function(message, callback) {
    Modal.confirm({
      title: message,
      onOk() {
        callback(true);
      },
      onCancel() {
       callback(false);
      },
    })
  }
  ```
 
  页面中配合 `umi/prompt` 即可实现自定义路由切换询问提示

- close https://github.com/umijs/umi/ISSUE_URL


-----
[View rendered docs/config/README.md](https://github.com/zhiyuc123/umi/blob/leaveConfirmation/docs/config/README.md)
[View rendered docs/zh/config/README.md](https://github.com/zhiyuc123/umi/blob/leaveConfirmation/docs/zh/config/README.md)