### PR TITLE
fix: should use @umijs/deps webpack version

### DIFF
--- a/packages/bundler-webpack/src/webpack/plugins/terser-webpack-plugin/src/index.js
+++ b/packages/bundler-webpack/src/webpack/plugins/terser-webpack-plugin/src/index.js
@@ -8,7 +8,7 @@ import webpack, {
   SourceMapDevToolPlugin,
   javascript,
   version as webpackVersion,
-} from 'webpack';
+} from '@umijs/deps/compiled/webpack';
 import RequestShortener from 'webpack/lib/RequestShortener';
 
 import serialize from '@umijs/deps/compiled/serialize-javascript';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
   no, just @umijs/bundler-webpack should always use internal version in @umijs/deps (same as [these code](https://github.com/umijs/umi/blob/v3.4.0/packages/bundler-webpack/src/getConfig/getConfig.ts#L7)), otherwise, umi user will encounter webpack importation error `Cannot find module 'webpack' from 'index.js'`
- close https://github.com/umijs/umi/ISSUE_URL
