### PR TITLE
fix(ssr): getInitialProps should has `history` in csr

### DIFF
--- a/packages/renderer-react/src/renderRoutes/renderRoutes.tsx
+++ b/packages/renderer-react/src/renderRoutes/renderRoutes.tsx
@@ -46,6 +46,7 @@ function wrapInitialPropsFetch(route: IRoute, opts: IOpts): IComponent {
         const defaultCtx = {
           isServer: false,
           match: props?.match,
+          history: props?.history,
           route,
           ...(opts.getInitialPropsCtx || {}),
           ...restRouteParams,


### PR DESCRIPTION


##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Description of change

according to [doc](https://umijs.org/zh-CN/docs/ssr#%E9%A1%B5%E9%9D%A2%E7%BA%A7%E6%95%B0%E6%8D%AE%E8%8E%B7%E5%8F%96)

> getInitialProps 中有几个固定参数：
> history：history 对象
