### PR TITLE
feat(import-to-await): support to process export * with user config

### DIFF
--- a/packages/babel-plugin-import-to-await-require/src/index.test.ts
+++ b/packages/babel-plugin-import-to-await-require/src/index.test.ts
@@ -178,7 +178,7 @@ test('export *', () => {
     transformWithPlugin(`export * from 'antd'; foo;`, {
       libs: ['antd'],
       remoteName: 'foo',
-      libAllExports: { antd: ['a', 'b', 'c'] },
+      exportAllMembers: { antd: ['a', 'b', 'c'] },
     }),
   ).toEqual(
     `

--- a/packages/babel-plugin-import-to-await-require/src/index.test.ts
+++ b/packages/babel-plugin-import-to-await-require/src/index.test.ts
@@ -172,3 +172,24 @@ foo;
     `.trim(),
   );
 });
+
+test('export *', () => {
+  expect(
+    transformWithPlugin(`export * from 'antd'; foo;`, {
+      libs: ['antd'],
+      remoteName: 'foo',
+      libAllExports: { antd: ['a', 'b', 'c'] },
+    }),
+  ).toEqual(
+    `
+const __all_exports = await import("foo/antd");
+
+export const {
+  a: a,
+  b: b,
+  c: c
+} = __all_exports;
+foo;
+    `.trim(),
+  );
+});

--- a/packages/babel-plugin-import-to-await-require/src/index.ts
+++ b/packages/babel-plugin-import-to-await-require/src/index.ts
@@ -12,7 +12,7 @@ export interface IOpts {
   remoteName: string;
   alias?: IAlias;
   onTransformDeps?: Function;
-  libAllExports?: Record<string, string[]>;
+  exportAllMembers?: Record<string, string[]>;
 }
 
 export function specifiersToProperties(specifiers: any[]) {
@@ -135,7 +135,7 @@ export default function () {
                 isExportAllDeclaration: true,
               });
 
-              if (isMatch && opts.libAllExports?.[d.source.value]) {
+              if (isMatch && opts.exportAllMembers?.[d.source.value]) {
                 const id = t.identifier('__all_exports');
                 const init = t.awaitExpression(
                   t.callExpression(t.import(), [
@@ -154,12 +154,12 @@ export default function () {
                 );
 
                 // replace node with export const { a, b, c } = __all_exports
-                // a, b, c was declared from opts.libAllExports
+                // a, b, c was declared from opts.exportAllMembers
                 path.node.body[index] = t.exportNamedDeclaration(
                   t.variableDeclaration('const', [
                     t.variableDeclarator(
                       t.objectPattern(
-                        opts.libAllExports[d.source.value].map((m) =>
+                        opts.exportAllMembers[d.source.value].map((m) =>
                           t.objectProperty(t.identifier(m), t.identifier(m)),
                         ),
                       ),


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] tests are included
- [x] commit message follows commit guidelines

##### Description of change

`babel-plugin-import-to-await-require` 支持传递 `exportAllMembers`配置项，用于将 `export * from 'x'` 转换为 静态的 member exports，使得 mfsu 能对 `export *` 语法生效，但词法是手动挡，未来找到更合适的方案再换成自动挡