### PR TITLE
feat: SSR removeWindowInitialProps & fix warning in autoprefixer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,16 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
       - name: restore lerna
+        id: cache
         uses: actions/cache@v2
         with:
           path: |
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn --ignore-engines
+      - name: install
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn --ignore-engines
       - run: yarn build
       - run: yarn test --forceExit
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,13 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node_version }}
+      - name: restore lerna
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn --ignore-engines
       - run: yarn build
       - run: yarn test --forceExit

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
         displayName: install
       - script: yarn build
         displayName: build
-      - script: yarn test --forceExit --detectOpenHandles --runInBand
+      - script: yarn test --forceExit --detectOpenHandles --maxWorkers=4
         env:
           PROGRESS: none
           CI: true

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1062,6 +1062,7 @@ __webpack_public_path__ = window.publicPath;
 * 开启后，执行 `umi dev` 时，访问 http://localhost:8000 ，默认将单页应用（SPA）渲染成 html 片段，片段可以通过开发者工具『显示网页源代码』进行查看。
 * 执行 `umi build`，产物会额外生成 `umi.server.js` 文件，此文件运行在 Node.js 服务端，用于做服务端渲染，渲染 html 片段。
 * 如果应用没有 Node.js 服务端，又希望生成 html 片段做 SEO（搜索引擎优化），可以开启 [exportStatic](#exportstatic) 配置，会在执行 `umi build` 构建时进行**预渲染**。
+* `removeWindowInitialProps` 与 `forceInitial` 不可同时使用
 
 了解更多，可点击 [服务端渲染文档](/zh-CN/docs/ssr)。
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1041,6 +1041,7 @@ __webpack_public_path__ = window.publicPath;
   ssr: {
     // 更多配置
     // forceInitial: false,
+    // removeWindowInitialProps: false
     // devServerRender: true,
     // mode: 'string',
     // staticMarkup: false,
@@ -1051,6 +1052,7 @@ __webpack_public_path__ = window.publicPath;
 配置说明：
 
 * `forceInitial`：客户端渲染时强制执行 `getInitialProps` 方法，常见的场景：静态站点希望每次访问时保持数据最新，以客户端渲染为主。
+* `removeWindowInitialProps`: HTML 中移除 `window.getInitialProps` 变量，避免 HTML 中有大量数据影响 SEO 效果，场景：静态站点
 * `devServerRender`：在 `umi dev` 开发模式下，执行渲染，用于 umi SSR 项目的快速开发、调试，服务端渲染效果所见即所得，同时我们考虑到可能会与服务端框架（如 [Egg.js](https://eggjs.org/)、[Express](https://expressjs.com/)、[Koa](https://koajs.com/)）结合做本地开发、调试，关闭后，在 `umi dev` 下不执行服务端渲染，但会生成 `umi.server.js`（Umi SSR 服务端渲染入口文件），渲染开发流程交由开发者处理。
 * `mode`：渲染模式，默认使用 `string` 字符串渲染，同时支持流式渲染 `mode: 'stream'`，减少 TTFB（浏览器开始收到服务器响应数据的时间） 时长。
 * `staticMarkup`：html 上的渲染属性（例如 React 渲染的 `data-reactroot`），常用于静态站点生成的场景上。

--- a/docs/config/README.zh-CN.md
+++ b/docs/config/README.zh-CN.md
@@ -1038,6 +1038,7 @@ __webpack_public_path__ = window.publicPath;
   ssr: {
     // 更多配置
     // forceInitial: false,
+    // removeWindowInitialProps: false
     // devServerRender: true,
     // mode: 'string',
     // staticMarkup: false,
@@ -1048,6 +1049,7 @@ __webpack_public_path__ = window.publicPath;
 配置说明：
 
 * `forceInitial`：客户端渲染时强制执行 `getInitialProps` 方法，常见的场景：静态站点希望每次访问时保持数据最新，以客户端渲染为主。
+* `removeWindowInitialProps`: HTML 中移除 `window.getInitialProps` 变量，避免 HTML 中有大量数据影响 SEO 效果，场景：静态站点
 * `devServerRender`：在 `umi dev` 开发模式下，执行渲染，用于 umi SSR 项目的快速开发、调试，服务端渲染效果所见即所得，同时我们考虑到可能会与服务端框架（如 [Egg.js](https://eggjs.org/)、[Express](https://expressjs.com/)、[Koa](https://koajs.com/)）结合做本地开发、调试，关闭后，在 `umi dev` 下不执行服务端渲染，但会生成 `umi.server.js`（Umi SSR 服务端渲染入口文件），渲染开发流程交由开发者处理。
 * `mode`：渲染模式，默认使用 `string` 字符串渲染，同时支持流式渲染 `mode: 'stream'`，减少 TTFB（浏览器开始收到服务器响应数据的时间） 时长。
 * `staticMarkup`：html 上的渲染属性（例如 React 渲染的 `data-reactroot`），常用于静态站点生成的场景上。

--- a/docs/config/README.zh-CN.md
+++ b/docs/config/README.zh-CN.md
@@ -1059,6 +1059,7 @@ __webpack_public_path__ = window.publicPath;
 * 开启后，执行 `umi dev` 时，访问 http://localhost:8000 ，默认将单页应用（SPA）渲染成 html 片段，片段可以通过开发者工具『显示网页源代码』进行查看。
 * 执行 `umi build`，产物会额外生成 `umi.server.js` 文件，此文件运行在 Node.js 服务端，用于做服务端渲染，渲染 html 片段。
 * 如果应用没有 Node.js 服务端，又希望生成 html 片段做 SEO（搜索引擎优化），可以开启 [exportStatic](#exportstatic) 配置，会在执行 `umi build` 构建时进行**预渲染**。
+* `removeWindowInitialProps` 与 `forceInitial` 不可同时使用
 
 了解更多，可点击 [服务端渲染文档](/zh-CN/docs/ssr)。
 

--- a/examples/ssr-normal/.umirc.ts
+++ b/examples/ssr-normal/.umirc.ts
@@ -8,7 +8,17 @@ export default defineConfig({
   routes: [
     {
       path: '/',
-      component: '@/pages/index',
+      component: '@/layouts/index',
+      routes: [
+        {
+          path: '/',
+          component: '@/pages/index',
+        },
+        {
+          path: '/about',
+          component: '@/pages/about',
+        },
+      ],
     },
   ],
 });

--- a/examples/ssr-normal/layouts/index.tsx
+++ b/examples/ssr-normal/layouts/index.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Link } from 'umi';
+
+export default function Layout(props) {
+  return (
+    <div>
+      <ul>
+        <li>
+          <Link to="/">/</Link>{' '}
+        </li>
+        <li>
+          <Link to="/about">/about</Link>
+        </li>
+      </ul>
+      {props.children}
+    </div>
+  );
+}

--- a/examples/ssr-normal/pages/about.tsx
+++ b/examples/ssr-normal/pages/about.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+function About(props) {
+  const { aboutData } = props;
+  return <div>Hello {aboutData?.hello}</div>;
+}
+
+About.getInitialProps = async () => {
+  return {
+    aboutData: {
+      hello: 'world',
+    },
+  };
+};
+
+export default About;

--- a/examples/ssr-normal/pages/index.tsx
+++ b/examples/ssr-normal/pages/index.tsx
@@ -1056,7 +1056,7 @@ const fetch = () =>
   ]);
 
 const Home = (props) => {
-  const { result } = props;
+  const { result = [] } = props;
 
   return (
     <div>

--- a/packages/bundler-webpack/src/getConfig/css.ts
+++ b/packages/bundler-webpack/src/getConfig/css.ts
@@ -111,10 +111,13 @@ export function createCSSRule({
               // https://github.com/csstools/postcss-preset-env
               require('postcss-preset-env')({
                 // TODO: set browsers
-                autoprefixer: {
-                  ...config.autoprefixer,
-                  overrideBrowserslist: browserslist,
-                },
+                autoprefixer:
+                  type === BundlerConfigType.ssr
+                    ? false
+                    : {
+                        ...config.autoprefixer,
+                        overrideBrowserslist: browserslist,
+                      },
                 // https://cssdb.org/
                 stage: 3,
               }),

--- a/packages/preset-built-in/package.json
+++ b/packages/preset-built-in/package.json
@@ -28,7 +28,7 @@
     "@types/merge-stream": "1.1.2",
     "@types/multer": "1.4.3",
     "@types/react-router-config": "5.0.1",
-    "@types/serialize-javascript": "1.5.0",
+    "@types/serialize-javascript": "4.0.0",
     "@umijs/babel-preset-umi": "3.2.22",
     "@umijs/bundler-webpack": "3.2.22",
     "@umijs/renderer-mpa": "3.2.22",
@@ -51,7 +51,7 @@
     "react-router-config": "5.1.1",
     "react-router-dom": "5.2.0",
     "regenerator-runtime": "0.13.5",
-    "serialize-javascript": "4.0.0",
+    "serialize-javascript": "5.0.1",
     "umi-webpack-bundle-analyzer": "3.6.0",
     "zlib": "1.0.5"
   }

--- a/packages/preset-built-in/src/plugins/features/ssr/ssr.ts
+++ b/packages/preset-built-in/src/plugins/features/ssr/ssr.ts
@@ -60,9 +60,10 @@ export default (api: IApi) => {
         return joi.object({
           forceInitial: joi
             .boolean()
-            .description(
-              'remove window.g_initialProps in html, to force execing Page getInitialProps  functions',
-            ),
+            .description('force execing Page getInitialProps functions'),
+          removeWindowInitialProps: joi
+            .boolean()
+            .description('remove window.g_initialProps in html'),
           devServerRender: joi
             .boolean()
             .description('disable serve-side render in umi dev mode.'),
@@ -141,6 +142,7 @@ export default (api: IApi) => {
         StaticMarkup: !!api.config.ssr?.staticMarkup,
         // @ts-ignore
         ForceInitial: !!api.config.ssr?.forceInitial,
+        RemoveWindowInitialProps: !!api.config.ssr?.removeWindowInitialProps,
         Basename: api.config.base,
         PublicPath: api.config.publicPath,
         ManifestFileName: api.config.manifest

--- a/packages/preset-built-in/src/plugins/features/ssr/ssr.ts
+++ b/packages/preset-built-in/src/plugins/features/ssr/ssr.ts
@@ -57,21 +57,28 @@ export default (api: IApi) => {
     key: 'ssr',
     config: {
       schema: (joi) => {
-        return joi.object({
-          forceInitial: joi
-            .boolean()
-            .description('force execing Page getInitialProps functions'),
-          removeWindowInitialProps: joi
-            .boolean()
-            .description('remove window.g_initialProps in html'),
-          devServerRender: joi
-            .boolean()
-            .description('disable serve-side render in umi dev mode.'),
-          mode: joi.string().valid('stream', 'string'),
-          staticMarkup: joi
-            .boolean()
-            .description('static markup in static site'),
-        });
+        return joi
+          .object({
+            forceInitial: joi
+              .boolean()
+              .description('force execing Page getInitialProps functions'),
+            removeWindowInitialProps: joi
+              .boolean()
+              .description('remove window.g_initialProps in html'),
+            devServerRender: joi
+              .boolean()
+              .description('disable serve-side render in umi dev mode.'),
+            mode: joi.string().valid('stream', 'string'),
+            staticMarkup: joi
+              .boolean()
+              .description('static markup in static site'),
+          })
+          .without('forceInitial', ['removeWindowInitialProps'])
+          .error(
+            new Error(
+              'The `removeWindowInitialProps` cannot be enabled when `forceInitial` has been enabled at the same time.',
+            ),
+          );
       },
     },
     // 配置开启

--- a/packages/preset-built-in/src/plugins/features/ssr/templates/server.tpl
+++ b/packages/preset-built-in/src/plugins/features/ssr/templates/server.tpl
@@ -34,6 +34,7 @@ const render: IServerRender = async (params) => {
     basename = '{{{ Basename }}}',
     staticMarkup = {{{ StaticMarkup }}},
     forceInitial = {{{ ForceInitial }}},
+    removeWindowInitialProps = {{{ RemoveWindowInitialProps }}},
     getInitialPropsCtx,
   } = params;
   let manifest = params.manifest;
@@ -122,7 +123,7 @@ const render: IServerRender = async (params) => {
         },
         async: true,
       });
-      html = await handleHTML({ html, rootContainer, pageInitialProps, mountElementId, mode, forceInitial, routesMatched, dynamicImport, manifest });
+      html = await handleHTML({ html, rootContainer, pageInitialProps, mountElementId, mode, forceInitial, removeWindowInitialProps, routesMatched, dynamicImport, manifest });
     }
   } catch (e) {
     // downgrade into csr

--- a/packages/preset-built-in/src/plugins/features/ssr/templates/utils.test.tsx
+++ b/packages/preset-built-in/src/plugins/features/ssr/templates/utils.test.tsx
@@ -47,6 +47,38 @@ test('handleHTML normal', async () => {
   expect(html).toContain('</html>');
 });
 
+test('handleHTML using removeWindowInitialProps', async () => {
+  const html = await handleHTML({
+    pageInitialProps: {
+      username: 'ycjcl868',
+    },
+    removeWindowInitialProps: true,
+    rootContainer: '<h1>ycjcl868</h1>',
+    html: defaultHTML,
+    mountElementId: 'root',
+  });
+  expect(html).toContain('<!DOCTYPE html>');
+  expect(html).not.toMatch('window.g_initialProps');
+  expect(html).toMatch('<div id="root"><h1>ycjcl868</h1></div>');
+  expect(html).toContain('</html>');
+});
+
+test('handleHTML using forceInitial', async () => {
+  const html = await handleHTML({
+    pageInitialProps: {
+      username: 'ycjcl868',
+    },
+    rootContainer: '<h1>ycjcl868</h1>',
+    forceInitial: true,
+    html: defaultHTML,
+    mountElementId: 'root',
+  });
+  expect(html).toContain('<!DOCTYPE html>');
+  expect(html).toMatch('window.g_initialProps = null;');
+  expect(html).toMatch('<div id="root"><h1>ycjcl868</h1></div>');
+  expect(html).toContain('</html>');
+});
+
 test('handleHTML stream', (done) => {
   handleHTML({
     pageInitialProps: {

--- a/packages/preset-built-in/src/plugins/features/ssr/templates/utils.ts
+++ b/packages/preset-built-in/src/plugins/features/ssr/templates/utils.ts
@@ -51,6 +51,7 @@ export interface IHandleHTMLOpts {
   mountElementId: string;
   mode: 'stream' | 'string';
   forceInitial: boolean;
+  removeWindowInitialProps: boolean;
   routesMatched: IRoute[];
   html: string;
   dynamicImport: boolean;
@@ -62,13 +63,13 @@ export interface IHandleHTMLOpts {
  * @param param
  */
 export const handleHTML = async (opts: Partial<IHandleHTMLOpts> = {}) => {
-  const { pageInitialProps, rootContainer, mountElementId, mode, forceInitial, routesMatched, dynamicImport, manifest } = opts;
+  const { pageInitialProps, rootContainer, mountElementId, mode, forceInitial, removeWindowInitialProps, routesMatched, dynamicImport, manifest } = opts;
   let html = opts.html;
   if (typeof html !== 'string') {
     return '';
   }
   const windowInitialVars = {
-    ...(pageInitialProps && !forceInitial ? { 'window.g_initialProps': serialize(pageInitialProps) } : {}),
+    ...(pageInitialProps && !removeWindowInitialProps ? { 'window.g_initialProps': serialize(forceInitial ? null : pageInitialProps) } : {}),
   }
   // get chunks in `dynamicImport: {}`
   if (dynamicImport && Array.isArray(routesMatched)) {
@@ -85,6 +86,7 @@ export const handleHTML = async (opts: Partial<IHandleHTMLOpts> = {}) => {
           if (manifestChunk !== 'umi.css'
             && chunk
             && manifestChunk.startsWith(chunk)
+            && manifest
             && /\.css$/.test(manifest[manifestChunk])
           ) {
             cssChunkSet.add(`<link rel="stylesheet" href="${manifest[manifestChunk]}" />`)
@@ -99,7 +101,7 @@ export const handleHTML = async (opts: Partial<IHandleHTMLOpts> = {}) => {
   const rootHTML = `<div id="${mountElementId}"></div>`;
   const scriptsContent = `\n\t<script>
   window.g_useSSR = true;
-  ${Object.keys(windowInitialVars || {}).map(name => `${name} = ${windowInitialVars[name]}`).join(';\n')};\n\t</script>`;
+  ${Object.keys(windowInitialVars || {}).map(name => `${name} = ${windowInitialVars[name]};`).join('\n')}\n\t</script>`;
   const newRootHTML = `<div id="${mountElementId}">${rootContainer}</div>${scriptsContent}`;
 
   if (mode === 'stream') {

--- a/packages/renderer-react/src/renderClient/renderClient.test.tsx
+++ b/packages/renderer-react/src/renderClient/renderClient.test.tsx
@@ -9,11 +9,15 @@ beforeEach(() => {
   container = document.createElement('div');
   container.id = 'app';
   document.body.appendChild(container);
+  window.g_useSSR = true;
+  window.g_initialProps = null;
 });
 
 afterEach(() => {
   document.body.removeChild(container);
   container = null;
+  delete window.g_useSSR;
+  delete window.g_initialProps;
   cleanup();
 });
 

--- a/packages/renderer-react/src/renderClient/renderClient.tsx
+++ b/packages/renderer-react/src/renderClient/renderClient.tsx
@@ -26,7 +26,7 @@ function RouterComponent(props: IRouterComponentProps) {
   useEffect(() => {
     // first time using window.g_initialProps
     // switch route fetching data, if exact route reset window.getInitialProps
-    if ((window as any).g_initialProps) {
+    if ((window as any).g_useSSR) {
       (window as any).g_initialProps = null;
     }
     function routeChangeHandler(location: any, action?: string) {
@@ -113,8 +113,8 @@ export default function renderClient(opts: IOpts) {
         ? document.getElementById(opts.rootElement)
         : opts.rootElement;
     const callback = opts.callback || (() => {});
-    
-    // flag showing SSR successed    
+
+    // flag showing SSR successed
     if (window.g_useSSR) {
       if (opts.dynamicImport) {
         // dynamicImport should preload current route component

--- a/packages/renderer-react/src/renderRoutes/renderRoutes.test.tsx
+++ b/packages/renderer-react/src/renderRoutes/renderRoutes.test.tsx
@@ -1,12 +1,6 @@
 import React from 'react';
 import { MemoryRouter, Plugin, Link } from '@umijs/runtime';
-import {
-  getByText,
-  render,
-  screen,
-  wait,
-  waitFor,
-} from '@testing-library/react';
+import { getByText, render, screen, waitFor } from '@testing-library/react';
 import renderRoutes from './renderRoutes';
 import { IRoute } from '..';
 
@@ -266,7 +260,7 @@ test('/pass-props', async () => {
   const { container } = render(
     <MemoryRouter initialEntries={['/pass-props']}>{routes}</MemoryRouter>,
   );
-  await wait(() => getByText(container, 'bar'));
+  await waitFor(() => getByText(container, 'bar'));
   expect((await screen.findByTestId('test')).innerHTML).toEqual('bar');
 });
 
@@ -309,8 +303,8 @@ test('/get-initial-props-embed', async () => {
       {newRoutes}
     </MemoryRouter>,
   );
-  await wait(() => getByText(container, 'bar'));
-  await wait(() => getByText(container, 'parent'));
+  await waitFor(() => getByText(container, 'bar'));
+  await waitFor(() => getByText(container, 'parent'));
   expect((await screen.findByTestId('test')).innerHTML).toEqual('bar');
   expect((await screen.findByTestId('test-parent')).innerHTML).toEqual(
     'parent',

--- a/packages/renderer-react/src/renderRoutes/renderRoutes.test.tsx
+++ b/packages/renderer-react/src/renderRoutes/renderRoutes.test.tsx
@@ -185,6 +185,16 @@ const routerConfig = {
 };
 let routes = renderRoutes(routerConfig);
 
+beforeEach(() => {
+  window.g_useSSR = true;
+  window.g_initialProps = null;
+});
+
+afterEach(() => {
+  delete window.g_useSSR;
+  delete window.g_initialProps;
+});
+
 test('/layout', async () => {
   render(<MemoryRouter initialEntries={['/layout']}>{routes}</MemoryRouter>);
   expect((await screen.findByTestId('layout')).innerHTML).toEqual('Layout');

--- a/packages/renderer-react/src/renderRoutes/renderRoutes.tsx
+++ b/packages/renderer-react/src/renderRoutes/renderRoutes.tsx
@@ -36,35 +36,37 @@ function wrapInitialPropsFetch(route: IRoute, opts: IOpts): IComponent {
        * 3. 如果任何时候都走 2 次，配置 forceInitial: true，这个场景用于静态站点的首屏加载希望走最新数据
        * 4. 开启动态加载后，会在执行 getInitialProps 前预加载下
        */
-      if (!(window as any).g_initialProps) {
-        (async () => {
-          // preload when enalbe dynamicImport
-          if (Component.preload) {
-            const preloadComponent = await Component.preload();
-            // for test case, really use .default
-            Component = preloadComponent.default || preloadComponent;
-          }
-          const defaultCtx = {
-            isServer: false,
-            match: props?.match,
-            route,
-            ...(opts.getInitialPropsCtx || {}),
-            ...restRouteParams,
-          };
-          if (Component?.getInitialProps) {
-            const ctx = await opts.plugin.applyPlugins({
-              key: 'ssr.modifyGetInitialPropsCtx',
-              type: ApplyPluginsType.modify,
-              initialValue: defaultCtx,
-              async: true,
-            });
+      const handleGetInitialProps = async () => {
+        // preload when enalbe dynamicImport
+        if (Component.preload) {
+          const preloadComponent = await Component.preload();
+          // for test case, really use .default
+          Component = preloadComponent.default || preloadComponent;
+        }
+        const defaultCtx = {
+          isServer: false,
+          match: props?.match,
+          route,
+          ...(opts.getInitialPropsCtx || {}),
+          ...restRouteParams,
+        };
+        if (Component?.getInitialProps) {
+          const ctx = await opts.plugin.applyPlugins({
+            key: 'ssr.modifyGetInitialPropsCtx',
+            type: ApplyPluginsType.modify,
+            initialValue: defaultCtx,
+            async: true,
+          });
 
-            const initialProps = await Component!.getInitialProps!(
-              ctx || defaultCtx,
-            );
-            setInitialProps(initialProps);
-          }
-        })();
+          const initialProps = await Component!.getInitialProps!(
+            ctx || defaultCtx,
+          );
+          setInitialProps(initialProps);
+        }
+      };
+      // null 时，一定会触发 getInitialProps 执行
+      if ((window as any).g_initialProps === null) {
+        handleGetInitialProps();
       }
     }, [window.location.pathname, window.location.search]);
     return <Component {...props} {...initialProps} />;

--- a/packages/runtime/src/dynamic/dynamic.test.tsx
+++ b/packages/runtime/src/dynamic/dynamic.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getByText, render, wait } from '@testing-library/react';
+import { getByText, render, waitFor } from '@testing-library/react';
 import dynamic from './dynamic';
 
 const delay = (timeout: number) =>
@@ -14,7 +14,7 @@ test('dynamic', async () => {
   });
   const { container } = render(<App />);
   expect(container.innerHTML).toEqual('<p>loading...</p>');
-  await wait(() => getByText(container, 'App'));
+  await waitFor(() => getByText(container, 'App'));
   expect(container.innerHTML).toEqual('<h1>App</h1>');
 });
 
@@ -25,7 +25,7 @@ test('dynamic + Promise args', async () => {
   });
   const { container } = render(<App />);
   expect(container.innerHTML).toEqual('<p>loading...</p>');
-  await wait(() => getByText(container, 'App'));
+  await waitFor(() => getByText(container, 'App'));
   expect(container.innerHTML).toEqual('<h1>App</h1>');
 });
 

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -261,6 +261,7 @@ interface IManifest {
 
 interface ISSR {
   forceInitial?: boolean;
+  removeWindowInitialProps?: boolean;
   devServerRender?: boolean;
   mode?: 'string' | 'stream';
   staticMarkup?: boolean;
@@ -366,6 +367,7 @@ interface IServerRenderParams {
   basename?: string;
   staticMarkup?: boolean;
   forceInitial?: boolean;
+  removeWindowInitialProps?: boolean;
   getInitialPropsCtx?: object;
   manifest?: string;
   [k: string]: any;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3571,9 +3571,10 @@
   version "7.3.3"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.3.tgz#3ad6ed949e7487e7bda6f886b4a2434a2c3d7b1a"
 
-"@types/serialize-javascript@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@types/serialize-javascript/-/serialize-javascript-1.5.0.tgz#bdd334cfbb4fc0eca1fc608da37ad733c86381eb"
+"@types/serialize-javascript@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/serialize-javascript/-/serialize-javascript-4.0.0.tgz#ab9c47edf71f6a4590221118d1dffc37b50d71a2"
+  integrity sha512-y9UO8ozDGF30EVRizmsXuCdZzAxHmYpEEiL+/SQjX+7bnxslkvZQU8rLydixJv7yVae6bWyrNDFHsh6fYHkFMA==
 
 "@types/serve-static@*":
   version "1.13.3"
@@ -13745,15 +13746,22 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@4.0.0, serialize-javascript@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
+serialize-javascript@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
+  integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
   dependencies:
     randombytes "^2.1.0"
 
 serialize-javascript@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
+
+serialize-javascript@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
+  dependencies:
+    randombytes "^2.1.0"
 
 serve-static@1.14.1:
   version "1.14.1"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->
增加一个配置 `ssr: { removeWindowInitialProps: true }`，可用来隐藏 `window.g_initialProps`

Close https://github.com/umijs/umi/issues/5509

Close https://github.com/umijs/umi/issues/4734, ref https://github.com/umijs/umi/pull/5513/commits/3cfc8c6f90ba2edfcdd481bcb424d6c86ec05042

![image](https://user-images.githubusercontent.com/13595509/95551709-28559400-09c0-11eb-9588-104dc40b2538.png)


##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL


-----
[View rendered docs/config/README.md](https://github.com/umijs/umi/blob/feat-ssr-hide-initData/docs/config/README.md)
[View rendered docs/config/README.zh-CN.md](https://github.com/umijs/umi/blob/feat-ssr-hide-initData/docs/config/README.zh-CN.md)