### PR TITLE
fix(ssr): render failed if configure dynamicImport.loading with ssr

### DIFF
--- a/packages/preset-built-in/src/plugins/features/ssr/ssr.ts
+++ b/packages/preset-built-in/src/plugins/features/ssr/ssr.ts
@@ -126,6 +126,7 @@ export default (api: IApi) => {
           require.resolve('regenerator-runtime/runtime'),
         ),
         DynamicImport: !!api.config.dynamicImport,
+        LoadingComponent: api.config.dynamicImport?.loading,
         Utils: winPath(require.resolve('./templates/utils')),
         Mode: !!api.config.ssr?.mode || 'string',
         MountElementId: api.config.mountElementId,

--- a/packages/preset-built-in/src/plugins/features/ssr/templates/server.tpl
+++ b/packages/preset-built-in/src/plugins/features/ssr/templates/server.tpl
@@ -9,6 +9,10 @@ import { ApplyPluginsType, createMemoryHistory{{ #DynamicImport }}, dynamic{{ /D
 import { plugin } from './plugin';
 import './pluginRegister';
 
+{{ #LoadingComponent }}
+import LoadingComponent from '{{{ LoadingComponent }}}';
+{{ /LoadingComponent }}
+
 // origin require module
 // https://github.com/webpack/webpack/issues/4175#issuecomment-342931035
 const requireFunc = typeof __webpack_require__ === "function" ? __non_webpack_require__ : require;


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Description of change

修复配置自定义 dynamic loading 组件后 ssr 失败的问题，该问题是由于下方关联的 commit 中更新了 `routes.tpl`、但 `server.tpl` 没有做相应调整导致的，控制台会抛出类似 Error：

```bash
ERROR [SSR] /path/to/page ReferenceError: LoadingComponent is not defined
    at p (/path/to/umi.server.js:1:1392007)
```

- 关联 commit https://github.com/umijs/umi/commit/b77b023211c3d2040b3c19d0d612bc0deae4f41d
- close #5376 
