### PR TITLE
Automatically switch to the branch of umi@3

### DIFF
--- a/packages/umi-build-dev/src/plugins/commands/block/download.js
+++ b/packages/umi-build-dev/src/plugins/commands/block/download.js
@@ -86,9 +86,13 @@ export const urlAddGit = url => {
  * @param {*} ref
  */
 const getAntdVersion = ref => {
-  const { version } = require('antd');
-  if (version.startsWith(3) && ref === 'master') {
-    return 'antd@3';
+  try {
+    const { version } = require('antd');
+    if (version.startsWith(3) && ref === 'master') {
+      return 'antd@3';
+    }
+  } catch (error) {
+    // return ref;
   }
 
   if (process.env.BLOCK_REPO_BRANCH) {
@@ -108,7 +112,7 @@ export async function parseGitUrl(url, closeFastGithub) {
     resource === 'github.com' && !closeFastGithub
       ? args.toString().replace(`${resource}`, fastGithub)
       : args.toString();
-  console.log(getAntdVersion(ref));
+
   return {
     repo: urlAddGit(repo),
     branch: getAntdVersion(ref) || 'master',

--- a/packages/umi-build-dev/src/plugins/commands/block/download.js
+++ b/packages/umi-build-dev/src/plugins/commands/block/download.js
@@ -32,7 +32,7 @@ export function downloadFromGit(url, id, branch = 'master', log, args = {}) {
     // cd id && git pull
     log.info(`${url} exist in cache, start pull from git to update...`);
     if (dryRun) {
-      log.log(`dryRun is true, skip git pull`);
+      log.log('dryRun is true, skip git pull');
     } else {
       spawnSync('git', ['fetch'], {
         cwd: templateTmpDirPath,
@@ -49,9 +49,9 @@ export function downloadFromGit(url, id, branch = 'master', log, args = {}) {
     // git clone url id
     log.info(`start clone code from ${url}...`);
     if (dryRun) {
-      log.log(`dryRun is true, skip git clone`);
+      log.log('dryRun is true, skip git clone');
     } else {
-      spawnSync('git', ['clone', url, id, '--single-branch', '-b', branch], {
+      spawnSync('git', ['clone', url, id, '-b', branch], {
         cwd: blocksTempPath,
       });
     }
@@ -81,6 +81,22 @@ export const urlAddGit = url => {
   return `${url}.git`;
 };
 
+/**
+ * 使用 antd@3 的模板和区块
+ * @param {*} ref
+ */
+const getAntdVersion = ref => {
+  const { version } = require('antd');
+  if (version.startsWith(3) && ref === 'master') {
+    return 'antd@3';
+  }
+
+  if (process.env.BLOCK_REPO_BRANCH) {
+    return process.env.BLOCK_REPO_BRANCH;
+  }
+  return ref;
+};
+
 export async function parseGitUrl(url, closeFastGithub) {
   const args = GitUrlParse(url);
   const { ref, filepath, resource, full_name: fullName } = args;
@@ -92,10 +108,10 @@ export async function parseGitUrl(url, closeFastGithub) {
     resource === 'github.com' && !closeFastGithub
       ? args.toString().replace(`${resource}`, fastGithub)
       : args.toString();
-
+  console.log(getAntdVersion(ref));
   return {
     repo: urlAddGit(repo),
-    branch: ref || 'master',
+    branch: getAntdVersion(ref) || 'master',
     path: `/${filepath}`,
     id: `${resource}/${fullName}`, // 唯一标识一个 git 仓库
   };

--- a/packages/umi-build-dev/src/plugins/commands/block/ui/server/core/tasks/git_clone.ts
+++ b/packages/umi-build-dev/src/plugins/commands/block/ui/server/core/tasks/git_clone.ts
@@ -2,13 +2,13 @@ import { IFlowContext, ICtxTypes } from '../types';
 
 const clone = async (ctx: IFlowContext) => {
   const { logger, execa } = ctx;
-  const { repo, id, branch, blocksTempPath, repoExists } = ctx.stages.blockCtx as ICtxTypes;
+  const { repo, id, blocksTempPath, repoExists } = ctx.stages.blockCtx as ICtxTypes;
   if (repoExists) {
     return;
   }
 
   logger.appendLog(`🚚  Start git clone from ${repo}`);
-  await execa('git', ['clone', repo, id, '--single-branch', '--recurse-submodules', '-b', branch], {
+  await execa('git', ['clone', repo, id, '--recurse-submodules'], {
     cwd: blocksTempPath,
     env: process.env,
   });

--- a/packages/umi-build-dev/src/plugins/commands/block/ui/server/core/tasks/git_update.ts
+++ b/packages/umi-build-dev/src/plugins/commands/block/ui/server/core/tasks/git_update.ts
@@ -36,7 +36,7 @@ const clone = async (ctx: IFlowContext, args: IAddBlockOption) => {
     });
   } catch (e) {
     logger.appendLog(`Faild git checkout: ${e.message}\n`);
-    throw new Error(e);
+    // throw new Error(e);
   }
 
   logger.appendLog(`🎉  Success git checkout ${branch}\n`);

--- a/packages/umi-build-dev/src/plugins/commands/block/util.ts
+++ b/packages/umi-build-dev/src/plugins/commands/block/util.ts
@@ -255,15 +255,11 @@ export const reduceData = treeData =>
 export async function gitClone(ctx, mySpinner) {
   mySpinner.start(`🔍  clone git repo from ${ctx.repo}`);
   try {
-    await execa(
-      'git',
-      ['clone', ctx.repo, ctx.id, '--single-branch', '--recurse-submodules', '-b', ctx.branch],
-      {
-        cwd: ctx.blocksTempPath,
-        env: process.env,
-        stdio: 'inherit',
-      },
-    );
+    await execa('git', ['clone', ctx.repo, ctx.id, '--recurse-submodules'], {
+      cwd: ctx.blocksTempPath,
+      env: process.env,
+      stdio: 'inherit',
+    });
   } catch (e) {
     mySpinner.fail();
     throw new Error(e);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->
close https://github.com/ant-design/ant-design-pro/issues/6138#issuecomment-599159613

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines


主要改动有两处
* 判断 antd 的版本切换分支
* 修改了分支切换的逻辑，从原来的默认 clone -b 到现在 checkout。这样可以保证 antd@3 分支不存在的情况下也可以继续流程

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
