### PR TITLE
fix: remove unnecessary false

### DIFF
--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -273,11 +273,7 @@ interface BaseIConfig extends IConfigCore {
   manifest?: Partial<IManifest>;
   metas?: Partial<HTMLMetaElement>[];
   mpa?: object;
-  mock?:
-    | {
-        exclude?: string[];
-      }
-    | false;
+  mock?: { exclude?: string[]; };
   mountElementId?: string;
   nodeModulesTransform?: {
     type: 'all' | 'none';
@@ -299,7 +295,7 @@ interface BaseIConfig extends IConfigCore {
   targets?: ITargets;
   terserOptions?: object;
   theme?: object;
-  title?: string | false;
+  title?: string;
   [key: string]: any;
 }
 


### PR DESCRIPTION
### Description of change

<!-- Provide a description of the change below this comment. -->

- rm unnecessary `false` type in BaseIConfig in package @umijs/types.

### side node
Otherwise, it is also reported as an "extends error" between BaseIConfig and IConfigCore
![image](https://user-images.githubusercontent.com/5611770/80378919-f2b86500-88cf-11ea-969b-558445fbb7c1.png)

