### PR TITLE
feat(ast): [getExportProps] find function attributes when exporting function

### DIFF
--- a/packages/ast/src/getExportProps/getExportProps.test.ts
+++ b/packages/ast/src/getExportProps/getExportProps.test.ts
@@ -105,6 +105,15 @@ test('export literal value', () => {
   expect(getExportProps('export default null;')).toEqual(null);
 });
 
+test('assign after exported function', () => {
+  const props = getExportProps(`
+    export default function foo() {};
+    foo.a = 1;
+    foo.b = [0, '1', () => {}];
+  `);
+  expect(props).toEqual({ a: 1, b: [0, '1', expect.any(Function)] });
+});
+
 test('no default export', () => {
   const props = getExportProps(
     `

--- a/packages/ast/src/getExportProps/getExportProps.ts
+++ b/packages/ast/src/getExportProps/getExportProps.ts
@@ -32,6 +32,15 @@ export function getExportProps(code: string) {
           );
           if (resolver) {
             props = resolver.get(defaultExport as any);
+            if ('id' in defaultExport && t.isIdentifier(defaultExport.id)) {
+              props = {
+                ...(props as object),
+                ...findAssignmentExpressionProps({
+                  programNode: node,
+                  name: defaultExport.id.name,
+                }),
+              };
+            }
           }
         }
       },

--- a/packages/ast/src/getExportProps/propertyResolver.ts
+++ b/packages/ast/src/getExportProps/propertyResolver.ts
@@ -88,7 +88,7 @@ const ArrayResolver: IResolver<t.ArrayExpression> = {
 
 const FunctionResolver: IResolver<t.FunctionExpression> = {
   is(src) {
-    return t.isFunctionExpression(src);
+    return t.isFunctionExpression(src) || t.isFunctionDeclaration(src);
   },
   get(src) {
     return function () {};


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- 默认导出函数时，函数的属性没有被导出
- close https://github.com/umijs/umi/ISSUE_URL

##### 问题
```
export default function foo() {};
foo.a = 1;
foo.b = [0, '1', () => {}];

// output
props = function () {}
```
##### 期望
```
export default function foo() {};
foo.a = 1;
foo.b = 2;

// output
props = { a: 1, b: 2 }
```

##### 使用场景

使用约定式路由扩展路由属性时，上面的情况无法将属性添加到路由上，会产生一些困惑。


