### PR TITLE
fix: use lazyCompilation in development mode only

### DIFF
--- a/packages/preset-built-in/src/plugins/features/webpack5.ts
+++ b/packages/preset-built-in/src/plugins/features/webpack5.ts
@@ -30,7 +30,11 @@ export default (api: IApi) => {
   api.modifyBundleConfig((memo) => {
     // lazy compilation
     // @ts-ignore
-    if (api.config.webpack5!.lazyCompilation) {
+    if (
+      process.env.NODE_ENV === 'development' &&
+      api.config.webpack5 &&
+      api.config.webpack5.lazyCompilation
+    ) {
       // @ts-ignore
       memo.experiments = {
         // @ts-ignore

--- a/packages/preset-built-in/src/plugins/features/webpack5.ts
+++ b/packages/preset-built-in/src/plugins/features/webpack5.ts
@@ -30,11 +30,7 @@ export default (api: IApi) => {
   api.modifyBundleConfig((memo) => {
     // lazy compilation
     // @ts-ignore
-    if (
-      process.env.NODE_ENV === 'development' &&
-      api.config.webpack5 &&
-      api.config.webpack5.lazyCompilation
-    ) {
+    if (api.env === 'development' && api.config.webpack5.lazyCompilation) {
       // @ts-ignore
       memo.experiments = {
         // @ts-ignore


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

lazyCompilation开启后build时会少生成文件，只生成默认路由的文件，故只在dev模式下启用。
