### PR TITLE
feat: support to pass rootElement for client render (#5020)

### DIFF
--- a/packages/preset-built-in/src/plugins/generateFiles/umi.tpl
+++ b/packages/preset-built-in/src/plugins/generateFiles/umi.tpl
@@ -11,7 +11,7 @@ import { renderClient } from '{{{ rendererPath }}}';
 const getClientRender = (args: { hot?: boolean } = {}) => plugin.applyPlugins({
   key: 'render',
   type: ApplyPluginsType.compose,
-  initialValue: () => {
+  initialValue: (opts = {}) => {
     return renderClient({
       // @ts-ignore
       routes: require('./core/routes').routes,
@@ -21,7 +21,7 @@ const getClientRender = (args: { hot?: boolean } = {}) => plugin.applyPlugins({
 {{#dynamicImport}}
       dynamicImport: {{{ dynamicImport }}},
 {{/dynamicImport}}
-      rootElement: '{{{ rootElement }}}',
+      rootElement: opts.rootElement || '{{{ rootElement }}}',
 {{#enableTitle}}
       defaultTitle: `{{{ defaultTitle }}}`,
 {{/enableTitle}}


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

支持给 renderClient 传递 rootElement，实现在运行时指定应用的 mount 节点，主要用于 qiankun 多子应用的情形

相关 issue：#5020
相关 PR：umijs/plugins#310