### PR TITLE
feat(import-to-await): support to process export * with user config (3.3.x)

### DIFF
--- a/packages/babel-plugin-import-to-await-require/src/index.test.ts
+++ b/packages/babel-plugin-import-to-await-require/src/index.test.ts
@@ -172,3 +172,24 @@ foo;
     `.trim(),
   );
 });
+
+test('export *', () => {
+  expect(
+    transformWithPlugin(`export * from 'antd'; foo;`, {
+      libs: ['antd'],
+      remoteName: 'foo',
+      exportAllMembers: { antd: ['a', 'b', 'c'] },
+    }),
+  ).toEqual(
+    `
+const __all_exports = await import("foo/antd");
+
+export const {
+  a: a,
+  b: b,
+  c: c
+} = __all_exports;
+foo;
+    `.trim(),
+  );
+});

--- a/packages/babel-plugin-import-to-await-require/src/index.ts
+++ b/packages/babel-plugin-import-to-await-require/src/index.ts
@@ -12,6 +12,7 @@ export interface IOpts {
   remoteName: string;
   alias?: IAlias;
   onTransformDeps?: Function;
+  exportAllMembers?: Record<string, string[]>;
 }
 
 export function specifiersToProperties(specifiers: any[]) {
@@ -120,13 +121,53 @@ export default function () {
               }
             }
 
+            // export * from 'foo';
             if (t.isExportAllDeclaration(d) && d.source) {
+              const isMatch = isMatchLib(
+                d.source.value,
+                opts.libs,
+                opts.alias || {},
+              );
               opts.onTransformDeps?.({
                 source: d.source.value,
                 file: path.hub.file.opts.filename,
                 isMatch: false,
                 isExportAllDeclaration: true,
               });
+
+              if (isMatch && opts.exportAllMembers?.[d.source.value]) {
+                const id = t.identifier('__all_exports');
+                const init = t.awaitExpression(
+                  t.callExpression(t.import(), [
+                    t.stringLiteral(
+                      `${opts.remoteName}/${getPath(
+                        d.source.value,
+                        opts.alias || {},
+                      )}`,
+                    ),
+                  ]),
+                );
+                variableDeclarations.unshift(
+                  t.variableDeclaration('const', [
+                    t.variableDeclarator(id, init),
+                  ]),
+                );
+
+                // replace node with export const { a, b, c } = __all_exports
+                // a, b, c was declared from opts.exportAllMembers
+                path.node.body[index] = t.exportNamedDeclaration(
+                  t.variableDeclaration('const', [
+                    t.variableDeclarator(
+                      t.objectPattern(
+                        opts.exportAllMembers[d.source.value].map((m) =>
+                          t.objectProperty(t.identifier(m), t.identifier(m)),
+                        ),
+                      ),
+                      t.identifier('__all_exports'),
+                    ),
+                  ]),
+                );
+              }
             }
 
             // export { bar } from 'foo';


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] tests are included
- [x] commit message follows commit guidelines

##### Description of change

`babel-plugin-import-to-await-require` 支持传递 `exportAllMembers`配置项，用于将 `export * from 'x'` 转换为 静态的 member exports，使得 mfsu 能对 `export *` 语法生效，但词法是手动挡，未来找到更合适的方案再换成自动挡

和 https://github.com/umijs/umi/pull/6260 一致，用于 3.3.x