### PR TITLE
fix(Service): await onPluginReady events to avoid concurrent issue

### DIFF
--- a/packages/core/src/Service/Service.ts
+++ b/packages/core/src/Service/Service.ts
@@ -214,7 +214,7 @@ export default class Service extends EventEmitter {
 
     // plugin is totally ready
     this.setStage(ServiceStage.pluginReady);
-    this.applyPlugins({
+    await this.applyPlugins({
       key: 'onPluginReady',
       type: ApplyPluginsType.event,
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

onPluginReady event 没有 await 处理，可能导致 onPluginReady 里的变更因为时序问题而被忽略（比如在 onPluginReady 通过环境变量启用了另一个插件，另一个插件的 modifyDefaultConfig就会失效）

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/umi/5139)
<!-- Reviewable:end -->
