### PR TITLE
fix: remove react-error-overlay warning in dev

### DIFF
--- a/packages/bundler-webpack/bundled/webpackHotDevClient.js
+++ b/packages/bundler-webpack/bundled/webpackHotDevClient.js
@@ -6874,7 +6874,7 @@
                   (window.__REACT_ERROR_OVERLAY_GLOBAL_HOOK__.iframeReady = function () {
                     (re = !0), (te = !1), ve();
                   }),
-                  true &&
+                  process.env.NODE_ENV === 'production' &&
                     console.warn(
                       'react-error-overlay is not meant for use in production. You should ensure it is not included in your build to reduce bundle size.',
                     );


### PR DESCRIPTION
好像是上次更新把之前的修复覆盖了