### PR TITLE
chore: added generic support for `IGetInitialProps` interface

### DIFF
--- a/packages/preset-built-in/src/plugins/features/ssr/templates/clientExports.tpl
+++ b/packages/preset-built-in/src/plugins/features/ssr/templates/clientExports.tpl
@@ -7,4 +7,4 @@ interface IParams extends Pick<IRouteComponentProps, 'match'> {
   isServer: Boolean;
 }
 
-export type IGetInitialProps = (params: IParams) => Promise<any>;
+export type IGetInitialProps<T = any> = (params: IParams) => Promise<T>;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- 为`IGetInitialProps`接口提供泛型支持，编写如下代码时将因为类型不一致而提示错误。

```js
import React from 'react';
import { IGetInitialProps } from 'umi';

interface InitialProps {
  title: string;
}

export default class extends React.PureComponent<InitialProps> {
  static getInitialProps: IGetInitialProps<InitialProps> = async () => {
    const data = {
      // title: 'Hello World',
    };

    return Promise.resolve(data);
  };

  render() {
    return (
      <div>
        <h1>{this.props.title}</h1>
      </div>
    );
  }
}
```