### PR TITLE
chore: improve error message when plugin resolved failed

### DIFF
--- a/packages/core/src/Service/Service.test.ts
+++ b/packages/core/src/Service/Service.test.ts
@@ -528,3 +528,19 @@ test('resolvePackage with APP_ROOT specified', () => {
   });
   expect(service.pkg.name).toEqual('foo');
 });
+
+test('path no string', async () => {
+  const cwd = join(fixtures, 'no-package-json');
+
+  // 'as any' for ignore ts
+  const path = ['umi-plugin-dva', { immer: true }] as any;
+  const service = new Service({
+    cwd,
+    plugins: [path],
+  });
+  await expect(service.init()).rejects.toThrow(
+    `Plugin resolved failed, Please check your plugins config, it must be array of string.\nError Plugin Config: ${JSON.stringify(
+      path,
+    )}`,
+  );
+});

--- a/packages/core/src/Service/Service.test.ts
+++ b/packages/core/src/Service/Service.test.ts
@@ -529,16 +529,17 @@ test('resolvePackage with APP_ROOT specified', () => {
   expect(service.pkg.name).toEqual('foo');
 });
 
-test('path no string', async () => {
+test('path no string', () => {
   const cwd = join(fixtures, 'no-package-json');
 
   // 'as any' for ignore ts
   const path = ['umi-plugin-dva', { immer: true }] as any;
-  const service = new Service({
-    cwd,
-    plugins: [path],
-  });
-  await expect(service.init()).rejects.toThrow(
+  expect(() => {
+    new Service({
+      cwd,
+      plugins: [path],
+    });
+  }).toThrow(
     `Plugin resolved failed, Please check your plugins config, it must be array of string.\nError Plugin Config: ${JSON.stringify(
       path,
     )}`,

--- a/packages/core/src/Service/utils/pluginUtils.ts
+++ b/packages/core/src/Service/utils/pluginUtils.ts
@@ -61,6 +61,13 @@ function getPluginsOrPresets(type: PluginType, opts: IOpts): string[] {
       type === PluginType.preset ? 'userConfigPresets' : 'userConfigPlugins'
     ] as any) || []),
   ].map((path) => {
+    if (typeof path !== 'string') {
+      throw new Error(
+        `Plugin resolved failed, Please check your plugins config, it must be array of string.\nError Plugin Config: ${JSON.stringify(
+          path,
+        )}`,
+      );
+    }
     return resolve.sync(path, {
       basedir: opts.cwd,
       extensions: ['.js', '.ts'],


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->
配置plugin：
```
{
  plugins: [[
    'umi-plugin-dva',
    {
      immer: true,
    },
  ]],
}
```
修改前：
```
Path must be a string.
TypeError: Path must be a string.
```
修改后：
```
Plugin resolved failed, Please check your plugins config, it must be array of string.
Error Plugin Config: ["umi-plugin-dva",{"immer":true}]
```
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
-  https://github.com/umijs/umi/issues/6303
