### PR TITLE
fix(ssr): clone extraProps in SSR HOC

### DIFF
--- a/packages/umi/src/renderRoutes.js
+++ b/packages/umi/src/renderRoutes.js
@@ -85,7 +85,7 @@ function wrapWithInitialProps(WrappedComponent, initialProps, extraProps = {}) {
     constructor(props) {
       super(props);
       this.state = {
-        extraProps,
+        extraProps: { ...extraProps },
       };
       if (!routeChanged) {
         routeChanged = !window.g_useSSR || (props.history && props.history.action !== 'POP');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- fixes "object is not extensible" in HOC getInitialProps
![image](https://user-images.githubusercontent.com/2323992/78214371-b0298580-74e7-11ea-9904-332fa649ad18.png)
