### PR TITLE
feat: routerContainer

### DIFF
--- a/packages/preset-built-in/src/plugins/generateFiles/core/plugin.ts
+++ b/packages/preset-built-in/src/plugins/generateFiles/core/plugin.ts
@@ -18,6 +18,7 @@ export default function (api: IApi) {
         'modifyClientRenderOpts',
         'patchRoutes',
         'rootContainer',
+        'routerContainer',
         'render',
         'onRouteChange',
       ],

--- a/packages/renderer-react/src/renderRoutes/renderRoutes.tsx
+++ b/packages/renderer-react/src/renderRoutes/renderRoutes.tsx
@@ -97,6 +97,7 @@ function render({
     { location: props.location },
   );
   let { component: Component, wrappers } = route;
+  let children = routes;
   if (Component) {
     const defaultPageInitialProps = opts.isServer
       ? {}
@@ -108,6 +109,7 @@ function render({
       route,
       routes: opts.rootRoutes,
     };
+
     // @ts-ignore
     let ret = <Component {...newProps}>{routes}</Component>;
 
@@ -120,10 +122,20 @@ function render({
       }
     }
 
-    return ret;
+    children = ret;
   } else {
-    return routes;
+    children = routes;
   }
+
+  return opts.plugin.applyPlugins({
+    type: ApplyPluginsType.modify,
+    key: 'routerContainer',
+    initialValue: children,
+    args: {
+      routes: opts.routes,
+      plugin: opts.plugin,
+    },
+  });
 }
 
 function getRouteElement({ route, index, opts }: IGetRouteElementOpts) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- add container inside router provider.

> 原本是尝试解决 useModel 中不能用 react-router context 的问题，但 model 的 Provider 放到 router context 内部后，路由变化会导致状态丢失。应该不能使用此方案，不过 routerContainer 的 API 可能有其他使用场景，先提一下。

