### PR TITLE
fix: show explict error message when parsing conventional route components failed

### DIFF
--- a/packages/core/src/Route/getConventionalRoutes.ts
+++ b/packages/core/src/Route/getConventionalRoutes.ts
@@ -40,7 +40,13 @@ function getFiles(root: string) {
     if (isFile) {
       if (!/\.(j|t)sx?$/.test(file)) return false;
       const content = readFileSync(absFile, 'utf-8');
-      if (!isReactComponent(content)) return false;
+      try {
+        if (!isReactComponent(content)) return false;
+      } catch (e) {
+        throw new Error(
+          `[CONVENTIONAL ROUTES] Parse ${absFile} failed, ${e.message}`,
+        );
+      }
     }
     return true;
   });
@@ -96,7 +102,13 @@ function fileToRouteReducer(opts: IOpts, memo: IRoute[], file: string) {
 function normalizeRoute(route: IRoute, opts: IOpts) {
   let props: unknown = undefined;
   if (route.component) {
-    props = getExportProps(readFileSync(route.component, 'utf-8'));
+    try {
+      props = getExportProps(readFileSync(route.component, 'utf-8'));
+    } catch (e) {
+      throw new Error(
+        `[CONVENTIONAL ROUTES] Parse ${route.component} failed, ${e.message}`,
+      );
+    }
     route.component = winPath(relative(join(opts.root, '..'), route.component));
     route.component = `${opts.componentPrefix || '@/'}${route.component}`;
   }

--- a/packages/core/src/Route/getConventionalRoutes.ts
+++ b/packages/core/src/Route/getConventionalRoutes.ts
@@ -44,7 +44,7 @@ function getFiles(root: string) {
         if (!isReactComponent(content)) return false;
       } catch (e) {
         throw new Error(
-          `[CONVENTIONAL ROUTES] Parse ${absFile} failed, ${e.message}`,
+          `Parse conventional route component ${absFile} failed, ${e.message}`,
         );
       }
     }
@@ -106,7 +106,7 @@ function normalizeRoute(route: IRoute, opts: IOpts) {
       props = getExportProps(readFileSync(route.component, 'utf-8'));
     } catch (e) {
       throw new Error(
-        `[CONVENTIONAL ROUTES] Parse ${route.component} failed, ${e.message}`,
+        `Parse conventional route component ${route.component} failed, ${e.message}`,
       );
     }
     route.component = winPath(relative(join(opts.root, '..'), route.component));


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/35128/92552078-5e550a80-f292-11ea-8e9a-eaa2596d1fc6.png)

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
