### PR TITLE
fix: put window.resourceBaseUrl into publicPathStr that we could modify it by modifyPublicPathStr

### DIFF
--- a/packages/preset-built-in/src/plugins/commands/htmlUtils.ts
+++ b/packages/preset-built-in/src/plugins/commands/htmlUtils.ts
@@ -105,6 +105,9 @@ export function getHtmlGenerator({ api }: { api: IApi }): any {
         publicPathStr = `location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '') + window.routerBase`;
       }
 
+      // window.resourceBaseUrl 用来兼容 egg.js 项目注入的 publicPath
+      publicPathStr = `window.resourceBaseUrl || ${publicPathStr};`;
+
       publicPathStr = await api.applyPlugins({
         key: 'modifyPublicPathStr',
         type: api.ApplyPluginsType.modify,
@@ -146,8 +149,7 @@ export function getHtmlGenerator({ api }: { api: IApi }): any {
             // 只在设置了 runtimePublicPath 或 exportStatic?.dynamicRoot 时才会用到
             // 设置了 exportStatic?.dynamicRoot 时会自动设置 runtimePublicPath
             api.config.runtimePublicPath && {
-              // window.resourceBaseUrl 用来兼容 egg.js 项目注入的 publicPath
-              content: `window.publicPath = window.resourceBaseUrl || ${publicPathStr};`,
+              content: `window.publicPath = ${publicPathStr};`,
             },
           ].filter(Boolean),
         }),


### PR DESCRIPTION

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

ref https://github.com/umijs/umi/pull/5630

window.resourceBaseUrl 放到 publicPathStr 变量里，这样才能确保外部通过 api.modifyPublicPathStr 复写 publicPath

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/umi/5653)
<!-- Reviewable:end -->
