### PR TITLE
feat: verify dynamic configuration

### DIFF
--- a/packages/core/src/Config/Config.ts
+++ b/packages/core/src/Config/Config.ts
@@ -12,7 +12,6 @@ import {
   createDebug,
 } from '@umijs/utils';
 import assert from 'assert';
-import joi from '@hapi/joi';
 import Service from '../Service/Service';
 import { ServiceStage } from '../Service/enums';
 import {
@@ -93,21 +92,6 @@ export default class Config {
       const value = getUserConfigWithKey({ key, userConfig });
       // 不校验 false 的值，此时已禁用插件
       if (value === false) return;
-
-      // do validate
-      const schema = config.schema(joi);
-      assert(
-        joi.isSchema(schema),
-        `schema return from plugin ${pluginId} is not valid schema.`,
-      );
-      const { error } = schema.validate(value);
-      if (error) {
-        const e = new Error(
-          `Validate config "${key}" failed, ${error.message}`,
-        );
-        e.stack = error.stack;
-        throw e;
-      }
 
       // remove key
       const index = userConfigKeys.indexOf(key.split('.')[0]);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->
使用 `api.modifyDefaultConfig` 修改的配置会被绕过校验。
比如在插件中错误设置history
```ts
api.modifyDefaultConfig(memo => {
    return {
      ...memo,
      history: 'hash',
    }
  });
```

![image](https://user-images.githubusercontent.com/11746742/77412816-64951e80-6df9-11ea-8998-bf1c243c4ab8.png)
此时因为 type 为空，所以生成了一个错误的变量。但是光从这里很难排查是什么原因导致的。
其他的配置也有别的的问题，有些插件是从 umi@2 升级上来的，所以都是简单的测试一样运行时没报错就算通过了，没仔细核对 umi@3 的配置变更。

## 做了啥
将原来的校验 `api.userConfig` 改成现在的校验 `api.config`
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
