### PR TITLE
fix(utils): add check for parseRequireDeps to exclude non-existent path

### DIFF
--- a/packages/utils/src/parseRequireDeps/fixtures/not-exist/.umirc.ts
+++ b/packages/utils/src/parseRequireDeps/fixtures/not-exist/.umirc.ts
@@ -1,0 +1,9 @@
+import './config/foo';
+
+import './notExist1'
+import './notExist2/non-existent-file'
+require('./not-exist3')
+
+if (false) {
+    require('./notExist4')
+}

--- a/packages/utils/src/parseRequireDeps/fixtures/not-exist/config/foo.ts
+++ b/packages/utils/src/parseRequireDeps/fixtures/not-exist/config/foo.ts
@@ -1,0 +1,5 @@
+// @ts-ignore
+import a from '../src/a';
+import 'b';
+
+a();

--- a/packages/utils/src/parseRequireDeps/fixtures/not-exist/src/a.js
+++ b/packages/utils/src/parseRequireDeps/fixtures/not-exist/src/a.js
@@ -1,0 +1,1 @@
+import 'bar';

--- a/packages/utils/src/parseRequireDeps/parseRequireDeps.test.ts
+++ b/packages/utils/src/parseRequireDeps/parseRequireDeps.test.ts
@@ -31,3 +31,11 @@ test('avoid cycle', () => {
   );
   expect(ret).toEqual(['./a.ts', './b.ts', './c.ts']);
 });
+
+test('non-existent files or directories', () => {
+  const fixture = join(fixtures, 'not-exist');
+  const ret = parseRequireDeps(join(fixture, '.umirc.ts')).map((p) =>
+    p.replace(winPath(fixture), '.'),
+  );
+  expect(ret).toEqual(['./.umirc.ts', './config/foo.ts', './src/a.js']);
+});

--- a/packages/utils/src/parseRequireDeps/parseRequireDeps.ts
+++ b/packages/utils/src/parseRequireDeps/parseRequireDeps.ts
@@ -22,7 +22,7 @@ function parse(filePath: string): string[] {
           }),
         );
       } catch (error) {
-        console.log(`${error.code} path: ${path}`);
+        console.log(`${error.code}: '${path}' from '${filePath}'`);
         return '';
       }
     });

--- a/packages/utils/src/parseRequireDeps/parseRequireDeps.ts
+++ b/packages/utils/src/parseRequireDeps/parseRequireDeps.ts
@@ -22,7 +22,7 @@ function parse(filePath: string): string[] {
           }),
         );
       } catch (error) {
-        // console.debug('[parseRequireDeps.parse]', error);
+        console.log(`${error.code} path: ${path}`);
         return '';
       }
     });

--- a/packages/utils/src/parseRequireDeps/parseRequireDeps.ts
+++ b/packages/utils/src/parseRequireDeps/parseRequireDeps.ts
@@ -13,14 +13,19 @@ function parse(filePath: string): string[] {
   return (crequire(content) as any[])
     .map<string>((o) => o.path)
     .filter((path) => path.charAt(0) === '.')
-    .map((path) =>
-      winPath(
-        resolve.sync(path, {
-          basedir: dirname(filePath),
-          extensions: ['.tsx', '.ts', '.jsx', '.js'],
-        }),
-      ),
-    );
+    .map((path) => {
+      try {
+        return winPath(
+          resolve.sync(path, {
+            basedir: dirname(filePath),
+            extensions: ['.tsx', '.ts', '.jsx', '.js'],
+          }),
+        );
+      } catch (error) {
+        // console.debug('[parseRequireDeps.parse]', error);
+        return '';
+      }
+    });
 }
 
 export default function parseRequireDeps(filePath: string): string[] {
@@ -29,7 +34,7 @@ export default function parseRequireDeps(filePath: string): string[] {
 
   while (paths.length) {
     // 避免依赖循环
-    const extraPaths = lodash.pullAll(parse(paths.shift()!), ret);
+    const extraPaths = lodash.pullAll(parse(paths.shift()!), [...ret, '']);
     if (extraPaths.length) {
       paths.push(...extraPaths);
       ret.push(...extraPaths);


### PR DESCRIPTION


<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

根据issue来看crequire会解析false语句里的require。
因为是deps没有改动，只增加了trycatch并返回空字符串，然后在外层过滤空字符串。
算是一种健壮性fix。
并增加了一个测试。

close #6487
