### PR TITLE
fix: headScripts order bug

### DIFF
--- a/packages/preset-built-in/src/index.test.ts
+++ b/packages/preset-built-in/src/index.test.ts
@@ -113,7 +113,7 @@ test('html', async () => {
   expect(removeSpace($('head style').eq(0).html())).toEqual(`.a{color:red;}`);
   expect(removeSpace($('head style').eq(1).html())).toEqual(`.b{color:blue;}`);
   expect($('head script[src="//g.alicdn.com/ga.js"]')).toBeTruthy();
-  expect(removeSpace($('head script').eq(3).html())).toContain(
+  expect(removeSpace($('head script').eq(2).html())).toContain(
     `console.log(3)`,
   );
 

--- a/packages/preset-built-in/src/plugins/features/html/headScripts.ts
+++ b/packages/preset-built-in/src/plugins/features/html/headScripts.ts
@@ -11,7 +11,11 @@ export default function (api: IApi) {
     },
   });
 
-  api.addHTMLHeadScripts(() => {
-    return getScripts(api.config?.headScripts || []);
+  // ensure userConfig headScripts add the front of `devScripts.ts`
+  api.addHTMLHeadScripts({
+    fn: () => {
+      return getScripts(api.config?.headScripts || []);
+    },
+    stage: -1,
   });
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

> 背景是，本地测浏览器兼容性时，需要在 headScripts 加一些脚本，而 `devScripts.js` 本身不兼容 IE 浏览器，需要放在用户配置 `headScripts` 执行

实际：

![image](https://user-images.githubusercontent.com/13595509/87368934-ca2c3700-c5b1-11ea-8bee-c8fa61c1dca8.png)


预期：

![image](https://user-images.githubusercontent.com/13595509/87368950-d57f6280-c5b1-11ea-9734-c6754f48d7af.png)


##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
