### PR TITLE
fix: resolve correct component and wrappers path in windows

### DIFF
--- a/packages/core/src/Route/Route.ts
+++ b/packages/core/src/Route/Route.ts
@@ -2,6 +2,7 @@ import { lodash, winPath } from '@umijs/utils';
 import { join } from 'path';
 import { IConfig, IRoute } from '..';
 import assert from 'assert';
+import path from 'path';
 import getConventionalRoutes from './getConventionalRoutes';
 import routesToJSON from './routesToJSON';
 
@@ -108,7 +109,7 @@ class Route {
       !opts.isConventional &&
       typeof route.component === 'string' &&
       !route.component.startsWith('@/') &&
-      !route.component.startsWith('/')
+      !path.isAbsolute(route.component)
     ) {
       route.component = winPath(join(opts.root, route.component));
     }
@@ -116,7 +117,7 @@ class Route {
     // resolve wrappers path
     if (route.wrappers) {
       route.wrappers = route.wrappers.map((wrapper) => {
-        if (wrapper.startsWith('@/') || wrapper.startsWith('/')) {
+        if (wrapper.startsWith('@/') || path.isAbsolute(wrapper)) {
           return wrapper;
         } else {
           return winPath(join(opts.root, wrapper));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- 修复在 windows 平台下 wrappers 的地址错误的情况
- close https://github.com/umijs/umi/issues/5401
