### PR TITLE
fix: add cjs/mjs support in test

### DIFF
--- a/packages/test/src/createDefaultConfig/createDefaultConfig.ts
+++ b/packages/test/src/createDefaultConfig/createDefaultConfig.ts
@@ -49,13 +49,13 @@ export default function (cwd: string, args: IUmiTestArgs) {
     ],
     testPathIgnorePatterns: ['/node_modules/', '/fixtures/'],
     transform: {
-      '^.+\\.(js|jsx|ts|tsx)$': require.resolve(
+      '^.+\\.(js|jsx|ts|tsx|cjs|mjs)$': require.resolve(
         '../../helpers/transformers/javascript',
       ),
       '^.+\\.(css|less|sass|scss|stylus)$': require.resolve(
         '../../helpers/transformers/css',
       ),
-      '^(?!.*\\.(js|jsx|ts|tsx|css|less|sass|scss|stylus|json)$)': require.resolve(
+      '^(?!.*\\.(js|jsx|ts|tsx|cjs|mjs|css|less|sass|scss|stylus|json)$)': require.resolve(
         '../../helpers/transformers/file',
       ),
     },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
一些三方库（例如[nanoid](https://www.npmjs.com/package/nanoid)）开始使用`.cjs/.mjs`为后缀的输出文件，在使用@umijs/test的时候，会被错误的匹配使用file parse，导致测试运行错误。
