### PR TITLE
feat: improve svg usage. import as url shall be supported

### DIFF
--- a/packages/create-umi-app/templates/AppGenerator/typings.d.ts
+++ b/packages/create-umi-app/templates/AppGenerator/typings.d.ts
@@ -3,4 +3,6 @@ declare module '*.less';
 declare module "*.png";
 declare module '*.svg' {
   export function ReactComponent(props: React.SVGProps<SVGSVGElement>): React.ReactElement
+  const url: string
+  export default url
 }


### PR DESCRIPTION
##### Checklist

- [x] commit message follows commit guidelines

##### Description of change

优化 `.svg` 引用时的 编程体验。 之前只加了作为 `ReactComponent` 时的体验。
但如果当做 url 引入时，使用的时候可能会提示类型不对。
所以又加了作为url时的类型声明，效果如下：

![svg_usage](https://user-images.githubusercontent.com/1059956/81274357-c3011e00-9082-11ea-950c-bd21bf1eb619.gif)



