### PR TITLE
Update plugin-qiankun.zh-CN.md

### DIFF
--- a/docs/plugins/plugin-qiankun.zh-CN.md
+++ b/docs/plugins/plugin-qiankun.zh-CN.md
@@ -47,6 +47,8 @@ $ cd packages/plguin-qiankun && yarn start
 
 ##### a. 插件构建期配置子应用
 
+> config/config.ts
+
 ```js
 export default {
   qiankun: {
@@ -67,21 +69,57 @@ export default {
 };
 ```
 
-##### b. 运行时动态配置子应用（src/app.ts 里开启）
+##### b. 运行时动态配置子应用
+
+> config/config.ts
+
+```js
+export default {
+  qiankun: {
+    master: {}
+  }
+};
+```
+
+> src/app.ts
 
 ```js
 // 从接口中获取子应用配置，export 出的 qiankun 变量是一个 promise
-export const qiankun = fetch('/config').then(({ apps }}) => ({
-  // 注册子应用信息
-  apps,
-  // 完整生命周期钩子请看 https://qiankun.umijs.org/zh/api/#registermicroapps-apps-lifecycles
-  lifeCycles: {
-    afterMount: props => {
-      console.log(props);
-    },
-  },
-  // 支持更多的其他配置，详细看这里 https://qiankun.umijs.org/zh/api/#start-opts
-}));
+export const qiankun = fetch('/api/config')
+  .then((response) => {
+    return response.json();
+  })
+  .then((responseJson) => {
+    const { apps } = responseJson;
+    return new Promise((resolve, reject) => {
+      resolve({
+        // 注册子应用信息
+        apps,
+        // 完整生命周期钩子请看 https://qiankun.umijs.org/zh/api/#registermicroapps-apps-lifecycles
+        lifeCycles: {
+          afterMount: (props) => {
+            console.log(props);
+          }
+        }
+        // 支持更多的其他配置，详细看这里 https://qiankun.umijs.org/zh/api/#start-opts
+      });
+    });
+  });
+```
+
+> mock/config.ts
+
+```js
+export default {
+  'GET /api/config': {
+    apps: [
+      {
+        name: 'app1', // 唯一 id
+        entry: '//localhost:7001', // html entry
+      }
+    ]
+  }
+};
 ```
 
 完整的主应用配置项看这里 [masterOptions 配置列表](#masterOptions)


### PR DESCRIPTION
完善 主应用配置 之 运行时动态配置子应用 该部分的内容；
运行时动态配置子应用中 src/app.ts 代码示例存在错误（多了一个花括号），进行修正；
对运行时动态配置子应用中 src/app.ts 代码示例的 fetch Promise 处理部分进行了改写，使入门阅读者更易理解；

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [x] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL


-----
[View rendered docs/plugins/plugin-qiankun.zh-CN.md](https://github.com/blueju/umi/blob/patch-2/docs/plugins/plugin-qiankun.zh-CN.md)