### PR TITLE
fix: service.resolvePackage not working properly while APP_ROOT specified

### DIFF
--- a/packages/core/src/Service/Service.test.ts
+++ b/packages/core/src/Service/Service.test.ts
@@ -473,3 +473,13 @@ test('hasPlugins and hasPresets', async () => {
   service.userConfig.mie = 1;
   expect(service.hasPlugins(['mie_id'])).toEqual(true);
 });
+
+test('resolvePackage with APP_ROOT specified', () => {
+  const appRoot = join(fixtures, 'normal', 'approot', 'nextlevel');
+  const repoRoot = join(fixtures, 'normal');
+  const service = new Service({
+    cwd: appRoot,
+    repoDir: repoRoot,
+  });
+  expect(service.pkg.name).toEqual('foo');
+});

--- a/packages/core/src/Service/Service.test.ts
+++ b/packages/core/src/Service/Service.test.ts
@@ -479,7 +479,7 @@ test('resolvePackage with APP_ROOT specified', () => {
   const repoRoot = join(fixtures, 'normal');
   const service = new Service({
     cwd: appRoot,
-    repoDir: repoRoot,
+    pkg: require(join(repoRoot, 'package.json')),
   });
   expect(service.pkg.name).toEqual('foo');
 });

--- a/packages/core/src/Service/Service.ts
+++ b/packages/core/src/Service/Service.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join, dirname } from 'path';
 import { EventEmitter } from 'events';
 import assert from 'assert';
 import { BabelRegister, NodeEnv, lodash } from '@umijs/utils';
