### PR TITLE
fix: #5129, #4633. ensure devTmpFiles being removed before build. and enforce build with @@/* = src/.umi-production/*

### DIFF
--- a/packages/create-umi-app/templates/AppGenerator/tsconfig.json
+++ b/packages/create-umi-app/templates/AppGenerator/tsconfig.json
@@ -11,7 +11,7 @@
     "strict": true,
     "paths": {
       "@/*": ["src/*"],
-      "@@/*": ["src/.umi/*"]
+      "@@/*": ["src/.umi/*", "src/.umi-production/*"]
     },
     "allowSyntheticDefaultImports": true
   },

--- a/packages/preset-built-in/src/plugins/commands/build/build.ts
+++ b/packages/preset-built-in/src/plugins/commands/build/build.ts
@@ -1,5 +1,5 @@
 import { IApi } from '@umijs/types';
-import { relative } from 'path';
+import { relative, dirname, join } from 'path';
 import { existsSync } from 'fs';
 import { Logger } from '@umijs/core';
 import {
@@ -24,6 +24,13 @@ export default function (api: IApi) {
       cleanTmpPathExceptCache({
         absTmpPath: paths.absTmpPath!,
       });
+
+      // for #5129, #4633
+      // ensure dev generated tmp files is removed
+      // this should work with "@@/*": ["src/.umi/*", "src/.umi-production/*"] in tsconfig.json
+      const devTmpPath = join(dirname(paths.absTmpPath!), '.umi');
+      logger.debug(`Clear devTmpPath: ${devTmpPath}`);
+      rimraf.sync(devTmpPath);
 
       // generate files
       await generateFiles({ api, watch: false });


### PR DESCRIPTION
##### Checklist

- [x] commit message follows commit guidelines

##### Description of change


**generator**

- add new path `"@@/*": ["src/.umi/*", "src/.umi-production/*"]` to `tsconfig.json` for new app

**cli**
- ensure dev generated files being removed before `umi build`
- enforce `umi build` using `@@/* -> src/.umi-production/*` config
