### PR TITLE
feat: assign array, object property on exported Component is supported now

### DIFF
--- a/packages/ast/src/getExportProps/getExportProps.test.ts
+++ b/packages/ast/src/getExportProps/getExportProps.test.ts
@@ -9,9 +9,14 @@ foo.a = 1;
 foo.b = '2';
 foo.c = function() {};
 
-// TODO: support object and array
-foo.d = {};
-foo.e = [];
+foo.d = {
+  aa: '1',
+  bb: true,
+  cc: {
+    dd: 90
+  }
+};
+foo.e = ['hh'];
 
 foo.f = true;
 foo.g = false;
@@ -22,6 +27,14 @@ export default foo;
   expect(props).toEqual({
     a: 1,
     b: '2',
+    d: {
+      aa: '1',
+      bb: true,
+      cc: {
+        dd: 90,
+      },
+    },
+    e: ['hh'],
     f: true,
     g: false,
   });

--- a/packages/ast/src/getExportProps/getExportProps.test.ts
+++ b/packages/ast/src/getExportProps/getExportProps.test.ts
@@ -14,12 +14,19 @@ foo.d = {
   bb: true,
   cc: {
     dd: 90
-  }
+  },
+  ee: [2],
+  ff: null,
+  gg: undefined,
+  hh: () => {},
+  jj() {}
 };
-foo.e = ['hh'];
+foo.e = ['hh', { ff: 66 }, ['gg'], null, undefined, () => {}];
 
 foo.f = true;
 foo.g = false;
+foo.i = null;
+foo.j = undefined;
 bar.h = true;
 export default foo;
     `,
@@ -33,9 +40,23 @@ export default foo;
       cc: {
         dd: 90,
       },
+      ee: [2],
+      ff: null,
+      gg: undefined,
     },
-    e: ['hh'],
+    e: ['hh', { ff: 66 }, ['gg'], null, undefined],
     f: true,
     g: false,
+    i: null,
+    j: undefined,
   });
+});
+
+test('no default export', () => {
+  const props = getExportProps(
+    `
+export function foo () {}
+    `,
+  );
+  expect(props).toEqual({});
 });

--- a/packages/ast/src/getExportProps/getExportProps.ts
+++ b/packages/ast/src/getExportProps/getExportProps.ts
@@ -43,6 +43,10 @@ function findObjectProperties(node: t.ObjectExpression) {
     if (t.isObjectProperty(p) && t.isIdentifier(p.key)) {
       if (isLiteral(p.value)) {
         target[p.key.name] = p.value.value;
+      } else if (t.isNullLiteral(p.value)) {
+        target[p.key.name] = null;
+      } else if (t.isIdentifier(p.value) && p.value.name === 'undefined') {
+        target[p.key.name] = undefined;
       } else if (t.isObjectExpression(p.value)) {
         target[p.key.name] = findObjectProperties(p.value);
       } else if (t.isArrayExpression(p.value)) {
@@ -58,6 +62,10 @@ function findArrayProperties(node: t.ArrayExpression) {
   node.elements.forEach(p => {
     if (isLiteral(p)) {
       target.push(p.value);
+    } else if (t.isNullLiteral(p)) {
+      target.push(null);
+    } else if (t.isIdentifier(p) && p.name === 'undefined') {
+      target.push(undefined);
     } else if (t.isObjectExpression(p)) {
       target.push(findObjectProperties(p));
     } else if (t.isArrayExpression(p)) {
@@ -86,6 +94,13 @@ function findAssignmentExpressionProps(opts: {
     ) {
       if (isLiteral(node.right)) {
         props[node.left.property.name] = node.right.value;
+      } else if (t.isNullLiteral(node.right)) {
+        props[node.left.property.name] = null;
+      } else if (
+        t.isIdentifier(node.right) &&
+        node.right.name === 'undefined'
+      ) {
+        props[node.left.property.name] = undefined;
       } else if (t.isObjectExpression(node.right)) {
         props[node.left.property.name] = findObjectProperties(node.right);
       } else if (t.isArrayExpression(node.right)) {

--- a/packages/ast/src/getExportProps/propertyResolver.ts
+++ b/packages/ast/src/getExportProps/propertyResolver.ts
@@ -1,0 +1,105 @@
+import { t } from '@umijs/utils';
+
+interface IResolver<U> {
+  is(src: any): boolean;
+  get(src: U): any;
+}
+
+const StringResolver: IResolver<t.StringLiteral> = {
+  is(src: any) {
+    return t.isStringLiteral(src);
+  },
+  get(src) {
+    return src.value;
+  },
+};
+
+const NumberResolver: IResolver<t.NumericLiteral> = {
+  is(src: any) {
+    return t.isNumericLiteral(src);
+  },
+  get(src) {
+    return src.value;
+  },
+};
+
+const BooleanResolver: IResolver<t.BooleanLiteral> = {
+  is(src: any) {
+    return t.isBooleanLiteral(src);
+  },
+  get(src) {
+    return src.value;
+  },
+};
+
+const NullResolver: IResolver<t.NullLiteral> = {
+  is(src: any) {
+    return t.isNullLiteral(src);
+  },
+  get(src) {
+    return null;
+  },
+};
+
+const UndefinedResolver: IResolver<t.Identifier> = {
+  is(src: any) {
+    return t.isIdentifier(src) && src.name === 'undefined';
+  },
+  get(src) {
+    return undefined;
+  },
+};
+
+const ObjectResolver: IResolver<t.ObjectExpression> = {
+  is(src: any) {
+    return t.isObjectExpression(src);
+  },
+  get(src) {
+    return findObjectProperties(src);
+  },
+};
+
+const ArrayResolver: IResolver<t.ArrayExpression> = {
+  is(src: any) {
+    return t.isArrayExpression(src);
+  },
+  get(src) {
+    return findArrayProperties(src);
+  },
+};
+
+export const RESOLVABLE_WHITELIST = [
+  StringResolver,
+  NumberResolver,
+  BooleanResolver,
+  NullResolver,
+  UndefinedResolver,
+  ObjectResolver,
+  ArrayResolver,
+];
+
+function findObjectProperties(node: t.ObjectExpression) {
+  const target = {};
+  node.properties.forEach(p => {
+    if (t.isObjectProperty(p) && t.isIdentifier(p.key)) {
+      const resolver = RESOLVABLE_WHITELIST.find(resolver =>
+        resolver.is(p.value),
+      );
+      if (resolver) {
+        target[p.key.name] = resolver.get(p.value as any);
+      }
+    }
+  });
+  return target;
+}
+
+function findArrayProperties(node: t.ArrayExpression) {
+  const target: any[] = [];
+  node.elements.forEach(p => {
+    const resolver = RESOLVABLE_WHITELIST.find(resolver => resolver.is(p));
+    if (resolver) {
+      target.push(resolver.get(p as any));
+    }
+  });
+  return target;
+}


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] commit message follows commit guidelines

##### Description of change

support `object`, `array`, 'null', 'undefined' property on exported component, as below:

```javascript
function Login({}) {
  return <div>hello</div>
}

Login.propTypes = {}

Login.title = 'Login'
Login.menu = false
Login.layout = {
  hideNav: true,
  hideMenu: true
}
Login.access = 'canReadLogin'
Login.aaa = null
Login.bbb = undefined

export default Login
```