### PR TITLE
feat: add default 404 plugin for convention-routing

### DIFF
--- a/packages/preset-built-in/src/index.ts
+++ b/packages/preset-built-in/src/index.ts
@@ -63,6 +63,7 @@ export default function () {
       require.resolve('./plugins/features/theme'),
       require.resolve('./plugins/features/umiInfo'),
       require.resolve('./plugins/features/runtimeHistory'),
+      require.resolve('./plugins/features/convention-404'),
 
       // html
       require.resolve('./plugins/features/html/favicon'),

--- a/packages/preset-built-in/src/plugins/features/convention-404.ts
+++ b/packages/preset-built-in/src/plugins/features/convention-404.ts
@@ -53,5 +53,7 @@ export default (api: IApi) => {
         ? { component }
         : { redirect },
     )
+
+    return routes
   })
 }

--- a/packages/preset-built-in/src/plugins/features/convention-404.ts
+++ b/packages/preset-built-in/src/plugins/features/convention-404.ts
@@ -1,0 +1,57 @@
+/**
+ * 为约定式路由中添加默认 404 路由
+ *
+ * 在有约定 /404.tsx 路由组件的情况下，
+ * 给嵌套路由中的每一项 routes 末尾添加不匹配任何 path 的 404 路由
+ */
+import { IApi, IRoute } from '@umijs/types'
+
+
+export const find404Route = (routes: IRoute[]): IRoute => {
+  for (const route of routes) {
+    if (route.path === '/404') {
+      return route
+    }
+    if (route.routes) {
+      return find404Route(route.routes)
+    }
+  }
+}
+
+export const addInsurance404 = (routes: IRoute[], notFoundRoute: IRoute) => {
+  for (const route of routes) {
+    if (route.routes) {
+      addInsurance404(route.routes, notFoundRoute)
+    }
+  }
+
+  routes.push(notFoundRoute)
+}
+
+export default (api: IApi) => {
+  api.modifyRoutes((routes: IRoute[]) => {
+    // https://umijs.org/config#exportstatic
+    if (api.config.exportStatic) {
+      return
+    }
+
+    const notFoundRoute = find404Route(routes)
+
+    if (!notFoundRoute) {
+      return routes
+    }
+
+    if (!notFoundRoute.component && !notFoundRoute.redirect) {
+      throw new Error('Invalid route config for /404, no component and redirect')
+    }
+
+    const { component, redirect } = notFoundRoute
+
+    addInsurance404(
+      routes,
+      notFoundRoute.component
+        ? { component }
+        : { redirect },
+    )
+  })
+}


### PR DESCRIPTION
### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

#### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
  
  为约定式路由增加默认 404 路由

   - 在有约定式 `/404.tsx` 路由组件的情况下，
   - 给嵌套路由中的每一项 routes 末尾添加不匹配任何 path 的 404 路由
   - #4987 中的写法有问题，只有顶层 `/` 一层路径下才有 404 路由

- close #4437 #4987 #5081 #5085 #5227
