### PR TITLE
chore: Update typings

### DIFF
--- a/packages/preset-built-in/src/plugins/features/ssr/ssr.ts
+++ b/packages/preset-built-in/src/plugins/features/ssr/ssr.ts
@@ -248,4 +248,11 @@ export default (api: IApi) => {
       source: `../${TMP_PLUGIN_DIR}/${CLIENT_EXPORTS}`,
     },
   ]);
+
+  api.addUmiExports(() => {
+    return {
+      specifiers: ['IRender', 'IParams', 'IRenderResult'],
+      source: `./${CHUNK_NAME}`,
+    };
+  });
 };

--- a/packages/preset-built-in/src/plugins/features/ssr/ssr.ts
+++ b/packages/preset-built-in/src/plugins/features/ssr/ssr.ts
@@ -248,11 +248,4 @@ export default (api: IApi) => {
       source: `../${TMP_PLUGIN_DIR}/${CLIENT_EXPORTS}`,
     },
   ]);
-
-  api.addUmiExports(() => {
-    return {
-      specifiers: ['IRender', 'IParams', 'IRenderResult'],
-      source: `./${CHUNK_NAME}`,
-    };
-  });
 };

--- a/packages/preset-built-in/src/plugins/features/ssr/templates/clientExports.tpl
+++ b/packages/preset-built-in/src/plugins/features/ssr/templates/clientExports.tpl
@@ -5,6 +5,7 @@ export { isBrowser } from '{{{ SSRUtils }}}';
 
 interface IParams extends Pick<IRouteComponentProps, 'match'> {
   isServer: Boolean;
+  [k: string]: any;
 }
 
 export type IGetInitialProps<T = any> = (params: IParams) => Promise<T>;

