### PR TITLE
feat: plaintext shall be imported

### DIFF
--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -47,6 +47,7 @@
     "postcss-preset-env": "6.7.0",
     "postcss-safe-parser": "4.0.2",
     "react-error-overlay": "6.0.6",
+    "raw-loader": "4.0.0",
     "sockjs-client": "1.4.0",
     "speed-measure-webpack-plugin": "1.3.1",
     "strip-ansi": "6.0.0",

--- a/packages/bundler-webpack/src/getConfig/getConfig.ts
+++ b/packages/bundler-webpack/src/getConfig/getConfig.ts
@@ -235,6 +235,13 @@ export default async function getConfig(
         esModule: false,
       });
 
+  // prettier-ignore
+  webpackConfig.module
+    .rule('plaintext')
+    .test(/\.(txt|text)$/)
+    .use('raw-loader')
+      .loader(require.resolve('raw-loader'));
+
   // css
   css({
     config,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12688,6 +12688,14 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+raw-loader@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-4.0.0.tgz#d639c40fb9d72b5c7f8abc1fb2ddb25b29d3d540"
+  integrity sha512-iINUOYvl1cGEmfoaLjnZXt4bKfT2LJnZZib5N/LLyAphC+Dd11vNP9CNVb38j+SAJpFI1uo8j9frmih53ASy7Q==
+  dependencies:
+    loader-utils "^1.2.3"
+    schema-utils "^2.5.0"
+
 rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"


### PR DESCRIPTION


##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Description of change

We should support plaintext import scenario, as below:

```javascript
import txt from '@/assets/content.txt'

console.log('txt is', txt)
```
