### PR TITLE
feat(test): support jest.config.ts

### DIFF
--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -29,6 +29,7 @@
     "@babel/core": "7.12.10",
     "@umijs/babel-preset-umi": "3.4.7",
     "@umijs/utils": "3.4.7",
+    "@jest/types": "26.6.2",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^26.6.3",
     "core-js": "3.8.2",
@@ -36,7 +37,9 @@
     "jest": "^26.6.3",
     "jest-cli": "^26.6.3",
     "jest-environment-jsdom-fourteen": "1.0.1",
+    "jest-util": "^27.0.0-next.6",
     "regenerator-runtime": "^0.13.7",
+    "ts-node": "^9.1.1",
     "whatwg-fetch": "^3.5.0"
   },
   "bin": {

--- a/packages/test/src/fixtures/normal/jest.config.ts
+++ b/packages/test/src/fixtures/normal/jest.config.ts
@@ -1,0 +1,3 @@
+module.exports = {
+  baz: 1
+}

--- a/packages/test/src/fixtures/normal/jest.config.ts
+++ b/packages/test/src/fixtures/normal/jest.config.ts
@@ -1,3 +1,8 @@
-module.exports = {
-  baz: 1
+import { Config } from '@jest/types';
+
+
+const config : Config.InitialOptions = {
+  bail: 1000
 }
+
+export default config;

--- a/packages/test/src/index.test.ts
+++ b/packages/test/src/index.test.ts
@@ -51,5 +51,5 @@ test('run jest', async () => {
   // @ts-ignore
   expect(argsArr[0].updateSnapshot).toEqual(true);
   // @ts-ignore
-  expect(argsArr[0].config).toContain('"bar":1,"hoo":2,"baz":1,"foo":1');
+  expect(argsArr[0].config).toContain('"bar":1,"hoo":2,"bail":1000,"foo":1');
 });

--- a/packages/test/src/index.test.ts
+++ b/packages/test/src/index.test.ts
@@ -51,5 +51,5 @@ test('run jest', async () => {
   // @ts-ignore
   expect(argsArr[0].updateSnapshot).toEqual(true);
   // @ts-ignore
-  expect(argsArr[0].config).toContain('"bar":1,"hoo":2,"foo":1');
+  expect(argsArr[0].config).toContain('"bar":1,"hoo":2,"baz":1,"foo":1');
 });

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -30,7 +30,11 @@ export default async function (args: IUmiTestArgs) {
 
   const cwd = args.cwd || process.cwd();
 
-  // Read config from cwd/jest.config.js
+  // Read config from cwd/jest.config.ts or cwd/jest.config.js
+  const userJestConfigTsFile = join(cwd, 'jest.config.ts');
+  const userJestConfigTs =
+    existsSync(userJestConfigTsFile) && require(userJestConfigTsFile);
+
   const userJestConfigFile = join(cwd, 'jest.config.js');
   const userJestConfig =
     existsSync(userJestConfigFile) && require(userJestConfigFile);
@@ -47,6 +51,7 @@ export default async function (args: IUmiTestArgs) {
   const config = mergeConfig(
     createDefaultConfig(cwd, args),
     packageJestConfig,
+    userJestConfigTs,
     userJestConfig,
   );
   debug(`final config: ${JSON.stringify(config)}`);

--- a/packages/test/src/utils/index.ts
+++ b/packages/test/src/utils/index.ts
@@ -1,1 +1,2 @@
 export { default as mockConsole } from './mockConsole';
+export { default as loadTSConfigFile } from './loadTsConfig';

--- a/packages/test/src/utils/loadTsConfig.test.ts
+++ b/packages/test/src/utils/loadTsConfig.test.ts
@@ -6,9 +6,7 @@ const cwd = join(fixtures, 'normal');
 
 test('test loadTsConfigError when ts-node is not installed', async () => {
   // mock ts-node is undefined
-  jest.mock('ts-node', () => {}, {
-    virtual: true,
-  });
+  jest.mock('ts-node', () => ({}));
 
   const userJestConfigTsFile = join(cwd, 'jest.config.ts');
   await expect(loadTSConfigFile(userJestConfigTsFile)).rejects.toThrow();

--- a/packages/test/src/utils/loadTsConfig.test.ts
+++ b/packages/test/src/utils/loadTsConfig.test.ts
@@ -1,0 +1,17 @@
+import { default as loadTSConfigFile } from './loadTsConfig';
+import { join } from 'path';
+
+const fixtures = join(__dirname, '..', 'fixtures');
+const cwd = join(fixtures, 'normal');
+
+test('test loadTsConfigError when ts-node is not installed', async () => {
+  // mock ts-node is undefined
+  jest.mock('ts-node', () => {}, {
+    virtual: true,
+  });
+
+  const userJestConfigTsFile = join(cwd, 'jest.config.ts');
+  await expect(loadTSConfigFile(userJestConfigTsFile)).rejects.toThrow();
+
+  jest.clearAllMocks();
+});

--- a/packages/test/src/utils/loadTsConfig.ts
+++ b/packages/test/src/utils/loadTsConfig.ts
@@ -1,0 +1,40 @@
+// Load the TypeScript configuration
+import { Config } from '@jest/types';
+import { Service } from 'ts-node';
+import { interopRequireDefault } from 'jest-util';
+
+export default async (
+  configPath: Config.Path,
+): Promise<Config.InitialOptions> => {
+  let registerer: Service;
+
+  // Register TypeScript compiler instance
+  try {
+    registerer = require('ts-node').register({
+      compilerOptions: {
+        module: 'CommonJS',
+      },
+    });
+  } catch (e) {
+    if (e.code === 'MODULE_NOT_FOUND') {
+      throw new Error(
+        `Jest: 'ts-node' is required for the TypeScript configuration files. Make sure it is installed\nError: ${e.message}`,
+      );
+    }
+
+    throw e;
+  }
+
+  registerer.enabled(true);
+
+  let configObject = interopRequireDefault(require(configPath)).default;
+
+  // In case the config is a function which imports more Typescript code
+  if (typeof configObject === 'function') {
+    configObject = await configObject();
+  }
+
+  registerer.enabled(false);
+
+  return configObject;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1569,6 +1569,17 @@
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
 
+"@jest/types@26.6.2", "@jest/types@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
+  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
 "@jest/types@^24.3.0", "@jest/types@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.9.0.tgz#63cb26cb7500d069e5a389441a7c6ab5e909fc59"
@@ -1578,15 +1589,15 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@jest/types@^26.6.2":
-  version "26.6.2"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
-  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
+"@jest/types@^27.0.0-next.3":
+  version "27.0.0-next.3"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.0.0-next.3.tgz#60eefb07c6cbce9fbaafc097521cdc0add7329df"
+  integrity sha512-4/NR8Z6RwpIGwz3eYYrnCYNy2HnxTkxYwMLw/dBy8Sp65v4OoKra2U48KhR865U4uNawRzPfbpAPfU/zBFfOSw==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
     "@types/node" "*"
-    "@types/yargs" "^15.0.0"
+    "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
 "@lerna/add@3.21.0":
@@ -2939,6 +2950,13 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/yargs@^16.0.0":
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.1.tgz#5fc5d41f69762e00fbecbc8d4bf9dea47d8726f4"
+  integrity sha512-x4HABGLyzr5hKUzBC9dvjciOTm11WVH1NWonNjGgxapnTHu5SWUqyqn0zQ6Re0yQU0lsQ6ztLCoMAKDGZflyxA==
+  dependencies:
+    "@types/yargs-parser" "*"
+
 "@umijs/deps@0.7.1":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@umijs/deps/-/deps-0.7.1.tgz#a83ff42dc75fcd5695946eda525e0ad9513abbe1"
@@ -3314,6 +3332,11 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -4161,6 +4184,11 @@ ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
+ci-info@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.1.1.tgz#9a32fcefdf7bcdb6f0a7e1c0f8098ec57897b80a"
+  integrity sha512-kdRWLBIJwdsYJWYJFtAFFYxybguqeF91qpZaggjG5Nf8QKdizFG2hjqvaTXbxFIcYbSaD74KpAXv6BSm17DHEQ==
+
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
@@ -4717,6 +4745,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -5211,6 +5244,11 @@ diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -7191,6 +7229,13 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
+is-ci@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.0.tgz#c7e7be3c9d8eef7d0fa144390bd1e4b88dc4c994"
+  integrity sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==
+  dependencies:
+    ci-info "^3.1.1"
+
 is-color-stop@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-color-stop/-/is-color-stop-1.1.0.tgz#cfff471aee4dd5c9e158598fbe12967b5cdad345"
@@ -8039,6 +8084,18 @@ jest-util@^26.6.2:
     is-ci "^2.0.0"
     micromatch "^4.0.2"
 
+jest-util@^27.0.0-next.6:
+  version "27.0.0-next.6"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.0.0-next.6.tgz#639cc0b026a4a8e61ce15a8ff549db5c1a873831"
+  integrity sha512-qC0W3xOJZbgH3mpeaGDo0FnLYmIqPiPjwSucJSGCHRyemXlYwdnOdBTZlioU9YqcELLzDOEYvEKQYiH3+zMZ3A==
+  dependencies:
+    "@jest/types" "^27.0.0-next.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    is-ci "^3.0.0"
+    micromatch "^4.0.2"
+
 jest-validate@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-26.6.2.tgz#23d380971587150467342911c3d7b4ac57ab20ec"
@@ -8752,6 +8809,11 @@ make-dir@^3.0.0, make-dir@^3.0.2:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
+
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 make-fetch-happen@^5.0.0:
   version "5.0.2"
@@ -12432,7 +12494,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.16, source-map-support@^0.5.6, source-map-support@~0.5.19:
+source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -13251,6 +13313,18 @@ ts-loader@^8.0.7:
     loader-utils "^2.0.0"
     micromatch "^4.0.0"
     semver "^7.3.4"
+
+ts-node@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
+  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+  dependencies:
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
 
 tslib@2.0.1:
   version "2.0.1"
@@ -14245,6 +14319,11 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yorkie@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- 支持 `jest.config.ts` 的自动发现与 merge.  see #6319  (该PR支持了点1)

为了支持 ts 配置文件的读取，依赖部分新增了以下依赖:
- jest-util@27.0.0-next.6 (原为 @26.6.2), 为直接复用 `interopRequireDefault` 方法
- ts-node

新增了 `packages/test/utils/loadTsConfig.ts`。目前方法内容为复制 [https://github.com/facebook/jest/blob/b3f9e4ac667f7e4b3c6ac720ca6c33fc92ae7196/packages/jest-config/src/readConfigFileAndSetRootDir.ts#L79 ](jest-config) 中的内部方法




