### PR TITLE
fix: add @types/jest, or vscode giving error while writing ut

### DIFF
--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@babel/core": "7.9.0",
+    "@types/jest": "25.2.2",
     "@umijs/babel-preset-umi": "3.1.4",
     "@umijs/utils": "3.1.4",
     "babel-core": "7.0.0-bridge.0",


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Description of change

`@types/jest` 应该加上，不然写ut时，vscode会提示错误，如下：

![Screen Shot 2020-05-14 at 13 22 00](https://user-images.githubusercontent.com/1059956/81901728-92c0fe80-95f1-11ea-9068-3aad2a7bca30.png)
