### PR TITLE
fix: ssr default HTML assets not hash

### DIFF
--- a/packages/preset-built-in/src/plugins/features/exportStatic.ts
+++ b/packages/preset-built-in/src/plugins/features/exportStatic.ts
@@ -64,7 +64,6 @@ export default (api: IApi) => {
     const routeMap = (await html.getRouteMap()) || defaultRouteMap;
     const { exportStatic } = api.config;
     // for dynamic routes
-    // TODO: test case
     if (exportStatic && typeof exportStatic.extraRoutePaths === 'function') {
       const extraRoutePaths = await exportStatic.extraRoutePaths();
       extraRoutePaths?.forEach((path) => {

--- a/packages/preset-built-in/src/plugins/features/ssr/fixtures/normal/.umirc.ts
+++ b/packages/preset-built-in/src/plugins/features/ssr/fixtures/normal/.umirc.ts
@@ -1,0 +1,3 @@
+export default {
+  outputPath: './customDist',
+}

--- a/packages/preset-built-in/src/plugins/features/ssr/fixtures/normal/customDist/umi.server.js
+++ b/packages/preset-built-in/src/plugins/features/ssr/fixtures/normal/customDist/umi.server.js
@@ -1,0 +1,4 @@
+let manifest = params.manifest;
+const env = 'production';
+let html = htmlTemplate || "<!DOCTYPE html>\n<html>\n  <head>\n    <meta charset=\"utf-8\" />\n    <meta\n      name=\"viewport\"\n      content=\"width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no\"\n    />\n    <link rel=\"stylesheet\" href=\"/umi.css\" />\n    <script>\n      window.routerBase = \"/\";\n    </script>\n    <script>\n      //! umi version: undefined\n    </script>\n  </head>\n  <body>\n    <div id=\"root\"></div>\n\n    <script src=\"/umi.js\"></script>\n  </body>\n</html>\n";
+let rootContainer = '';

--- a/packages/preset-built-in/src/plugins/features/ssr/ssr.test.ts
+++ b/packages/preset-built-in/src/plugins/features/ssr/ssr.test.ts
@@ -1,0 +1,42 @@
+import { join } from 'path';
+import { Service } from '@umijs/core';
+import { onBuildComplete } from './ssr';
+
+const fixtures = join(__dirname, 'fixtures');
+
+test('onBuildComplete normal', async () => {
+  const cwd = join(fixtures, 'normal');
+
+  const service = new Service({
+    cwd,
+    presets: [require.resolve('../../../index')],
+  });
+  await service.init();
+  const api = service.getPluginAPI({
+    service,
+    id: 'test',
+    key: 'test',
+  });
+  const stats = {
+    stats: [
+      {
+        compilation: {
+          chunks: [
+            {
+              name: 'umi',
+              files: ['umi.6f4c357e.css', 'umi.e1837763.js'],
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  const buildComplete = onBuildComplete(api, true);
+  const serverContent = await buildComplete({
+    err: null,
+    stats,
+  });
+  expect(serverContent).toContain('/umi.6f4c357e.css');
+  expect(serverContent).toContain('/umi.e1837763.js');
+});

--- a/packages/preset-built-in/src/plugins/features/ssr/ssr.ts
+++ b/packages/preset-built-in/src/plugins/features/ssr/ssr.ts
@@ -267,12 +267,11 @@ export default (api: IApi) => {
           chunks: clientStats.compilation.chunks,
         }),
       );
-      const htmlPath = path.join(api.paths.absOutputPath!, 'index.html');
       const serverPath = path.join(
         api.paths.absOutputPath!,
         OUTPUT_SERVER_FILENAME,
       );
-      if (fs.existsSync(serverPath) && fs.existsSync(htmlPath)) {
+      if (fs.existsSync(serverPath)) {
         const serverContent = fs
           .readFileSync(serverPath, 'utf-8')
           .replace(placeholderHTML, defaultHTML);

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -133,7 +133,10 @@ export interface IApi extends PluginAPI {
   onPatchRouteBefore: IEvent<{ route: IRoute; parentRoute?: IRoute }>;
   onPatchRoutes: IEvent<{ routes: IRoute[]; parentRoute?: IRoute }>;
   onPatchRoutesBefore: IEvent<{ routes: IRoute[]; parentRoute?: IRoute }>;
-  onBuildComplete: IEvent<{ err?: Error; stats?: webpack.Stats }>;
+  onBuildComplete: IEvent<{
+    err?: Error;
+    stats?: { stats: webpack.Stats[]; hash: string };
+  }>;
   onDevCompileDone: IEvent<{
     isFirstCompile: boolean;
     stats: webpack.Stats;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

- 修复 `hash: true` 下 `umi.server.js` 中默认 HTML 模板里的 js 和 css 没有被 hash 的问题
- 修复开启 dynamicImport 的预渲染，加载不正确的 chunks 

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
