### PR TITLE
fix(ssr): replace default html should be more accurate 

### DIFF
--- a/packages/preset-built-in/src/plugins/features/ssr/fixtures/thirdlib/.umirc.ts
+++ b/packages/preset-built-in/src/plugins/features/ssr/fixtures/thirdlib/.umirc.ts
@@ -1,0 +1,3 @@
+export default {
+  outputPath: './customDist',
+}

--- a/packages/preset-built-in/src/plugins/features/ssr/fixtures/thirdlib/customDist/umi.server.js
+++ b/packages/preset-built-in/src/plugins/features/ssr/fixtures/thirdlib/customDist/umi.server.js
@@ -1,0 +1,17 @@
+let manifest = params.manifest;
+const env = 'production';
+let thirdlib = {
+    key: 'getIframeHTML',
+    value: function getIframeHTML(domain) {
+      var domainScript = '';
+      var domainInput = '';
+      if (domain) {
+        var script = 'script';
+        domainScript = '<' + script + '>document.domain="' + domain + '";</' + script + '>';
+        domainInput = '<input name="_documentDomain" value="' + domain + '" />';
+      }
+      return '\n    <!DOCTYPE html>\n    <html>\n    <head>\n    <meta http-equiv="X-UA-Compatible" content="IE=edge" />\n    <style>\n    body,html {padding:0;margin:0;border:0;overflow:hidden;}\n    </style>\n    ' + domainScript + '\n    </head>\n    <body>\n  thirdlib </body>\n    </html>\n    ';
+    }
+}
+let html = htmlTemplate || "<!DOCTYPE html>\n<html>\n  <head>\n    <meta charset=\"utf-8\" />\n    <meta\n      name=\"viewport\"\n      content=\"width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no\"\n    />\n    <link rel=\"stylesheet\" href=\"/umi.css\" />\n    <script>\n      window.routerBase = \"/\";\n    </script>\n    <script>\n      //! umi version: undefined\n    </script>\n  </head>\n  <body>\n    <div id=\"root\"></div>\n\n    <script src=\"/umi.js\"></script>\n  </body>\n</html>\n";
+let rootContainer = '';

--- a/packages/preset-built-in/src/plugins/features/ssr/ssr.test.ts
+++ b/packages/preset-built-in/src/plugins/features/ssr/ssr.test.ts
@@ -40,3 +40,43 @@ test('onBuildComplete normal', async () => {
   expect(serverContent).toContain('/umi.6f4c357e.css');
   expect(serverContent).toContain('/umi.e1837763.js');
 });
+
+test('onBuildComplete thirdlib', async () => {
+  const cwd = join(fixtures, 'thirdlib');
+
+  const service = new Service({
+    cwd,
+    presets: [require.resolve('../../../index')],
+  });
+  await service.init();
+  const api = service.getPluginAPI({
+    service,
+    id: 'test',
+    key: 'test',
+  });
+  const stats = {
+    stats: [
+      {
+        compilation: {
+          chunks: [
+            {
+              name: 'umi',
+              files: ['umi.6f4c357e.css', 'umi.e1837763.js'],
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  const buildComplete = onBuildComplete(api, true);
+  const serverContent = await buildComplete({
+    err: null,
+    stats,
+  });
+
+  expect(serverContent).toContain('thirdlib'); //三方库没被替换掉
+  expect(serverContent).not.toContain('/umi.js');
+  expect(serverContent).toContain('/umi.6f4c357e.css');
+  expect(serverContent).toContain('/umi.e1837763.js');
+});

--- a/packages/preset-built-in/src/plugins/features/ssr/ssr.ts
+++ b/packages/preset-built-in/src/plugins/features/ssr/ssr.ts
@@ -25,7 +25,7 @@ export const onBuildComplete = (api: IApi, _isTest = false) => async ({
   stats,
 }: any) => {
   if (!err && stats?.stats) {
-    const HTML_REG = /<html.*?<\/html>/m;
+    const HTML_REG = /<html.*?<\/html>/mg;
     const [clientStats] = stats.stats;
     const html = getHtmlGenerator({ api });
     const [defaultHTML] =
@@ -42,7 +42,7 @@ export const onBuildComplete = (api: IApi, _isTest = false) => async ({
     if (fs.existsSync(serverPath) && defaultHTML) {
       const serverContent = fs
         .readFileSync(serverPath, 'utf-8')
-        .replace(HTML_REG, defaultHTML);
+        .replace(HTML_REG, (match) => match.includes(`umi version: ${process.env.UMI_VERSION}`) ? defaultHTML : match);
       // for test case
       if (_isTest) {
         return serverContent;

--- a/packages/preset-built-in/src/plugins/features/ssr/ssr.ts
+++ b/packages/preset-built-in/src/plugins/features/ssr/ssr.ts
@@ -25,7 +25,7 @@ export const onBuildComplete = (api: IApi, _isTest = false) => async ({
   stats,
 }: any) => {
   if (!err && stats?.stats) {
-    const HTML_REG = /<html.*?<\/html>/mg;
+    const HTML_REG = /<html.*?<\/html>/gm;
     const [clientStats] = stats.stats;
     const html = getHtmlGenerator({ api });
     const [defaultHTML] =
@@ -42,7 +42,9 @@ export const onBuildComplete = (api: IApi, _isTest = false) => async ({
     if (fs.existsSync(serverPath) && defaultHTML) {
       const serverContent = fs
         .readFileSync(serverPath, 'utf-8')
-        .replace(HTML_REG, (match) => match.includes(`umi version: ${process.env.UMI_VERSION}`) ? defaultHTML : match);
+        .replace(HTML_REG, (match) =>
+          match.includes(`umi version:`) ? defaultHTML : match,
+        );
       // for test case
       if (_isTest) {
         return serverContent;


### PR DESCRIPTION

##### Checklist

- [x] `npm test` passes
- [x] tests are included
- [x] commit message follows commit guidelines

##### Description of change

bundle may have multiple html template, eg: https://github.com/react-component/upload/blob/2.x/src/IframeUploader.jsx#L139

So, It will replace worng html in server.js when import libs like about