--- a/packages/preset-built-in/src/plugins/features/ssr/templates/server.tpl
+++ b/packages/preset-built-in/src/plugins/features/ssr/templates/server.tpl
@@ -26,7 +26,14 @@ export interface IParams {
   path: string;
   htmlTemplate?: string;
   mountElementId?: string;
-  context?: object
+  context?: object;
+  mode?: string;
+  basename?: string;
+  staticMarkup?: boolean;
+  forceInitial?: boolean;
+  getInitialPropsCtx?: object;
+  manifest?: string;
+  [k: string]?: any;
 }
 
 export interface IRenderResult<T> {

--- a/packages/preset-built-in/src/plugins/features/ssr/templates/server.tpl
+++ b/packages/preset-built-in/src/plugins/features/ssr/templates/server.tpl
@@ -18,7 +18,6 @@ plugin.applyPlugins({
   args: { routes },
 });
 
-
 // origin require module
 // https://github.com/webpack/webpack/issues/4175#issuecomment-342931035
 const requireFunc = typeof __webpack_require__ === "function" ? __non_webpack_require__ : require;
@@ -27,7 +26,7 @@ const requireFunc = typeof __webpack_require__ === "function" ? __non_webpack_re
  * server render function
  * @param params
  */
-const render: IRender = async (params) => {
+const render: IServerRender = async (params) => {
   let error;
   const {
     path,

--- a/packages/preset-built-in/src/plugins/features/ssr/templates/server.tpl
+++ b/packages/preset-built-in/src/plugins/features/ssr/templates/server.tpl
@@ -33,7 +33,7 @@ export interface IParams {
   forceInitial?: boolean;
   getInitialPropsCtx?: object;
   manifest?: string;
-  [k: string]?: any;
+  [k: string]: any;
 }
 
 export interface IRenderResult<T> {

--- a/packages/preset-built-in/src/plugins/features/ssr/templates/server.tpl
+++ b/packages/preset-built-in/src/plugins/features/ssr/templates/server.tpl
@@ -3,6 +3,7 @@ import '{{{ RuntimePolyfill }}}';
 import { format } from 'url';
 import renderServer from '{{{ Renderer }}}';
 import { stripBasename, cheerio, handleHTML } from '{{{ Utils }}}';
+import { IServerRender } from '@umijs/types';
 
 import { ApplyPluginsType, createMemoryHistory{{ #DynamicImport }}, dynamic{{ /DynamicImport }} } from '{{{ RuntimePath }}}';
 import { plugin } from './plugin';
@@ -21,30 +22,6 @@ plugin.applyPlugins({
 // origin require module
 // https://github.com/webpack/webpack/issues/4175#issuecomment-342931035
 const requireFunc = typeof __webpack_require__ === "function" ? __non_webpack_require__ : require;
-
-export interface IParams {
-  path: string;
-  htmlTemplate?: string;
-  mountElementId?: string;
-  context?: object;
-  mode?: string;
-  basename?: string;
-  staticMarkup?: boolean;
-  forceInitial?: boolean;
-  getInitialPropsCtx?: object;
-  manifest?: string;
-  [k: string]: any;
-}
-
-export interface IRenderResult<T> {
-  rootContainer: T;
-  html?: T;
-  error?: Error;
-}
-
-export interface IRender<T = string> {
-  (params: IParams): Promise<IRenderResult<T>>;
-}
 
 /**
  * server render function

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -347,6 +347,30 @@ type WithFalse<T> = {
   [P in keyof T]?: T[P] | false;
 };
 
+interface IServerRenderParams {
+  path: string;
+  htmlTemplate?: string;
+  mountElementId?: string;
+  context?: object;
+  mode?: string;
+  basename?: string;
+  staticMarkup?: boolean;
+  forceInitial?: boolean;
+  getInitialPropsCtx?: object;
+  manifest?: string;
+  [k: string]: any;
+}
+
+interface IServerRenderResult<T> {
+  rootContainer: T;
+  html?: T;
+  error?: Error;
+}
+
+interface IServerRender<T = string> {
+  (params: IServerRenderParams): Promise<IServerRenderResult<T>>;
+}
+
 export type IConfig = WithFalse<BaseIConfig>;
 
 export { webpack };
@@ -354,3 +378,4 @@ export { Html, IScriptConfig, IStyleConfig };
 export { Request, Express, Response, NextFunction, RequestHandler };
 
 export { History, Location, IRouteProps, IRouteComponentProps };
+export { IServerRender, IServerRenderParams, IServerRenderResult };

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -22,6 +22,7 @@ import WebpackChain from 'webpack-chain';
 import { Express, NextFunction, RequestHandler } from 'express';
 import { Request, Response } from 'express-serve-static-core';
 import { History, Location } from 'history-with-query';
+import { Stream } from 'stream';
 
 export enum BundlerConfigType {
   csr = 'csr',
@@ -361,10 +362,10 @@ interface IServerRenderParams {
   [k: string]: any;
 }
 
-interface IServerRenderResult<T> {
+interface IServerRenderResult<T = string | Stream> {
   rootContainer: T;
-  html?: T;
-  error?: Error;
+  html: T;
+  error: Error;
 }
 
 interface IServerRender<T = string> {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -353,7 +353,7 @@ interface IServerRenderParams {
   htmlTemplate?: string;
   mountElementId?: string;
   context?: object;
-  mode?: string | Stream;
+  mode?: 'string' | 'stream';
   basename?: string;
   staticMarkup?: boolean;
   forceInitial?: boolean;

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -353,7 +353,7 @@ interface IServerRenderParams {
   htmlTemplate?: string;
   mountElementId?: string;
   context?: object;
-  mode?: string;
+  mode?: string | Stream;
   basename?: string;
   staticMarkup?: boolean;
   forceInitial?: boolean;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

```ts
app.use(async (req, res) => {
  const render: IRender = require('./dist/umi.server.js');
  res.setHeader('Content-Type', 'text/html');
  const { html, error, rootContainer } = await render({
    path: req.url,
    getInitialPropsCtx: {
      req,
    },
  });
})
```

在使用如上代码时，期望给从`umi.server.js`导入的`render`函数加上类型提示，为此作如下修改：

- 通过调用`api.addUmiExports`，在生成的`umiExports.ts`文件中新增导出`IRender`，`IParams`，`IRenderResult`三个类型
- 根据`render`函数代码，完善`IParams`类型提示
https://github.com/umijs/umi/blob/7f7d51f5287c12a82b0caded34e98c8bd3bbbde7/packages/preset-built-in/src/plugins/features/ssr/templates/server.tpl#L48-L59

---

```ts
Page.getInitialProps = (async (ctx) => {
  if (ctx.isServer) {
    console.log(ctx.req);
  }
  return {};
}) as IGetInitialProps
```
如将服务端参数扩展到`ctx`中，在使用如上代码时，会提示`ctx`上不存在`req`属性。
因此给`IParams`类型加上索引签名。
