### PR TITLE
refactor: allow other plugin run dev command

### DIFF
--- a/packages/preset-built-in/src/plugins/commands/dev/dev.ts
+++ b/packages/preset-built-in/src/plugins/commands/dev/dev.ts
@@ -9,7 +9,6 @@ import { watchPkg } from './watchPkg';
 
 export default (api: IApi) => {
   const {
-    env,
     paths,
     utils: { chalk, portfinder },
   } = api;
@@ -197,8 +196,9 @@ export default (api: IApi) => {
   api.registerMethod({
     name: 'getPort',
     fn() {
+      // access env when method be called, to allow other plugin run dev command manually
       assert(
-        env === 'development',
+        api.env === 'development',
         `api.getPort() is only valid in development.`,
       );
       return port;
@@ -209,7 +209,7 @@ export default (api: IApi) => {
     name: 'getHostname',
     fn() {
       assert(
-        env === 'development',
+        api.env === 'development',
         `api.getHostname() is only valid in development.`,
       );
       return hostname;
@@ -220,7 +220,7 @@ export default (api: IApi) => {
     name: 'getServer',
     fn() {
       assert(
-        env === 'development',
+        api.env === 'development',
         `api.getServer() is only valid in development.`,
       );
       return server;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Description of change

现在 `env` 是在 `Service` 初始化之前设置的，如果在 `Service` 初始化的过程中其他插件（集）修改 `env` 为 `development`、并且尝试手动调用 `runCommand:dev`，则会导致命令启动失败。

应用场景：基于 Umi 的工具映射子命令到 `dev`，比如执行 `dumi doc dev` 等同于执行 `dumi dev`。

更好的方式：提供 `setEnv` 和 `getEnv` 让 plugin 读写 `Service` 的值。