### PR TITLE
docs: 修改一处(config)描述歧义，修改一处(faq)描述错误

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -16,7 +16,26 @@ export default {
 ## Configuration
 
 If your configurations are not complicated, we recommend configuring your app with `.umirc.ts`;
-If your configurations are complicated, it is possible to split your configurations into pieces and organize them in `config/config.ts`. For example, if you need to configure routers, it would be a good choice to have it in an individual module called `config/routes.ts` alongside `config/config.ts`.
+If your configurations are complicated, it is possible to split your configurations into pieces and organize them in `config/config.ts`. For example, if you need to configure routers, it would be a good choice to have it in an individual module called `routes.ts`.
+
+```typescript
+// config/routes.ts
+
+export default [
+    { exact: true, path: '/', component: 'index' },
+];
+```
+```typescript
+// config/config.ts
+
+import { defineConfig } from 'umi';
+import routes from './routes';
+
+export default defineConfig({
+  routes: routes,
+});
+
+```
 
 You have to choose between `.umirc.ts` and `config/config.ts`, `.umirc.ts` has higher priority.
 

--- a/docs/docs/config.zh-CN.md
+++ b/docs/docs/config.zh-CN.md
@@ -16,9 +16,27 @@ export default {
 ## 配置文件
 
 如果项目的配置不复杂，推荐在 `.umirc.ts` 中写配置；
-如果项目的配置比较复杂，可以将配置写在 `config/config.ts` 中，并把配置的一部分拆出去，比如路由配置可以拆成单独的 `config/routes.ts`。
+如果项目的配置比较复杂，可以将配置写在 `config/config.ts` 中，并把配置的一部分拆分出去，比如路由配置可以拆分成单独的 `routes.ts`：
+```typescript
+// config/routes.ts
 
-两种方式二选一，`.umirc.ts` 优先级更高。
+export default [
+    { exact: true, path: '/', component: 'index' },
+}
+```
+```typescript
+// config/config.ts
+
+import { defineConfig } from 'umi';
+import routes from './routes';
+
+export default defineConfig({
+  routes: routes,
+});
+
+```
+
+推荐两种配置方式二选一，`.umirc.ts` 优先级更高。
 
 ## TypeScript 提示
 

--- a/docs/docs/config.zh-CN.md
+++ b/docs/docs/config.zh-CN.md
@@ -22,7 +22,7 @@ export default {
 
 export default [
     { exact: true, path: '/', component: 'index' },
-}
+];
 ```
 ```typescript
 // config/config.ts

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -352,14 +352,20 @@ File sizes after gzip:
 
 ### 如何禁用掉每次刷新路由时出现的 loading... 状态？
 
-给 dynamicImport 配置加上 `loading: '() => <></>'`，比如：
+给 dynamicImport 引入一个空组件比如 `Loading.tsx` ，内容如下：
+```typescript
+// components/Loading.tsx
 
+import React from 'react';
+
+export default () => <></>;
 ```
+```typescript
 export default {
   dynamicImport: {
-    loading: '() => <></>'
+    loading: '@/components/Loading',
   },
-}
+};
 ```
 
 ## Test

--- a/docs/docs/faq.zh-CN.md
+++ b/docs/docs/faq.zh-CN.md
@@ -350,18 +350,18 @@ File sizes after gzip:
 
 给 dynamicImport 引入一个空组件比如 `Loading.tsx` ，内容如下：
 ```typescript
-//components/Loading.tsx
+// components/Loading.tsx
 
 import React from 'react';
 
 export default () => <></>;
 ```
-```
+```typescript
 export default {
   dynamicImport: {
-    loading: '@/components/Loading'
+    loading: '@/components/Loading',
   },
-}
+};
 ```
 
 ## Test

--- a/docs/docs/faq.zh-CN.md
+++ b/docs/docs/faq.zh-CN.md
@@ -348,12 +348,18 @@ File sizes after gzip:
 
 ### 如何禁用掉每次刷新路由时出现的 loading... 状态？
 
-给 dynamicImport 配置加上 `loading: '() => <></>'`，比如：
+给 dynamicImport 引入一个空组件比如 `Loading.tsx` ，内容如下：
+```typescript
+//components/Loading.tsx
 
+import React from 'react';
+
+export default () => <></>;
+```
 ```
 export default {
   dynamicImport: {
-    loading: '() => <></>'
+    loading: '@/components/Loading'
   },
 }
 ```


### PR DESCRIPTION
1. config：配置的描述歧义，会引发了一些错误的使用方式（例如认为routes可自动化配置，在route未被引用生效时，约定式路由会起作用，让人误以为拆分的routes是有效果的）
2. faq：关于取消全局loading的描述是错误的

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL


-----
[View rendered docs/docs/config.zh-CN.md](https://github.com/Jfreey/umi/blob/master/docs/docs/config.zh-CN.md)
[View rendered docs/docs/faq.zh-CN.md](https://github.com/Jfreey/umi/blob/master/docs/docs/faq.zh-CN.md)