### PR TITLE
feat: support config.srcPath

### DIFF
--- a/packages/core/src/Service/getPaths.test.ts
+++ b/packages/core/src/Service/getPaths.test.ts
@@ -142,3 +142,26 @@ test('src config singular', () => {
     cwd: '',
   });
 });
+
+test('src config srcPath', () => {
+  const cwd = join(fixtures, 'getPaths-with-h5');
+  expect(
+    stripCwd(
+      getPaths({
+        cwd,
+        config: {
+          srcPath: 'h5'
+        },
+        env: 'development',
+      }),
+      cwd,
+    ),
+  ).toEqual({
+    absNodeModulesPath: 'node_modules',
+    absOutputPath: 'dist',
+    absPagesPath: 'h5/pages',
+    absSrcPath: 'h5',
+    absTmpPath: 'h5/.umi',
+    cwd: '',
+  });
+});

--- a/packages/core/src/Service/getPaths.ts
+++ b/packages/core/src/Service/getPaths.ts
@@ -21,8 +21,8 @@ export default function getServicePaths({
   env?: string;
 }): IServicePaths {
   let absSrcPath = cwd;
-  if (isDirectoryAndExist(join(cwd, 'src'))) {
-    absSrcPath = join(cwd, 'src');
+  if (isDirectoryAndExist(join(cwd, config.srcPath || 'src'))) {
+    absSrcPath = join(cwd, config.srcPath || 'src');
   }
   const absPagesPath = config.singular
     ? join(absSrcPath, 'page')

--- a/packages/preset-built-in/src/index.ts
+++ b/packages/preset-built-in/src/index.ts
@@ -67,6 +67,7 @@ export default function () {
       require.resolve('./plugins/features/umiInfo'),
       require.resolve('./plugins/features/runtimeHistory'),
       require.resolve('./plugins/features/webpack5'),
+      require.resolve('./plugins/features/srcPath'),
 
       // html
       require.resolve('./plugins/features/html/favicon'),

--- a/packages/preset-built-in/src/plugins/features/srcPath.ts
+++ b/packages/preset-built-in/src/plugins/features/srcPath.ts
@@ -1,0 +1,12 @@
+import { IApi } from '@umijs/types';
+
+export default (api: IApi) => {
+  api.describe({
+    key: 'srcPath',
+    config: {
+      schema(joi) {
+        return joi.string();
+      },
+    },
+  });
+};


### PR DESCRIPTION
支持指定 umi 源码的 src 目录(需为相对路径)。方便多端开发项目能更合理的指向到 h5 工程。
类似小程序提供的：miniprogramRoot

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
