### PR TITLE
fix(renderer-react): wrapInitialPropsFetch

### DIFF
--- a/packages/renderer-react/src/renderRoutes/renderRoutes.tsx
+++ b/packages/renderer-react/src/renderRoutes/renderRoutes.tsx
@@ -65,7 +65,7 @@ function wrapInitialPropsFetch(route: IRoute, opts: IOpts): IComponent {
         }
       };
       // null 时，一定会触发 getInitialProps 执行
-      if ((window as any).g_initialProps === null) {
+      if (!(window as any).g_initialProps) {
         handleGetInitialProps();
       }
     }, [window.location.pathname, window.location.search]);


### PR DESCRIPTION
csr时, g_initialProps 为 undefined


##### Checklist

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Description of change

修复 csr时, 不自动调用 handleGetInitialProps