### PR TITLE
Update plugin-layout.zh-CN.md

### DIFF
--- a/docs/plugins/plugin-layout.zh-CN.md
+++ b/docs/plugins/plugin-layout.zh-CN.md
@@ -58,7 +58,7 @@ export const config = defineConfig({
 * Type: `boolean`
 * Default: `false`
 
-是否开始国际化配置。开启后路由里配置的菜单名会被当作菜单名国际化的 key，插件会去 locales 文件中查找 `menu.[key]`对应的文案，默认值为改 key。该功能需要配置 `@umijs/plugin-locale` 使用。
+是否开始国际化配置。开启后路由里配置的菜单名会被当作菜单名国际化的 key，插件会去 locales 文件中查找 `menu.[key]`对应的文案，默认值为该 key，路由配置的 name 字段的值就是对应的 key 值。如果菜单是多级路由假设是二级路由菜单，那么插件就会去 locales 文件中查找 `menu.[key].[key]`对应的文案，该功能需要配置 `@umijs/plugin-locale` 使用。
 
 ### 运行时配置
 


### PR DESCRIPTION
title的国际化和菜单的国际化容易混淆，导致取key取的不对。有一个错别字。菜单的国际化key是name字段的值，在嵌套路由的时候，由于还有一级menu字段，容易混淆特指出文案的取值方式。

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL


-----
[View rendered docs/plugins/plugin-layout.zh-CN.md](https://github.com/wangyuan0108/umi/blob/patch-3/docs/plugins/plugin-layout.zh-CN.md)