### PR TITLE
chore: move babel-plugin-auto-css-modules deps to devDeps

### DIFF
--- a/packages/babel-plugin-auto-css-modules/package.json
+++ b/packages/babel-plugin-auto-css-modules/package.json
@@ -23,7 +23,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
+  "devDependencies": {
     "@babel/traverse": "7.12.5",
     "@umijs/utils": "3.3.0"
   }

--- a/packages/babel-plugin-auto-css-modules/package.json
+++ b/packages/babel-plugin-auto-css-modules/package.json
@@ -26,5 +26,8 @@
   "devDependencies": {
     "@babel/traverse": "7.12.5",
     "@babel/types": "7.12.6"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.12.3"
   }
 }

--- a/packages/babel-plugin-auto-css-modules/package.json
+++ b/packages/babel-plugin-auto-css-modules/package.json
@@ -25,6 +25,6 @@
   },
   "devDependencies": {
     "@babel/traverse": "7.12.5",
-    "@umijs/utils": "3.3.0"
+    "@babel/types": "7.12.6"
   }
 }

--- a/packages/babel-plugin-auto-css-modules/src/index.ts
+++ b/packages/babel-plugin-auto-css-modules/src/index.ts
@@ -1,5 +1,5 @@
-import { NodePath, Visitor } from '@babel/traverse';
-import { t } from '@umijs/utils';
+import type { NodePath, Visitor } from '@babel/traverse';
+import type { ImportDeclaration } from '@babel/types';
 import { extname } from 'path';
 
 export interface IOpts {
@@ -12,7 +12,7 @@ export default function () {
   return {
     visitor: {
       ImportDeclaration(
-        path: NodePath<t.ImportDeclaration>,
+        path: NodePath<ImportDeclaration>,
         { opts }: { opts: IOpts },
       ) {
         const {

--- a/packages/babel-plugin-import-to-await-require/package.json
+++ b/packages/babel-plugin-import-to-await-require/package.json
@@ -29,5 +29,8 @@
   },
   "devDependencies": {
     "@babel/traverse": "7.12.5"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.12.3"
   }
 }

--- a/packages/babel-plugin-import-to-await-require/package.json
+++ b/packages/babel-plugin-import-to-await-require/package.json
@@ -25,7 +25,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@babel/traverse": "7.12.5",
-    "@umijs/utils": "3.3.0"
+    "@babel/types": "7.12.6"
+  },
+  "devDependencies": {
+    "@babel/traverse": "7.12.5"
   }
 }

--- a/packages/babel-plugin-import-to-await-require/src/index.ts
+++ b/packages/babel-plugin-import-to-await-require/src/index.ts
@@ -1,5 +1,5 @@
-import { t } from '@umijs/utils';
-import * as traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import type { Visitor, NodePath } from '@babel/traverse';
 
 type TLibs = (RegExp | string)[];
 
@@ -62,7 +62,7 @@ export default function () {
   return {
     visitor: {
       Program: {
-        exit(path: traverse.NodePath<t.Program>, { opts }: { opts: IOpts }) {
+        exit(path: NodePath<t.Program>, { opts }: { opts: IOpts }) {
           const variableDeclarations = [];
           let index = path.node.body.length - 1;
           while (index >= 0) {
@@ -169,6 +169,6 @@ export default function () {
           path.node.body = [...variableDeclarations, ...path.node.body];
         },
       },
-    } as traverse.Visitor,
+    } as Visitor,
   };
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

Move `@umijs/babel-plugin-auto-css-modules`'s dependencies to devDependencies because only types are [used](https://npmfs.com/package/@umijs/babel-plugin-auto-css-modules/3.2.28/lib/index.js), but will produces [![install size](https://packagephobia.com/badge?p=@umijs/babel-plugin-auto-css-modules)](https://packagephobia.com/result?p=@umijs/babel-plugin-auto-css-modules) in published package.

---

Updated: did the same thing to `babel-plugin-import-to-await-require`
