### PR TITLE
fix(ssr): csr 和 dynamicImport 一起使用导致组件 2 次 mount

### DIFF
--- a/packages/renderer-react/src/renderRoutes/renderRoutes.tsx
+++ b/packages/renderer-react/src/renderRoutes/renderRoutes.tsx
@@ -38,10 +38,11 @@ function wrapInitialPropsFetch(route: IRoute, opts: IOpts): IComponent {
        */
       const handleGetInitialProps = async () => {
         // preload when enalbe dynamicImport
+        let preloadComponent:any;
         if (Component.preload) {
-          const preloadComponent = await Component.preload();
+          preloadComponent = await Component.preload();
           // for test case, really use .default
-          Component = preloadComponent.default || preloadComponent;
+          preloadComponent = preloadComponent.default || preloadComponent;
         }
         const defaultCtx = {
           isServer: false,
@@ -51,7 +52,7 @@ function wrapInitialPropsFetch(route: IRoute, opts: IOpts): IComponent {
           ...(opts.getInitialPropsCtx || {}),
           ...restRouteParams,
         };
-        if (Component?.getInitialProps) {
+        if (preloadComponent?.getInitialProps) {
           const ctx = await opts.plugin.applyPlugins({
             key: 'ssr.modifyGetInitialPropsCtx',
             type: ApplyPluginsType.modify,
@@ -59,7 +60,7 @@ function wrapInitialPropsFetch(route: IRoute, opts: IOpts): IComponent {
             async: true,
           });
 
-          const initialProps = await Component!.getInitialProps!(
+          const initialProps = await preloadComponent!.getInitialProps!(
             ctx || defaultCtx,
           );
           setInitialProps(initialProps);

--- a/packages/renderer-react/src/renderRoutes/renderRoutes.tsx
+++ b/packages/renderer-react/src/renderRoutes/renderRoutes.tsx
@@ -38,7 +38,7 @@ function wrapInitialPropsFetch(route: IRoute, opts: IOpts): IComponent {
        */
       const handleGetInitialProps = async () => {
         // preload when enalbe dynamicImport
-        let preloadComponent:any;
+        let preloadComponent: any = Component;
         if (Component.preload) {
           preloadComponent = await Component.preload();
           // for test case, really use .default


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

Close https://github.com/umijs/umi/issues/5881

##### Description of change

改变 Component 会导致一次强制重渲染. 而这样, 会让组件中的 didMount 被调用两次.

事实上, 只需要将新的 initialProps 传给 LoadableComponent, LoadableComponent 会将这个 props 传递下去.

这样, 第二次渲染就不是强制渲染了.