### PR TITLE
Update runtime-config.zh-CN.md

### DIFF
--- a/docs/docs/runtime-config.zh-CN.md
+++ b/docs/docs/runtime-config.zh-CN.md
@@ -70,7 +70,10 @@ import { history } from 'umi';
 export function render(oldRender) {
   fetch('/api/auth').then(auth => {
     if (auth.isLogin) { oldRender() }
-    else { history.push('/login'); }
+    else { 
+      history.push('/login'); 
+      oldRender()
+    }
   });
 }
 ```


### PR DESCRIPTION
Should call `oldRender` when push to login route

-----
[View rendered docs/docs/runtime-config.zh-CN.md](https://github.com/djyde/umi/blob/patch-2/docs/docs/runtime-config.zh-CN.md)