### PR TITLE
fix: should always use webpack which is from @umijs/deps

### DIFF
--- a/packages/bundler-webpack/src/webpack/plugins/terser-webpack-plugin/src/index.js
+++ b/packages/bundler-webpack/src/webpack/plugins/terser-webpack-plugin/src/index.js
@@ -8,7 +8,7 @@ import webpack, {
   SourceMapDevToolPlugin,
   javascript,
   version as webpackVersion,
-} from 'webpack';
+} from '@umijs/deps/compiled/webpack';
 import RequestShortener from 'webpack/lib/RequestShortener';
 
 import serialize from '@umijs/deps/compiled/serialize-javascript';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes

##### Description of change

<!-- Provide a description of the change below this comment. -->

#6237 的问题没有得到解决。。。

周末抽空排查了下根本原因。造成报错的根本原因是，虽然在导入 @umijs/bundler-webpack 时会调用 [requireHook](https://github.com/umijs/umi/blob/v3.4.2/packages/bundler-webpack/src/index.ts#L15)，但在测试环境中并不会走 [这些对 module._resolveFilename](https://github.com/umijs/umi/blob/v3.4.2/packages/bundler-webpack/src/requireHook.ts#L44-L53) 的处理（即在测试环境下，并不会调用 nodejs runtime 的 require 及其 [内部的 Module._resolveFilename](https://github.com/nodejs/node/blob/v15.11.0/lib/internal/modules/cjs/loader.js#L769)），在测试环境中会存在额外的一套 require mock 机制，以 jest 测试框架来说（@umijs/dumi 的测试框架）:

> 以下所有堆栈信息均取自于 dumi 中的 test case

当我们在 [@umijs/bundler-webpack 此处](https://github.com/umijs/umi/blob/v3.4.2/packages/bundler-webpack/src/webpack/plugins/terser-webpack-plugin/src/index.js#L11) 导入 `webpack` 时，真实的 require 并不是 nodejs 中原生的 require 函数，而是：

![image](https://user-images.githubusercontent.com/32980314/111059119-f942d180-84cd-11eb-946b-ec3ebb8d21d1.png)

以 `webpack` 为例，这个包在 jest 中的导入堆栈如下:

![image](https://user-images.githubusercontent.com/32980314/111059183-6f473880-84ce-11eb-8de8-53b8ed82fe16.png)

明显可见 jest 中的模块导入底层依赖于 resolve 这个 npm package，其核心函数 loadNodeModulesSync 的逻辑在于：

1. 根据导入语句所在的 dirname 作为起始点，并向父级递归查找所有可能的 node_modules 位置，直至根目录

1. 根据上一步结果得到所有 webpack 可能在的位置

1. 实际导入，若路径存在则导出，否则返回 undefined

当 resolve npm package 的 loadNodeModulesSync 无法返回正常的 webpack 包（因为所有的父级都没有 install webpack），那么当 loadNodeModulesSync  返回 undefined 将导致其父级调用 resolveSync 将抛出模块导入错误，进而导致 jest-resolve 中的 resolveModuleFromDirIfExists 函数返回 null，进而导致父级调用 jest-resolve 中的 resolveModule 抛出我们在 terminal 中看到的模块未找到错误。

![image](https://user-images.githubusercontent.com/32980314/111059316-a407bf80-84cf-11eb-927e-6ff1be11b8ff.png)

## 为什么这个 pr 可以解决问题？

pr 中修改 `webpack` 为 `@umijs/deps/compiled/webpack` 相当于补全了在 loadNodeModulesSync  中的实际真实路径，使得可以找到对应的位于 @umijs/deps 对应文件下的 webpack 依赖。

**所以这是这个 pr 的必要性，解决在测试环境下 webpack  依赖无法定位的问题**。@sorrycc @ycjcl868 @PeachScript 
