### PR TITLE
Add Scaffold command for npm users in document

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -2,14 +2,25 @@
 
 ## Environment setup
 
-First you need to have [node](https://nodejs.org/en/). Make sure the node version is 10.13 or above. ([nvm](https://github.com/creationix/nvm) is recommended to manage node version for Mac OSX)
+First you need to install [node](https://nodejs.org/en/). Make sure the node version is 10.13 or above. ([nvm](https://github.com/creationix/nvm) is recommended to manage node version for Mac OSX)
 
 ```bash
 $ node -v
 v10.13.0
 ```
 
-It is recommended to use yarn to manage npm dependencies and [use domestic sources](https://github.com/yiminghe/tyarn) (Ali users use internal network sources).
+We recommend to use [yarn](https://github.com/yarnpkg/yarn) to manage npm dependencies.
+
+```bash
+# install yarn globally
+$ npm i yarn -g
+# confirm yarn version
+$ yarn -v
+```
+
+### For Users in China
+
+We recommend to use [tyarn](https://github.com/yiminghe/tyarn) to improve performance:
 
 ```bash
 # install tyarn globally
@@ -34,7 +45,8 @@ $ mkdir myapp && cd myapp
 Create project using `@umijs/umi-app` as the template
 
 ```bash
-$ yarn create @umijs/umi-app
+$ yarn create @umijs/umi-app // if use yarn
+$ npx @umijs/create-umi-app // if use npm
 
 Copy:  .editorconfig
 Write: .gitignore


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- 添加npm在英文版说明中的Scaffold的命令（该命令在中文版中有，但是英文版中被遗漏了）
- 将中国大陆/阿里用户这块的说明单独分开。因为对英文用户（一般就是海外用户）而言这块没有用处，当前版本这块的内容非常让人迷惑。其实我个人建议在英文版本里面直接删除。


-----
[View rendered docs/docs/getting-started.md](https://github.com/neekey/umi/blob/patch-1/docs/docs/getting-started.md)