### PR TITLE
feat: export IRouteProps since developer might use it for their own purpose

### DIFF
--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -12,7 +12,10 @@ import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import { Server, IServerOpts } from '@umijs/server';
 import { Generator } from '@umijs/utils';
 import { IOpts as IBabelPresetUmiOpts } from '@umijs/babel-preset-umi';
-import { IRouteComponentProps } from '@umijs/renderer-react';
+import {
+  IRouteComponentProps,
+  IRoute as IRouteProps,
+} from '@umijs/renderer-react';
 import webpack from 'webpack';
 import WebpackChain from 'webpack-chain';
 import {
@@ -296,4 +299,4 @@ export { webpack };
 export { Html, IScriptConfig, IStyleConfig };
 export { Request, Express, Response, NextFunction, RequestHandler };
 
-export { History, Location, IRouteComponentProps };
+export { History, Location, IRouteProps, IRouteComponentProps };


### PR DESCRIPTION

##### Checklist

- [x] commit message follows commit guidelines

##### Description of change

把 路由 props 里的 `IRoute` 定义页暴露出去给开发者。因为和之前导出的路由定义名字相同，顾改名为 `IRouteProps`