### PR TITLE
fix(umi): drop SSR init props on route change

### DIFF
--- a/packages/umi/src/renderRoutes.js
+++ b/packages/umi/src/renderRoutes.js
@@ -80,6 +80,11 @@ const popStateFn = () => {
   }
 };
 
+/**
+ * A flag indicating the route changed or not
+ */
+let routeChanged = false;
+
 function wrapWithInitialProps(WrappedComponent, initialProps) {
   return class extends React.Component {
     constructor(props) {
@@ -91,6 +96,10 @@ function wrapWithInitialProps(WrappedComponent, initialProps) {
 
     async componentDidMount() {
       const { history } = this.props;
+      // Mark route as changed on route change.
+      history.listen(() => {
+        routeChanged = true;
+      });
       _this = this;
       window.addEventListener('popstate', popStateFn);
       if (history.action !== 'POP') {
@@ -151,6 +160,9 @@ export default function renderRoutes(routes, extraProps = {}, switchProps = {}) 
             strict={route.strict}
             sensitive={route.sensitive}
             render={props => {
+              // Drop expired SSR init props, in favour of a loading indicator
+              // (SSR initial props are only valid before user navigation)
+              if (routeChanged) extraProps = { fetchingProps: true };
               // TODO: ssr StaticRoute context hook, handle 40x / 30x
               const childRoutes = renderRoutes(route.routes, extraProps, {
                 location: props.location,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
  - No new failed tests
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- Closes https://github.com/umijs/umi/issues/4328
- Provides a `fetchingProps` prop when CSR is running `getInitialProps()`