### PR TITLE
fix: IGetInitialProps match.params

### DIFF
--- a/packages/preset-built-in/src/plugins/features/ssr/templates/clientExports.tpl
+++ b/packages/preset-built-in/src/plugins/features/ssr/templates/clientExports.tpl
@@ -1,11 +1,16 @@
-import { IRouteComponentProps } from 'umi'
+import { IRouteComponentProps } from 'umi';
 
 // only export isBrowser for user
 export { isBrowser } from '{{{ SSRUtils }}}';
 
-interface IParams extends Pick<IRouteComponentProps, 'match'> {
+interface IParams<Params> extends Pick<IRouteComponentProps<Params>, 'match'> {
   isServer: Boolean;
   [k: string]: any;
 }
 
-export type IGetInitialProps<T = any> = (params: IParams) => Promise<T>;
+export type IGetInitialProps<
+  T = any,
+  Params extends {
+    [K in keyof Params]?: string;
+  } = {}
+> = (params: IParams<Params>) => Promise<T>;


### PR DESCRIPTION
修复 TypeScript 类型声明缺失。

```tsx
import React from "react";
import { IGetInitialProps } from "umi";

interface GetInitialProps {
  matchId: string;
}

interface DemoProps extends GetInitialProps {}

const Demo: React.FC<DemoProps> & {
  getInitialProps: IGetInitialProps<GetInitialProps, { id: string }>;
} = ({ matchId }) => {
  //  路由 /demo/4
  return (
    <div>
      <h1>Page demo</h1>

      {/* 4 | null */}
      <p>{matchId}</p>
    </div>
  );
};

Demo.getInitialProps = async (params) => {
  console.log(params.match.params.id);

  return {
    matchId: params.match.params.id,
  };
};

export default Demo;
```

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
