### PR TITLE
fix(webpack5): fix webpack5 cache cannot be invalidated when package.json changes

### DIFF
--- a/packages/preset-built-in/src/plugins/features/webpack5.ts
+++ b/packages/preset-built-in/src/plugins/features/webpack5.ts
@@ -53,7 +53,7 @@ export default (api: IApi) => {
         type: 'filesystem',
         // using umi version as `cache.version`
         version: process.env.UMI_VERSION,
-        buildDependencies: { config: [__filename] },
+        buildDependencies: { config: [join(process.cwd(), 'package.json')] },
         cacheDirectory: join(api.paths.absTmpPath!, '.cache', 'webpack'),
       };
       // 缓存失效会有日志，这里清除下日志

--- a/packages/preset-built-in/src/plugins/features/webpack5.ts
+++ b/packages/preset-built-in/src/plugins/features/webpack5.ts
@@ -53,7 +53,7 @@ export default (api: IApi) => {
         type: 'filesystem',
         // using umi version as `cache.version`
         version: process.env.UMI_VERSION,
-        buildDependencies: {},
+        buildDependencies: { config: [__filename] },
         cacheDirectory: join(api.paths.absTmpPath!, '.cache', 'webpack'),
       };
       // 缓存失效会有日志，这里清除下日志

--- a/packages/preset-built-in/src/plugins/features/webpack5.ts
+++ b/packages/preset-built-in/src/plugins/features/webpack5.ts
@@ -53,7 +53,7 @@ export default (api: IApi) => {
         type: 'filesystem',
         // using umi version as `cache.version`
         version: process.env.UMI_VERSION,
-        buildDependencies: { config: [join(process.cwd(), 'package.json')] },
+        buildDependencies: { config: [join(api.cwd, 'package.json')] },
         cacheDirectory: join(api.paths.absTmpPath!, '.cache', 'webpack'),
       };
       // 缓存失效会有日志，这里清除下日志


### PR DESCRIPTION
…rod mode

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

依赖文件变化时，比如echarts4 => echarts5，再build的时候会出现报错。
故使用webpack5 doc推荐的buildDependencies配置监控全依赖，当依赖变化时可以使缓存失效重新构建。

另外dev模式下也有此问题。
