### PR TITLE
fix: `yarn debug dev` not work

### DIFF
--- a/packages/umi/src/utils/fork.ts
+++ b/packages/umi/src/utils/fork.ts
@@ -18,10 +18,10 @@ export default function start({ scriptPath }: IOpts) {
     execArgv.splice(
       inspectArgvIndex,
       1,
-      inspectArgv.replace(/--inspect-brk=(.*)/, (match, s1) => {
+      inspectArgv.replace(/--inspect-brk=?(.*)/, (match, s1) => {
         let port;
         try {
-          port = parseInt(s1) + 1;
+          port = parseInt(s1 || '9229') + 1;
         } catch (e) {
           port = 9230; // node default inspect port plus 1.
         }


### PR DESCRIPTION
##### Checklist

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change
修复运行 yarn debug dev 时报以下错误的问题
```shell
Starting inspector on 127.0.0.1:9229 failed: address already in use
```