### PR TITLE
feat: add 404 plugin

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -10,6 +10,13 @@ toc: menu
 
 以下配置项通过字母排序。
 
+## 404
+
+- Type: `boolean`
+- Default: `true`
+
+约定式路由中 404 页面的生效规则，可通过设置为 false 关闭。
+
 ## alias
 
 - Type: `object`

--- a/docs/config/README.zh-CN.md
+++ b/docs/config/README.zh-CN.md
@@ -9,6 +9,13 @@ toc: menu
 
 以下配置项通过字母排序。
 
+## 404
+
+- Type: `boolean`
+- Default: `true`
+
+约定式路由中 404 页面的生效规则，可通过设置为 false 关闭。
+
 ## alias
 
 - Type: `object`

--- a/packages/preset-built-in/src/index.ts
+++ b/packages/preset-built-in/src/index.ts
@@ -17,6 +17,7 @@ export default function () {
       require.resolve('./plugins/generateFiles/umi'),
 
       // bundle configs
+      require.resolve('./plugins/features/404'),
       require.resolve('./plugins/features/alias'),
       require.resolve('./plugins/features/analyze'),
       require.resolve('./plugins/features/autoprefixer'),
@@ -68,7 +69,6 @@ export default function () {
       require.resolve('./plugins/features/runtimeHistory'),
       require.resolve('./plugins/features/webpack5'),
       require.resolve('./plugins/features/workerLoader'),
-      require.resolve('./plugins/features/404'),
 
       // html
       require.resolve('./plugins/features/html/favicon'),

--- a/packages/preset-built-in/src/index.ts
+++ b/packages/preset-built-in/src/index.ts
@@ -68,6 +68,7 @@ export default function () {
       require.resolve('./plugins/features/runtimeHistory'),
       require.resolve('./plugins/features/webpack5'),
       require.resolve('./plugins/features/workerLoader'),
+      require.resolve('./plugins/features/404'),
 
       // html
       require.resolve('./plugins/features/html/favicon'),

--- a/packages/preset-built-in/src/plugins/features/404.test.ts
+++ b/packages/preset-built-in/src/plugins/features/404.test.ts
@@ -1,0 +1,20 @@
+import { patchRoutes } from './404';
+
+test('404 js', async () => {
+  const routes = [
+    {
+      path: '/404',
+      exact: true,
+      component: '404 Pages',
+    },
+    {
+      path: '/',
+      exact: true,
+      component: 'Index Pages',
+    },
+  ];
+  patchRoutes(routes, { exportStatic: false });
+  expect(JSON.stringify(routes)).toEqual(
+    `[{"path":"/404","exact":true,"component":"404 Pages"},{"path":"/","exact":true,"component":"Index Pages"},{"component":"404 Pages"}]`,
+  );
+});

--- a/packages/preset-built-in/src/plugins/features/404.test.ts
+++ b/packages/preset-built-in/src/plugins/features/404.test.ts
@@ -97,3 +97,10 @@ test('404 with redirect', () => {
     { redirect: '/foo' },
   ]);
 });
+
+test('404 not found', () => {
+  const routes = [{ path: '/404' }, { path: '/b' }];
+  expect(() => {
+    patchRoutes(routes, { exportStatic: false });
+  }).toThrow(/Invalid route config for \/404/);
+});

--- a/packages/preset-built-in/src/plugins/features/404.test.ts
+++ b/packages/preset-built-in/src/plugins/features/404.test.ts
@@ -14,7 +14,86 @@ test('404 js', async () => {
     },
   ];
   patchRoutes(routes, { exportStatic: false });
-  expect(JSON.stringify(routes)).toEqual(
-    `[{"path":"/404","exact":true,"component":"404 Pages"},{"path":"/","exact":true,"component":"Index Pages"},{"component":"404 Pages"}]`,
-  );
+  expect(routes).toEqual([
+    {
+      path: '/404',
+      exact: true,
+      component: '404 Pages',
+    },
+    {
+      path: '/',
+      exact: true,
+      component: 'Index Pages',
+    },
+    { component: '404 Pages' },
+  ]);
+});
+
+test('exportStatic', async () => {
+  const routes = [
+    {
+      path: '/404',
+      exact: true,
+      component: '404 Pages',
+    },
+    {
+      path: '/',
+      exact: true,
+      component: 'Index Pages',
+    },
+  ];
+  patchRoutes(routes, { exportStatic: {} });
+  expect(routes).toEqual([
+    {
+      path: '/404',
+      exact: true,
+      component: '404 Pages',
+    },
+    {
+      path: '/',
+      exact: true,
+      component: 'Index Pages',
+    },
+  ]);
+});
+
+test('404 in child routes', () => {
+  const routes = [
+    {
+      path: '/b',
+      routes: [
+        {
+          path: '/404',
+          component: './A',
+        },
+        {
+          path: '/c',
+        },
+      ],
+    },
+  ];
+  patchRoutes(routes, { exportStatic: false });
+
+  expect(routes).toEqual([
+    {
+      path: '/b',
+      routes: [
+        { path: '/404', component: './A' },
+        { path: '/c' },
+        { component: './A' },
+      ],
+    },
+  ]);
+});
+
+test('404 with redirect', () => {
+  const routes = [{ path: '/404', redirect: '/foo' }, { path: '/b' }];
+
+  patchRoutes(routes, { exportStatic: false });
+
+  expect(routes).toEqual([
+    { path: '/404', redirect: '/foo' },
+    { path: '/b' },
+    { redirect: '/foo' },
+  ]);
 });

