### PR TITLE
chore: speed github ci faster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: install
         if: steps.cache.outputs.cache-hit != 'true'
-        run: yarn --ignore-engines
+        run: yarn --ignore-engines --frozen-lockfile
       - run: yarn build
       - run: yarn test --detectOpenHandles --maxWorkers=4 --forceExit
         env:

--- a/.github/workflows/outdated.yml
+++ b/.github/workflows/outdated.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: install
-        run: yarn --ignore-engines
+        run: yarn --ignore-engines --frozen-lockfile
       - name: outdated version
         uses: ycjcl868/outdated-version-action@v1
         with:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

> npm ci is fast—in some cases, twice as fast as using npm i

Refs: 
- https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable
- https://stackoverflow.com/questions/58482655/what-is-the-closest-to-npm-ci-in-yarn



##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
