### PR TITLE
fix: cssModulesTypescriptLoader.mode should be optional

### DIFF
--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -293,7 +293,7 @@ export interface BaseIConfig extends IConfigCore {
   };
   chunks?: string[];
   cssLoader?: object;
-  cssModulesTypescriptLoader?: { mode: 'verify' | 'emit' };
+  cssModulesTypescriptLoader?: { mode?: 'verify' | 'emit' };
   cssnano?: object;
   copy?: (string | ICopy)[];
   define?: {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- fix: cssModulesTypescriptLoader.mode should be optional
- close #5678

-----
[View rendered docs/docs/cli.md](https://github.com/yingzhiji/umi/blob/fix/css-modules-typescript-loader-typing/docs/config/README.md#cssmodulestypescriptloader-31)
[View rendered docs/docs/cli.zh-CN.md](https://github.com/yingzhiji/umi/blob/fix/css-modules-typescript-loader-typing/docs/config/README.zh-CN.md#cssmodulestypescriptloader-31)