### PR TITLE
fix: proxy error - update routes.ts

### DIFF
--- a/packages/utils/src/routes.ts
+++ b/packages/utils/src/routes.ts
@@ -35,6 +35,8 @@ export const routeToChunkName: IRouteToChunkName = (
         .replace(/[\[\]]/g, '')
         // 插件层的文件也可能是路由组件，比如 plugin-layout 插件
         .replace(/^.umi-production__/, 't__')
+        // .umi 开头的 webpackChunkName 在使用 plugin-layout 插件时会导致代理异常，eg: /api/** 无法匹配到 /api/.umi__plugin-layout__Layout
+        .replace(/^.umi__/, 't__')
         .replace(/^pages__/, 'p__')
         .replace(/^page__/, 'p__')
     : '';


### PR DESCRIPTION
.umi 开头的 webpackChunkName 在使用 plugin-layout 插件时会导致代理异常，eg: /api/** 无法匹配到 /api/.umi__plugin-layout__Layout

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines
