### PR TITLE
fix: typings.d.ts should be added in include section

### DIFF
--- a/packages/create-umi-app/templates/AppGenerator/tsconfig.json
+++ b/packages/create-umi-app/templates/AppGenerator/tsconfig.json
@@ -19,6 +19,7 @@
     "mock/**/*",
     "src/**/*",
     "config/**/*",
-    ".umirc.ts"
+    ".umirc.ts",
+    "typings.d.ts"
   ]
 }


### PR DESCRIPTION

##### Checklist

- [x] commit message follows commit guidelines

##### Description of change

不加 `typings.d.ts`，代码里引用 图片，css，less文件会提示错误，因为`typings.d.ts`没生效