### PR TITLE
feat(runtimePublicPath): runtimePublicPath supports string setting

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -128,10 +128,10 @@ Specifies the publicPath of the webpack, pointing to the path where the static r
 
 ### runtimePublicPath
 
-- Type: `Boolean`
+- Type: `Boolean` | `String`
 - Default: `false`
 
-Use the `window.publicPath` specified in the HTML when the value is `true`.
+Use the `window.publicPath` specified in the HTML when the value is `true`. You can also set it to a specified string variable, the theory is same as [modifyPublicPathStr](/plugin/develop.html#modifyPublicPathStr).
 
 ### cssPublicPath <Badge text="2.2.5+"/>
 

--- a/docs/zh/config/README.md
+++ b/docs/zh/config/README.md
@@ -130,10 +130,10 @@ export default {
 
 ### runtimePublicPath
 
-- 类型：`Boolean`
+- 类型：`Boolean` | `String`
 - 默认值：`false`
 
-值为 `true` 时使用 HTML 里指定的 `window.publicPath`。
+值为 `true` 时使用 HTML 里指定的 `window.publicPath`。也可以设置为指定的字符串变量，原理同 [modifyPublicPathStr](/zh/plugin/develop.html#modifypublicpathstr)。
 
 ### cssPublicPath <Badge text="2.2.5+"/>
 

--- a/docs/zh/plugin/develop.md
+++ b/docs/zh/plugin/develop.md
@@ -511,6 +511,15 @@ api.modifyHTMLWithAST(($, { route, getChunkPath }) => {
 
 修改 html ejs 渲染时的环境参数。
 
+```js
+api.modifyHTMLContext((memo, { route }) => {
+  return {
+    ...memo,
+    title: route.title, // umi-plugin-react 的 title 插件包含了类似的逻辑
+  };
+});
+```
+
 ### modifyPublicPathStr
 
 修改运行时的 `window.publicPath` 对应的变量值。
@@ -520,15 +529,6 @@ api.modifyPublicPathStr('window.__self_injected_public_path__');
 ```
 
 这将会导致 `window.publicPath = window.__self_injected_public_path__`.
-
-```js
-api.modifyHTMLContext((memo, { route }) => {
-  return {
-    ...memo,
-    title: route.title, // umi-plugin-react 的 title 插件包含了类似的逻辑
-  };
-});
-```
 
 ### modifyRoutes
 

--- a/packages/umi-build-dev/src/html/HTMLGenerator.js
+++ b/packages/umi-build-dev/src/html/HTMLGenerator.js
@@ -259,6 +259,10 @@ export default class HTMLGenerator {
       publicPathStr = this.modifyPublicPathStr(publicPathStr);
     }
 
+    if (typeof runtimePublicPath === 'string') {
+      publicPathStr = runtimePublicPath;
+    }
+
     const setPublicPath = runtimePublicPath || (exportStatic && exportStatic.dynamicRoot);
     headScripts.push({
       content: [

--- a/packages/umi-build-dev/src/html/HTMLGenerator.test.js
+++ b/packages/umi-build-dev/src/html/HTMLGenerator.test.js
@@ -264,6 +264,44 @@ describe('HG', () => {
     );
   });
 
+  it('getContent with runtimePublicPath string', () => {
+    const hg = new HTMLGenerator({
+      env: 'production',
+      chunksMap: {
+        umi: ['umi.js', 'umi.css'],
+      },
+      minify: false,
+      config: {
+        runtimePublicPath: '/runtimePublicPathStr/',
+        mountElementId: 'documenttestid',
+      },
+      paths: {
+        cwd: '/a',
+        absPageDocumentPath: '/tmp/files-not-exists',
+        defaultDocumentPath: join(__dirname, 'fixtures/document.ejs'),
+      },
+    });
+    const content = hg.getContent({
+      path: '/',
+    });
+    expect(winEOL(content.trim())).toEqual(
+      `
+<head>
+
+<link rel="stylesheet" href="/umi.css" />
+<script>
+  window.routerBase = "/";
+  window.publicPath = "/runtimePublicPathStr/";
+</script>
+</head>
+<body>
+<div id="documenttestid"></div>
+<script src="/umi.js"></script>
+</body>
+    `.trim(),
+    );
+  });
+
   it('getContent in development', () => {
     const hg = new HTMLGenerator({
       env: 'development',

--- a/packages/umi-build-dev/src/html/HTMLGenerator.test.js
+++ b/packages/umi-build-dev/src/html/HTMLGenerator.test.js
@@ -272,7 +272,7 @@ describe('HG', () => {
       },
       minify: false,
       config: {
-        runtimePublicPath: '/runtimePublicPathStr/',
+        runtimePublicPath: 'window.__injected_runtime_public_path__ || "/"',
         mountElementId: 'documenttestid',
       },
       paths: {
@@ -291,7 +291,7 @@ describe('HG', () => {
 <link rel="stylesheet" href="/umi.css" />
 <script>
   window.routerBase = "/";
-  window.publicPath = "/runtimePublicPathStr/";
+  window.publicPath = window.__injected_runtime_public_path__ || "/";
 </script>
 </head>
 <body>

--- a/packages/umi-types/config.d.ts
+++ b/packages/umi-types/config.d.ts
@@ -98,7 +98,7 @@ interface IConfig extends IAFWebpackConfig {
   outputPath?: string;
   plugins?: IPlugin[];
   routes?: IRoute[] | null;
-  runtimePublicPath?: boolean;
+  runtimePublicPath?: boolean | string;
   singular?: boolean;
   mock?: IMockOpts;
   treeShaking?: boolean;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- runtimePublicPath 支持设置成指定 string，类似 [modifyPublicPathStr](https://umijs.org/zh/plugin/develop.html#modifypublicpathstr)

有一些场景在部署的时候平台会注入一些自己的动态 publicPath 变量，比如 basement deployMode 为 render 和 sff 时，这些场景可以直接将这些变量赋给 `window.publicPath`


-----
[View rendered docs/config/README.md](https://github.com/umijs/umi/blob/feat/runtimePublicPath-str/docs/config/README.md)
[View rendered docs/zh/config/README.md](https://github.com/umijs/umi/blob/feat/runtimePublicPath-str/docs/zh/config/README.md)
[View rendered docs/zh/plugin/develop.md](https://github.com/umijs/umi/blob/feat/runtimePublicPath-str/docs/zh/plugin/develop.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/umi/3975)
<!-- Reviewable:end -->
