### PR TITLE
fix: 修复cwd祖先目录下的文件不触发编译的bug

### DIFF
--- a/packages/bundler-webpack/src/fixtures/import-from-outside/expect.ts
+++ b/packages/bundler-webpack/src/fixtures/import-from-outside/expect.ts
@@ -1,0 +1,5 @@
+import { IExpectOpts } from '../types';
+
+export default ({ indexJS }: IExpectOpts) => {
+  expect(indexJS).toContain(`(_a$b = a.b) === null || _a$b === void 0 ? void 0 : _a$b.c`);
+}

--- a/packages/bundler-webpack/src/fixtures/import-from-outside/import-from-outside.ts
+++ b/packages/bundler-webpack/src/fixtures/import-from-outside/import-from-outside.ts
@@ -1,0 +1,11 @@
+interface A {
+  b?: B;
+};
+
+interface B {
+  c: string;
+};
+
+const a: A = {};
+
+console.log(a.b?.c);

--- a/packages/bundler-webpack/src/fixtures/import-from-outside/index.ts
+++ b/packages/bundler-webpack/src/fixtures/import-from-outside/index.ts
@@ -1,0 +1,1 @@
+import './import-from-outside'

--- a/packages/bundler-webpack/src/getConfig/getConfig.ts
+++ b/packages/bundler-webpack/src/getConfig/getConfig.ts
@@ -161,7 +161,6 @@ export default async function getConfig(
   webpackConfig.module
     .rule('js')
       .test(/\.(js|mjs|jsx|ts|tsx)$/)
-      .include.add(cwd).end()
       .exclude.add(/node_modules/).end()
       .use('babel-loader')
         .loader(require.resolve('babel-loader'))

--- a/packages/bundler-webpack/src/getConfig/getConfig.ts
+++ b/packages/bundler-webpack/src/getConfig/getConfig.ts
@@ -66,7 +66,7 @@ export default async function getConfig(
 
   // entry
   if (entry) {
-    Object.keys(entry).forEach((key) => {
+    Object.keys(entry).forEach(key => {
       const e = webpackConfig.entry(key);
       if (hot && isDev) {
         e.add(require.resolve('../webpackHotDevClient/webpackHotDevClient'));
@@ -124,7 +124,7 @@ export default async function getConfig(
 
   // resolve.alias
   if (config.alias) {
-    Object.keys(config.alias).forEach((key) => {
+    Object.keys(config.alias).forEach(key => {
       webpackConfig.resolve.alias.set(key, config.alias![key]);
     });
   }
@@ -161,6 +161,8 @@ export default async function getConfig(
   webpackConfig.module
     .rule('js')
       .test(/\.(js|mjs|jsx|ts|tsx)$/)
+      // 不配置 include，因为在使用 APP_ROOT 的场景下通常会 import cwd 之外的文件
+      // ref: https://github.com/umijs/umi/pull/4327
       .exclude.add(/node_modules/).end()
       .use('babel-loader')
         .loader(require.resolve('babel-loader'))
@@ -309,7 +311,7 @@ export default async function getConfig(
         to: absOutputPath,
       },
       ...(config.copy
-        ? config.copy.map((from) => ({
+        ? config.copy.map(from => ({
             from: join(cwd, from),
             to: absOutputPath,
           }))
@@ -335,14 +337,14 @@ export default async function getConfig(
 
   webpackConfig.when(
     isDev,
-    (webpackConfig) => {
+    webpackConfig => {
       if (hot) {
         webpackConfig
           .plugin('hmr')
           .use(bundleImplementor.HotModuleReplacementPlugin);
       }
     },
-    (webpackConfig) => {
+    webpackConfig => {
       // don't emit files if have error
       webpackConfig.optimization.noEmitOnErrors(true);
 


### PR DESCRIPTION
在配置了include的情况下，不符合条件的文件不会触发编译。当某文件引用了cwd祖先目录下的js mjs jsx ts等文件时，就会出现不触发编译导致报错的问题。考虑移除include cwd，依赖webpack自动查找引用并编译。

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
