### PR TITLE
fix: @/pages/404.tsx only matches /404 path

### DIFF
--- a/packages/core/src/Route/Route.test.ts
+++ b/packages/core/src/Route/Route.test.ts
@@ -222,6 +222,36 @@ test('conventional route 404', async () => {
   ]);
 });
 
+test('conventional 404/404', async () => {
+  const route = new Route();
+  expect(
+    await route.getRoutes({
+      config: {},
+      root: join(fixtures, 'conventional-404-404/pages'),
+    }),
+  ).toEqual([
+    {
+      path: '/',
+      exact: true,
+      component: '@/pages/index.tsx',
+    },
+    {
+      path: '/user/404',
+      exact: true,
+      component: '@/pages/user/404.tsx',
+    },
+    {
+      path: '/user',
+      exact: true,
+      component: '@/pages/user/index.tsx',
+    },
+    {
+      exact: true,
+      component: '@/pages/404.tsx',
+    },
+  ]);
+});
+
 test('conventional sort routes func', async () => {
   expect(
     [

--- a/packages/core/src/Route/Route.test.ts
+++ b/packages/core/src/Route/Route.test.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
-import Route, { routesSortFn } from './Route';
+import Route from './Route';
+import { routesSortFn } from './getConventionalRoutes';
 
 const fixtures = join(__dirname, 'fixtures');
 

--- a/packages/core/src/Route/Route.test.ts
+++ b/packages/core/src/Route/Route.test.ts
@@ -202,6 +202,30 @@ test('conventional index/index', async () => {
   ]);
 });
 
+test('conventional route 404', async () => {
+  const route = new Route();
+  expect(
+    await route.getRoutes({
+      config: {},
+      root: join(fixtures, 'conventional-404/pages'),
+    }),
+  ).toEqual([
+    {
+      path: '/404',
+      exact: true,
+      component: '@/pages/404.tsx',
+    },
+    {
+      path: '/',
+      exact: true,
+      component: '@/pages/index.tsx',
+    },
+    {
+      component: '@/pages/404.tsx',
+    },
+  ]);
+});
+
 test('conventional opts.componentPrefix', async () => {
   const route = new Route();
   expect(

--- a/packages/core/src/Route/Route.test.ts
+++ b/packages/core/src/Route/Route.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
-import Route from './Route';
 import { routesSortFn } from './getConventionalRoutes';
+import Route from './Route';
 
 const fixtures = join(__dirname, 'fixtures');
 
@@ -203,7 +203,7 @@ test('conventional index/index', async () => {
   ]);
 });
 
-test('conventional route 404', async () => {
+test('conventional 404', async () => {
   const route = new Route();
   expect(
     await route.getRoutes({
@@ -245,6 +245,21 @@ test('conventional 404/404', async () => {
       path: '/user',
       exact: true,
       component: '@/pages/user/index.tsx',
+    },
+    {
+      path: '/post',
+      routes: [
+        {
+          path: '/post',
+          exact: true,
+          component: '@/pages/post/index.tsx',
+        },
+        {
+          exact: true,
+          component: '@/pages/post/404.tsx',
+        },
+      ],
+      component: '@/pages/post/_layout.tsx',
     },
     {
       exact: true,

--- a/packages/core/src/Route/Route.test.ts
+++ b/packages/core/src/Route/Route.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import Route from './Route';
+import Route, { routesSortFn } from './Route';
 
 const fixtures = join(__dirname, 'fixtures');
 
@@ -211,9 +211,87 @@ test('conventional route 404', async () => {
     }),
   ).toEqual([
     {
-      path: '/404',
+      path: '/',
+      exact: true,
+      component: '@/pages/index.tsx',
+    },
+    {
       exact: true,
       component: '@/pages/404.tsx',
+    },
+  ]);
+});
+
+test('conventional sort routes func', async () => {
+  expect(
+    [
+      { path: '/', exact: true, component: '@/pages/index.tsx' },
+      { exact: true, component: '@/pages/404.tsx' },
+      {
+        path: '/foo',
+        exact: true,
+        component: '@/pages/foo.tsx',
+      },
+    ].sort(routesSortFn),
+  ).toEqual([
+    {
+      path: '/',
+      exact: true,
+      component: '@/pages/index.tsx',
+    },
+    {
+      path: '/foo',
+      exact: true,
+      component: '@/pages/foo.tsx',
+    },
+    {
+      exact: true,
+      component: '@/pages/404.tsx',
+    },
+  ]);
+
+  expect(
+    [
+      { path: '/', exact: true, component: '@/pages/index.tsx' },
+      {
+        path: '/foo',
+        exact: true,
+        component: '@/pages/foo.tsx',
+      },
+      { exact: true, component: '@/pages/404.tsx' },
+    ].sort(routesSortFn),
+  ).toEqual([
+    {
+      path: '/',
+      exact: true,
+      component: '@/pages/index.tsx',
+    },
+    {
+      path: '/foo',
+      exact: true,
+      component: '@/pages/foo.tsx',
+    },
+    {
+      exact: true,
+      component: '@/pages/404.tsx',
+    },
+  ]);
+
+  expect(
+    [
+      { exact: true, component: '@/pages/404.tsx' },
+      {
+        path: '/foo',
+        exact: true,
+        component: '@/pages/foo.tsx',
+      },
+      { path: '/', exact: true, component: '@/pages/index.tsx' },
+    ].sort(routesSortFn),
+  ).toEqual([
+    {
+      path: '/foo',
+      exact: true,
+      component: '@/pages/foo.tsx',
     },
     {
       path: '/',
@@ -221,6 +299,7 @@ test('conventional route 404', async () => {
       component: '@/pages/index.tsx',
     },
     {
+      exact: true,
       component: '@/pages/404.tsx',
     },
   ]);

--- a/packages/core/src/Route/Route.ts
+++ b/packages/core/src/Route/Route.ts
@@ -5,17 +5,6 @@ import assert from 'assert';
 import getConventionalRoutes from './getConventionalRoutes';
 import routesToJSON from './routesToJSON';
 
-// 将 path 不存在的 route 置后，其余位置不变
-export function routesSortFn<T extends IRoute>(aRoute: T, bRoute: T) {
-  if (aRoute.path && !bRoute.path) {
-    return -1;
-  }
-  if (!aRoute.path && bRoute.path) {
-    return 1;
-  }
-  return 0;
-}
-
 interface IOpts {
   onPatchRoutesBefore?: Function;
   onPatchRoutes?: Function;
@@ -67,10 +56,6 @@ class Route {
         routes,
         parentRoute: opts.parentRoute,
       });
-    }
-    // 约定式路由，将 */404 置后
-    if (opts.isConventional) {
-      routes.sort(routesSortFn);
     }
     for (const route of routes) {
       await this.patchRoute(route, opts);

--- a/packages/core/src/Route/Route.ts
+++ b/packages/core/src/Route/Route.ts
@@ -57,8 +57,15 @@ class Route {
         parentRoute: opts.parentRoute,
       });
     }
+    let route404;
     for (const route of routes) {
       await this.patchRoute(route, opts);
+      if (route.path && route.path === '/404') {
+        route404 = route;
+      }
+    }
+    if (opts.isConventional && route404) {
+      routes.push({ component: route404.component });
     }
     if (this.opts.onPatchRoutes) {
       await this.opts.onPatchRoutes({

--- a/packages/core/src/Route/Route.ts
+++ b/packages/core/src/Route/Route.ts
@@ -5,6 +5,7 @@ import assert from 'assert';
 import getConventionalRoutes from './getConventionalRoutes';
 import routesToJSON from './routesToJSON';
 
+// 将 path 不存在的 route 置后，其余位置不变
 export function routesSortFn<T extends IRoute>(aRoute: T, bRoute: T) {
   if (aRoute.path && !bRoute.path) {
     return -1;
@@ -67,7 +68,7 @@ class Route {
         parentRoute: opts.parentRoute,
       });
     }
-    // 约定式路由，将 */404 置于底部
+    // 约定式路由，将 */404 置后
     if (opts.isConventional) {
       routes.sort(routesSortFn);
     }

--- a/packages/core/src/Route/Route.ts
+++ b/packages/core/src/Route/Route.ts
@@ -57,15 +57,15 @@ class Route {
         parentRoute: opts.parentRoute,
       });
     }
-    let route404;
+    let routeNotFound;
     for (const route of routes) {
       await this.patchRoute(route, opts);
       if (route.path && route.path === '/404') {
-        route404 = route;
+        routeNotFound = route;
       }
     }
-    if (opts.isConventional && route404) {
-      routes.push({ component: route404.component });
+    if (opts.isConventional && routeNotFound) {
+      routes.push({ component: routeNotFound.component });
     }
     if (this.opts.onPatchRoutes) {
       await this.opts.onPatchRoutes({

--- a/packages/core/src/Route/fixtures/conventional-404-404/pages/404.tsx
+++ b/packages/core/src/Route/fixtures/conventional-404-404/pages/404.tsx
@@ -1,0 +1,1 @@
+export default () => <h1>404</h1>;

--- a/packages/core/src/Route/fixtures/conventional-404-404/pages/index.tsx
+++ b/packages/core/src/Route/fixtures/conventional-404-404/pages/index.tsx
@@ -1,0 +1,1 @@
+export default () => <h1>abc</h1>;

--- a/packages/core/src/Route/fixtures/conventional-404-404/pages/post/404.tsx
+++ b/packages/core/src/Route/fixtures/conventional-404-404/pages/post/404.tsx
@@ -1,0 +1,1 @@
+export default () => <h1>abc</h1>;

--- a/packages/core/src/Route/fixtures/conventional-404-404/pages/post/_layout.tsx
+++ b/packages/core/src/Route/fixtures/conventional-404-404/pages/post/_layout.tsx
@@ -1,0 +1,1 @@
+export default () => <h1>abc</h1>;

--- a/packages/core/src/Route/fixtures/conventional-404-404/pages/post/index.tsx
+++ b/packages/core/src/Route/fixtures/conventional-404-404/pages/post/index.tsx
@@ -1,0 +1,1 @@
+export default () => <h1>abc</h1>;

--- a/packages/core/src/Route/fixtures/conventional-404-404/pages/user/404.tsx
+++ b/packages/core/src/Route/fixtures/conventional-404-404/pages/user/404.tsx
@@ -1,0 +1,1 @@
+export default () => <h1>abc</h1>;

--- a/packages/core/src/Route/fixtures/conventional-404-404/pages/user/index.tsx
+++ b/packages/core/src/Route/fixtures/conventional-404-404/pages/user/index.tsx
@@ -1,0 +1,1 @@
+export default () => <h1>abc</h1>;

--- a/packages/core/src/Route/fixtures/conventional-404/pages/404.tsx
+++ b/packages/core/src/Route/fixtures/conventional-404/pages/404.tsx
@@ -1,0 +1,1 @@
+export default () => <h1>404</h1>;

--- a/packages/core/src/Route/fixtures/conventional-404/pages/index.tsx
+++ b/packages/core/src/Route/fixtures/conventional-404/pages/index.tsx
@@ -1,0 +1,1 @@
+export default () => <h1>abc</h1>;

--- a/packages/core/src/Route/getConventionalRoutes.ts
+++ b/packages/core/src/Route/getConventionalRoutes.ts
@@ -6,6 +6,17 @@ import assert from 'assert';
 import { IRoute } from './types';
 import { IConfig } from '..';
 
+// 将 */404 置后，其余位置不变
+export function routesSortFn<T extends IRoute>(aRoute: T, bRoute: T) {
+  if (aRoute.path && !bRoute.path) {
+    return -1;
+  }
+  if (!aRoute.path && bRoute.path) {
+    return 1;
+  }
+  return 0;
+}
+
 interface IOpts {
   root: string;
   relDir?: string;
@@ -178,17 +189,16 @@ function normalizeRoutes(routes: IRoute[]): IRoute[] {
     `We should not have multiple dynamic routes under a directory.`,
   );
 
-  return [...exactRoutes, ...layoutRoutes, ...paramsRoutes].reduce(
-    (memo, route) => {
+  return [...exactRoutes, ...layoutRoutes, ...paramsRoutes]
+    .reduce((memo, route) => {
       if (route.__toMerge && route.routes) {
         memo = memo.concat(route.routes);
       } else {
         memo.push(route);
       }
       return memo;
-    },
-    [] as IRoute[],
-  );
+    }, [] as IRoute[])
+    .sort(routesSortFn);
 }
 
 export default function getRoutes(opts: IOpts) {

--- a/packages/core/src/Route/getConventionalRoutes.ts
+++ b/packages/core/src/Route/getConventionalRoutes.ts
@@ -77,9 +77,16 @@ function fileToRouteReducer(opts: IOpts, memo: IRoute[], file: string) {
     };
     memo.push(normalizeRoute(route, opts));
   } else {
-    const bName = basename(file, extname(file));
     // 404 路由处理，支持 404 子路由 #4469
-    if (bName === '404') {
+    // 子路由存在 _layout 情况下对 404 处理
+    const hasLayoutFile = !!getFile({
+      base: join(root, relDir),
+      fileNameWithoutExt: '_layout',
+      type: 'javascript',
+    });
+    const bName = basename(file, extname(file));
+    const routePath = normalizePath(join(relDir, bName), opts);
+    if (routePath === '/404' || (bName === '404' && hasLayoutFile)) {
       memo.push(
         normalizeRoute(
           {
@@ -94,7 +101,7 @@ function fileToRouteReducer(opts: IOpts, memo: IRoute[], file: string) {
       memo.push(
         normalizeRoute(
           {
-            path: normalizePath(join(relDir, bName), opts),
+            path: routePath,
             exact: true,
             component: absFile,
             __isDynamic,

--- a/packages/core/src/Route/getConventionalRoutes.ts
+++ b/packages/core/src/Route/getConventionalRoutes.ts
@@ -78,17 +78,31 @@ function fileToRouteReducer(opts: IOpts, memo: IRoute[], file: string) {
     memo.push(normalizeRoute(route, opts));
   } else {
     const bName = basename(file, extname(file));
-    memo.push(
-      normalizeRoute(
-        {
-          path: normalizePath(join(relDir, bName), opts),
-          exact: true,
-          component: absFile,
-          __isDynamic,
-        },
-        opts,
-      ),
-    );
+    // 404 路由处理，支持 404 子路由 #4469
+    if (bName === '404') {
+      memo.push(
+        normalizeRoute(
+          {
+            exact: true,
+            component: absFile,
+            __isDynamic,
+          },
+          opts,
+        ),
+      );
+    } else {
+      memo.push(
+        normalizeRoute(
+          {
+            path: normalizePath(join(relDir, bName), opts),
+            exact: true,
+            component: absFile,
+            __isDynamic,
+          },
+          opts,
+        ),
+      );
+    }
   }
   return memo;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

fix #4437 

根据 `routes` 中是否有 `{ exact: true, path: '/404', component: '@/pages/404.tsx' }` 
判断是否新增 `{ component: '@/pages/404' }` 到 `routes` 末尾

**只处理约定式路由，自定义路由不做处理**

**保留了已有的 404 配置，并未删除**