@@ -24,6 +24,7 @@ const logger = new Logger('umi:core:Service');
 
 export interface IServiceOpts {
   cwd: string;
+  repoDir?: string;
   presets?: string[];
   plugins?: string[];
   env?: NodeEnv;
@@ -39,6 +40,7 @@ interface IConfig {
 // 1. duplicated key
 export default class Service extends EventEmitter {
   cwd: string;
+  repoDir?: string;
   pkg: IPackage;
   skipPluginIds: Set<string> = new Set<string>();
   // lifecycle stage
@@ -96,6 +98,8 @@ export default class Service extends EventEmitter {
     logger.debug('opts:');
     logger.debug(opts);
     this.cwd = opts.cwd || process.cwd();
+    // repoDir should be the root dir of repo
+    this.repoDir = opts.repoDir;
     this.pkg = this.resolvePackage();
     this.env = opts.env || process.env.NODE_ENV;
 
@@ -164,7 +168,11 @@ export default class Service extends EventEmitter {
     try {
       return require(join(this.cwd, 'package.json'));
     } catch (e) {
-      return {};
+      try {
+        return require(join(this.repoDir || '', 'package.json'));
+      } catch (err) {
+        return {};
+      }
     }
   }
 

--- a/packages/core/src/Service/Service.ts
+++ b/packages/core/src/Service/Service.ts
@@ -24,7 +24,7 @@ const logger = new Logger('umi:core:Service');
 
 export interface IServiceOpts {
   cwd: string;
-  repoDir?: string;
+  pkg?: IPackage;
   presets?: string[];
   plugins?: string[];
   env?: NodeEnv;
@@ -40,7 +40,6 @@ interface IConfig {
 // 1. duplicated key
 export default class Service extends EventEmitter {
   cwd: string;
-  repoDir?: string;
   pkg: IPackage;
   skipPluginIds: Set<string> = new Set<string>();
   // lifecycle stage
@@ -99,8 +98,7 @@ export default class Service extends EventEmitter {
     logger.debug(opts);
     this.cwd = opts.cwd || process.cwd();
     // repoDir should be the root dir of repo
-    this.repoDir = opts.repoDir;
-    this.pkg = this.resolvePackage();
+    this.pkg = opts.pkg || this.resolvePackage();
     this.env = opts.env || process.env.NODE_ENV;
 
     assert(existsSync(this.cwd), `cwd ${this.cwd} does not exist.`);
@@ -168,11 +166,7 @@ export default class Service extends EventEmitter {
     try {
       return require(join(this.cwd, 'package.json'));
     } catch (e) {
-      try {
-        return require(join(this.repoDir || '', 'package.json'));
-      } catch (err) {
-        return {};
-      }
+      return {};
     }
   }
 

--- a/packages/core/src/Service/fixtures/normal/approot/nextlevel/pages/test.tsx
+++ b/packages/core/src/Service/fixtures/normal/approot/nextlevel/pages/test.tsx
@@ -1,0 +1,3 @@
+export default () => {
+  return <p>test</p>
+}

--- a/packages/preset-built-in/src/fixtures/build/package.json
+++ b/packages/preset-built-in/src/fixtures/build/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "build-test"
+}

--- a/packages/umi/src/cli.ts
+++ b/packages/umi/src/cli.ts
@@ -4,6 +4,7 @@ import { existsSync } from 'fs';
 import { Service } from './ServiceWithBuiltIn';
 import fork from './utils/fork';
 import getCwd from './utils/getCwd';
+import getPkg from './utils/getPkg';
 
 // process.argv: [node, umi.js, command, args]
 const args = yParser(process.argv.slice(2), {
@@ -49,7 +50,7 @@ if (args.help && !args._[0]) {
         }
         await new Service({
           cwd: getCwd(),
-          repoDir: process.cwd(),
+          pkg: getPkg(process.cwd()),
         }).run({
           name,
           args,

--- a/packages/umi/src/cli.ts
+++ b/packages/umi/src/cli.ts
@@ -49,6 +49,7 @@ if (args.help && !args._[0]) {
         }
         await new Service({
           cwd: getCwd(),
+          repoDir: process.cwd(),
         }).run({
           name,
           args,

--- a/packages/umi/src/forkedDev.ts
+++ b/packages/umi/src/forkedDev.ts
@@ -9,6 +9,7 @@ const args = yParser(process.argv.slice(2));
     process.env.NODE_ENV = 'development';
     const service = new Service({
       cwd: getCwd(),
+      repoDir: process.cwd(),
     });
     await service.run({
       name: 'dev',

--- a/packages/umi/src/forkedDev.ts
+++ b/packages/umi/src/forkedDev.ts
@@ -1,6 +1,8 @@
+import { join } from 'path';
 import { chalk, yParser } from '@umijs/utils';
 import { Service } from './ServiceWithBuiltIn';
 import getCwd from './utils/getCwd';
+import getPkg from './utils/getPkg';
 
 const args = yParser(process.argv.slice(2));
 
@@ -9,7 +11,7 @@ const args = yParser(process.argv.slice(2));
     process.env.NODE_ENV = 'development';
     const service = new Service({
       cwd: getCwd(),
-      repoDir: process.cwd(),
+      pkg: getPkg(process.cwd()),
     });
     await service.run({
       name: 'dev',

--- a/packages/umi/src/utils/fixtures/normal/package.json
+++ b/packages/umi/src/utils/fixtures/normal/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "normal"
+}

--- a/packages/umi/src/utils/getPkg.test.ts
+++ b/packages/umi/src/utils/getPkg.test.ts
@@ -1,0 +1,14 @@
+import { join } from 'path';
+import getPkg from './getPkg';
+
+const fixtures = join(__dirname, 'fixtures');
+
+test('normal', () => {
+  const pkg = getPkg(join(fixtures, 'normal'));
+  expect(pkg.name).toEqual('normal');
+});
+
+test('null while no package.json found in specific dir', () => {
+  const pkg = getPkg(fixtures);
+  expect(pkg).toEqual(null);
+});

--- a/packages/umi/src/utils/getPkg.ts
+++ b/packages/umi/src/utils/getPkg.ts
@@ -1,0 +1,9 @@
+import { join } from 'path';
+
+export default (dir: string) => {
+  try {
+    return require(join(dir, 'package.json'));
+  } catch (error) {
+    return null;
+  }
+};


### PR DESCRIPTION
### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

While env `APP_ROOT` is specified, `service.resolvePackageI()` returns info incorrectly.

Check my repo: [hosts-master](https://github.com/leftstick/hosts-high)

`@umijs/plugin-model` will not be discovered properly 