### PR TITLE
fix: ssr getinitialprops add pathname

### DIFF
--- a/packages/umi-build-dev/src/FilesGenerator.js
+++ b/packages/umi-build-dev/src/FilesGenerator.js
@@ -144,7 +144,7 @@ export default class FilesGenerator {
   // Both support SSR and CSR
   if (window.g_useSSR) {
     // 如果开启服务端渲染则客户端组件初始化 props 使用服务端注入的数据
-    props = window.g_initialData;
+    props = window.g_initialData[location.pathname];
   } else {
     const pathname = location.pathname;
     const activeRoute = findRoute(require('@@/router').routes, pathname);

--- a/packages/umi-build-dev/template/entry.js.tpl
+++ b/packages/umi-build-dev/template/entry.js.tpl
@@ -155,7 +155,9 @@ if (!__IS_BROWSER) {
       htmlElement: matchPath ? htmlTemplateMap[matchPath] : '',
       rootContainer,
       matchPath,
-      g_initialData: props,
+      g_initialData: {
+        [ctx.req.url]: props
+      },
       context,
     };
   }

--- a/packages/umi-plugin-dva/template/dva.js.tpl
+++ b/packages/umi-plugin-dva/template/dva.js.tpl
@@ -12,7 +12,7 @@ export function _onCreate() {
     history,
     <%= ExtendDvaConfig %>
     ...(runtimeDva.config || {}),
-    ...(window.g_useSSR ? { initialState: window.g_initialData } : {}),
+    ...(window.g_useSSR ? { initialState: window.g_initialData[location.pathname] } : {}),
   });
   <%= EnhanceApp %>
   app.use(createLoading());


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL

服务端初始化数据时使用pathname作为namespace分离，防止单页面应用跳转时的首次render的props污染