--- a/packages/preset-built-in/src/plugins/features/404.ts
+++ b/packages/preset-built-in/src/plugins/features/404.ts
@@ -23,6 +23,15 @@ export function patchRoutes(routes: IRoute[], config: IConfig) {
 }
 
 export default (api: IApi) => {
+  api.describe({
+    key: '404',
+    config: {
+      schema(joi) {
+        return joi.boolean();
+      },
+    },
+  });
+  if (api.userConfig['404']) return;
   api.modifyRoutes((routes: IRoute[]) => {
     return patchRoutes(routes, api.config);
   });

--- a/packages/preset-built-in/src/plugins/features/404.ts
+++ b/packages/preset-built-in/src/plugins/features/404.ts
@@ -31,7 +31,7 @@ export default (api: IApi) => {
       },
     },
   });
-  if (api.userConfig['404']) return;
+  if (api.userConfig['404'] === false) return;
   api.modifyRoutes((routes: IRoute[]) => {
     return patchRoutes(routes, api.config);
   });

--- a/packages/preset-built-in/src/plugins/features/404.ts
+++ b/packages/preset-built-in/src/plugins/features/404.ts
@@ -1,4 +1,4 @@
-import { IApi, IRoute, IConfig } from 'umi';
+import { IApi, IRoute, IConfig } from '@umijs/types';
 
 export function patchRoutes(routes: IRoute[], config: IConfig) {
   let notFoundIndex = null;

--- a/packages/preset-built-in/src/plugins/features/404.ts
+++ b/packages/preset-built-in/src/plugins/features/404.ts
@@ -1,0 +1,29 @@
+import { IApi, IRoute, IConfig } from 'umi';
+
+export function patchRoutes(routes: IRoute[], config: IConfig) {
+  let notFoundIndex = null;
+  routes.forEach((route, index) => {
+    if (route.path === '/404') {
+      notFoundIndex = index;
+    }
+    if (route.routes) {
+      patchRoutes(route.routes, config);
+    }
+  });
+  if (notFoundIndex !== null && !config.exportStatic) {
+    const notFoundRoute = routes.slice(notFoundIndex, notFoundIndex + 1)[0];
+    if (notFoundRoute.component) {
+      routes.push({ component: notFoundRoute.component });
+    } else if (notFoundRoute.redirect) {
+      routes.push({ redirect: notFoundRoute.redirect });
+    } else {
+      throw new Error('Invalid route config for /404');
+    }
+  }
+}
+
+export default (api: IApi) => {
+  api.modifyRoutes((routes: IRoute[]) => {
+    return patchRoutes(routes, api.config);
+  });
+};

--- a/packages/preset-built-in/src/plugins/features/404.ts
+++ b/packages/preset-built-in/src/plugins/features/404.ts
@@ -31,7 +31,6 @@ export default (api: IApi) => {
       },
     },
   });
-  if (api.userConfig['404'] === false) return;
   api.modifyRoutes((routes: IRoute[]) => {
     return patchRoutes(routes, api.config);
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change
增加约定式的 404 逻辑，文档里都有，这个功能应该是漏了。
没有实现 “umi dev 404 page” ，重复答疑次数太多了。（ dev 的时候，自定义的 404 页面无效，需要 build 之后才会生效。）
<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/issues/5092
