### PR TITLE
fix(webpack5): fix the failure of abandoning babel-loader cache

### DIFF
--- a/packages/preset-built-in/src/plugins/features/webpack5.ts
+++ b/packages/preset-built-in/src/plugins/features/webpack5.ts
@@ -25,6 +25,9 @@ export default (api: IApi) => {
       console.log('Bundle with webpack 5...');
     }
     process.env.USE_WEBPACK_5 = '1';
+    if (process.env.WEBPACK_FS_CACHE !== 'none') {
+      process.env.BABEL_CACHE = 'none';
+    }
   });
 
   api.modifyBundleConfig((memo) => {
@@ -67,15 +70,6 @@ export default (api: IApi) => {
           : {}),
       };
     }
-
-    api.modifyBabelOpts((memo) => {
-      // 开启 persistent caching 后，不再需要 babel cache 了
-      // 只要不禁用物理缓存，就禁用 babel 缓存
-      if (process.env.WEBPACK_FS_CACHE !== 'none') {
-        memo.cacheDirectory = false;
-      }
-      return memo;
-    });
 
     return memo;
   });

--- a/packages/preset-built-in/src/plugins/features/webpack5.ts
+++ b/packages/preset-built-in/src/plugins/features/webpack5.ts
@@ -25,6 +25,8 @@ export default (api: IApi) => {
       console.log('Bundle with webpack 5...');
     }
     process.env.USE_WEBPACK_5 = '1';
+    // 开启 persistent caching 后，不再需要 babel cache 了
+    // 只要不禁用物理缓存，就禁用 babel 缓存
     if (process.env.WEBPACK_FS_CACHE !== 'none') {
       process.env.BABEL_CACHE = 'none';
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

首先modifyBabelOpts放在modifyBundleConfig里是不生效的，拿出来以后会执行，但设置cacheDirectory = false也不能阻止babel-loader生成cache，猜测可能是执行顺序之类的。
因为有BABEL_CACHE的环境变量，所以直接改在onPluginReady设置BABEL_CACHE = 'none'来阻止babel-loader生成cache。
