### PR TITLE
chore: update the init template when the app is created

### DIFF
--- a/packages/create-umi-app/templates/AppGenerator/package.json.tpl
+++ b/packages/create-umi-app/templates/AppGenerator/package.json.tpl
@@ -20,14 +20,16 @@
     ]
   },
   "dependencies": {
-    "@ant-design/pro-layout": "^5.0.12",
+    "@ant-design/pro-layout": "^6.5.0",
     "@umijs/preset-react": "1.x",
     "@umijs/test": "^{{{ version }}}",
-    "lint-staged": "^10.0.7",
-    "prettier": "^1.19.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "umi": "^{{{ version }}}",
     "yorkie": "^2.0.0"
+  },
+  "devDependencies": {
+    "lint-staged": "^10.0.7",
+    "prettier": "^1.19.1",
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL


<br>
<br>

#### Background
- 当前初始化的项目中 @ant-design/pro-layout  版本是 5.x，而近期 @ant-design/pro-layout [迎来了一大波 fix](https://procomponents.ant.design/changelog/pro-layout)，希望 create umi app 时初始化模板中的依赖版本能够更新
- `lint-staged ` 和 `prettier`  和业务无关，但是被放到了 dependencies 中


<br>
<br>

#### Steps to reproduce
``` shell
$ mkdir myapp && cd myapp
$ yarn create @umijs/umi-app
```

<br>
<br>

#### My Solution to the Problem

##### 1. 更新 @ant-design/pro-layout 版本

``` js
@ant-design/pro-layout@^5.0.12  =>  @ant-design/pro-layout@^6.5.0
```


##### 2.将 `lint-staged` 和 `prettier` 移动到 devDependencies 中 
``` shell
"devDependencies": {
  "lint-staged": "^10.0.7",
  "prettier": "^1.19.1",
}
```

<br>


<br>
<br>


@ycjcl868   @sorrycc 
有空帮忙 review 一下吗

<br>
<br>
