### PR TITLE
docs: improve explanation for env config

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -15,7 +15,8 @@ export default {
 
 ## Configuration
 
-We recommend configuring your app with `.umirc.ts`. It is possible to split your configurations into pieces and organize them in `config/config.ts` if your app requires complicated configuration. For example, if you need to configure routers, it would be a good choice to have it in an individual module alongside `config/config.ts`.
+If your configurations are not complicated, we recommend configuring your app with `.umirc.ts`;
+If your configurations are complicated, it is possible to split your configurations into pieces and organize them in `config/config.ts`. For example, if you need to configure routers, it would be a good choice to have it in an individual module called `config/routes.ts` alongside `config/config.ts`.
 
 You have to choose between `.umirc.ts` and `config/config.ts`, `.umirc.ts` has higher priority.
 
@@ -44,10 +45,10 @@ Create `.umirc.local.ts`, it will be deep merged with `.umirc.ts` while using `u
 For example:
 
 ```js
-// .umirc.ts
+// .umirc.ts or config/config.ts
 export default { a: 1, b: 2 };
 
-// .umirc.local.ts
+// .umirc.local.ts or config/config.local.ts
 export default { c: 'local' };
 ```
 
@@ -74,13 +75,13 @@ Environment variable `UMI_ENV` shall be used to identify configurations for diff
 For example:
 
 ```js
-// .umirc.js
+// .umirc.js or config/config.js
 export default { a: 1, b: 2 };
 
-// .umirc.cloud.js
+// .umirc.cloud.js or config/config.cloud.js
 export default { b: 'cloud', c: 'cloud' };
 
-// .umirc.local.js
+// .umirc.local.js or config/config.local.js
 export default { c: 'local' };
 ```
 

--- a/docs/docs/config.zh-CN.md
+++ b/docs/docs/config.zh-CN.md
@@ -15,9 +15,10 @@ export default {
 
 ## 配置文件
 
-推荐在 `.umirc.ts` 中写配置。如果配置比较复杂需要拆分，可以放到 `config/config.ts` 中，并把配置的一部分拆出去，比如路由。
+如果项目的配置不复杂，推荐在 `.umirc.ts` 中写配置；
+如果项目的配置比较复杂，可以将配置写在 `config/config.ts` 中，并把配置的一部分拆出去，比如路由配置可以拆成单独的 `config/routes.ts`。
 
-两者二选一，`.umirc.ts` 优先级更高。
+两种方式二选一，`.umirc.ts` 优先级更高。
 
 ## TypeScript 提示
 
@@ -44,10 +45,10 @@ export default defineConfig({
 比如，
 
 ```js
-// .umirc.ts
+// .umirc.ts 或者 config/config.ts
 export default { a: 1, b: 2 };
 
-// .umirc.local.ts
+// .umirc.local.ts 或者 config/config.local.ts
 export default { c: 'local' };
 ```
 
@@ -74,13 +75,13 @@ export default { c: 'local' };
 举个例子，
 
 ```js
-// .umirc.js
+// .umirc.js 或者 config/config.js
 export default { a: 1, b: 2 };
 
-// .umirc.cloud.js
+// .umirc.cloud.js 或者 config/config.cloud.js
 export default { b: 'cloud', c: 'cloud' };
 
-// .umirc.local.js
+// .umirc.local.js 或者 config/config.local.js
 export default { c: 'local' };
 ```
 


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

有内部用户反馈看不懂拆分 `config/config.ts` 的意思，且理解为只有 `.umirc.ts` 支持 env 后缀，所以尝试把文档描述写得更详细，以减少答疑成本


-----
[View rendered docs/docs/config.md](https://github.com/umijs/umi/blob/support/env-config-doc/docs/docs/config.md)
[View rendered docs/docs/config.zh-CN.md](https://github.com/umijs/umi/blob/support/env-config-doc/docs/docs/config.zh-CN.md)