### PR TITLE
feat: with react18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /node_modules
+/**/node_modules
 /packages/*/lib
 /packages/*/dist
 /packages/*/node_modules
@@ -25,3 +26,4 @@ output.txt
 /examples/*/logs
 /examples/*/run
 /examples/*/.idea
+packages/bundler-webpack/src/fixtures/with-react18/yarn.lock

--- a/examples/with-react18/.env
+++ b/examples/with-react18/.env
@@ -1,0 +1,1 @@
+UMI_APP_USE_REACT18=true

--- a/examples/with-react18/.env
+++ b/examples/with-react18/.env
@@ -1,1 +1,0 @@
-UMI_APP_USE_REACT18=true

--- a/examples/with-react18/README.md
+++ b/examples/with-react18/README.md
@@ -1,0 +1,21 @@
+# with-react18
+
+with react@alpha
+
+Please run `yarn install` in the current directory and `link:umi` to the current development branch.
+
+The principle is that `umi` will give priority to the `react` version installed in the current project.
+
+Use the Env Variables:UMI_APP_USE_REACT18 in `.dev` file.
+
+TODO: UMI_APP_USE_REACT18,There should be umi auto guessing.
+
+## How to use
+
+Execute [`@umijs/create-umi-app`](https://github.com/umijs/umi/tree/master/packages/create-umi-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
+
+```bash
+npx @umijs/create-umi-app --example with-react18 with-react18-app
+# or
+yarn create @umijs/umi-app --example with-react18 with-react18-app
+```

--- a/examples/with-react18/README.md
+++ b/examples/with-react18/README.md
@@ -6,10 +6,6 @@ Please run `yarn install` in the current directory and `link:umi` to the current
 
 The principle is that `umi` will give priority to the `react` version installed in the current project.
 
-Use the Env Variables:UMI_APP_USE_REACT18 in `.dev` file.
-
-TODO: UMI_APP_USE_REACT18,There should be umi auto guessing.
-
 ## How to use
 
 Execute [`@umijs/create-umi-app`](https://github.com/umijs/umi/tree/master/packages/create-umi-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:

--- a/examples/with-react18/package.json
+++ b/examples/with-react18/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "with-react18",
+  "version": "0.0.1",
+  "description": "with-react18",
+  "scripts": {
+    "start": "umi dev",
+    "build": "umi build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/umijs/umi"
+  },
+  "keywords": [
+    "umi",
+    "umi examples"
+  ],
+  "authors": [
+    "chencheng <sorrycc@gmail.com> (https://github.com/sorrycc)"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "react": "^18.0.0-alpha-43f4cc160",
+    "react-dom": "^18.0.0-alpha-43f4cc160",
+    "umi": "latest"
+  },
+  "bugs": "http://github.com/umijs/umi/issues",
+  "homepage": "https://github.com/umijs/umi/tree/master/examples/with-react18#readme"
+}

--- a/examples/with-react18/pages/index.less
+++ b/examples/with-react18/pages/index.less
@@ -1,0 +1,3 @@
+.title {
+  background: rgb(121, 242, 157);
+}

--- a/examples/with-react18/pages/index.tsx
+++ b/examples/with-react18/pages/index.tsx
@@ -1,0 +1,25 @@
+//@ts-ignore
+import React, { useState, useTransition } from 'react';
+//@ts-ignore
+import styles from './index.less';
+
+export default function IndexPage() {
+  const [isPending, startTransition] = useTransition();
+  const [state, setstate] = useState(0);
+  return (
+    <div>
+      {isPending && <div>loading...</div>}
+      <h1
+        className={styles.title}
+        onClick={() => {
+          startTransition(() => {
+            setstate(1);
+          });
+        }}
+      >
+        Click Me!
+      </h1>
+      {state}
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "prettier": "prettier --write '**/*.{js,jsx,tsx,ts,less,md,json}'",
     "link:umi": "cd packages/umi && yarn link && cd -",
     "release": "node ./scripts/release.js",
+    "preinstall": "cd packages/bundler-webpack/src/fixtures/with-react18 && yarn install",
     "test": "umi-test",
     "test:coverage": "umi-test --coverage",
     "sync:tnpm": "node -e 'require(\"./scripts/syncTNPM\")()'",

--- a/packages/bundler-webpack/src/fixtures/with-react18/expect.ts
+++ b/packages/bundler-webpack/src/fixtures/with-react18/expect.ts
@@ -1,0 +1,5 @@
+import { IExpectOpts } from '../types';
+
+export default ({ indexJS }: IExpectOpts) => {
+  expect(indexJS).toContain(`console.log("true");`);
+};

--- a/packages/bundler-webpack/src/fixtures/with-react18/index.ts
+++ b/packages/bundler-webpack/src/fixtures/with-react18/index.ts
@@ -1,0 +1,1 @@
+console.log(process.env.UMI_APP_USE_REACT18);

--- a/packages/bundler-webpack/src/fixtures/with-react18/package.json
+++ b/packages/bundler-webpack/src/fixtures/with-react18/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "with-react18",
+  "dependencies": {
+    "react": "^18.0.0-alpha-43f4cc160",
+    "react-dom": "^18.0.0-alpha-43f4cc160"
+  }
+}

--- a/packages/bundler-webpack/src/getConfig/getConfig.ts
+++ b/packages/bundler-webpack/src/getConfig/getConfig.ts
@@ -83,9 +83,13 @@ export default async function getConfig(
   const isDev = env === 'development';
   const isProd = env === 'production';
   const disableCompress = process.env.COMPRESS === 'none';
-  const reactDomVersion = require(winPath(
+  let reactDomVersion = '0.0.0';
+  const reactDomPath = winPath(
     join(cwd, 'node_modules', 'react-dom', 'package.json'),
-  )).version;
+  );
+  if (existsSync(reactDomPath)) {
+    reactDomVersion = require(reactDomPath).version;
+  }
   const useReact18 =
     Boolean(reactDomVersion) &&
     (semver.gte(reactDomVersion!, '18.0.0') ||

--- a/packages/renderer-react/src/renderClient/renderClient.tsx
+++ b/packages/renderer-react/src/renderClient/renderClient.tsx
@@ -119,13 +119,18 @@ export default function renderClient(opts: IOpts) {
         : opts.rootElement;
     const callback = opts.callback || (() => {});
     if (process.env.UMI_APP_USE_REACT18) {
-      //TODO: opts.dynamicImport
       if (!reactRoot) {
         reactRoot = (ReactDOM as any).createRoot(rootElement, {
           hydrate: window.g_useSSR,
         });
       }
-      reactRoot.render(rootContainer);
+      if (opts.dynamicImport) {
+        preloadComponent(opts.routes).then(function () {
+          reactRoot.render(rootContainer);
+        });
+      } else {
+        reactRoot.render(rootContainer);
+      }
     } else {
       // flag showing SSR successed
       if (window.g_useSSR) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->
翻了一下 react18 的文档 https://github.com/reactwg/react-18/discussions

发现从 client 更新的话只需要修改渲染入口 [`createRoot`](https://github.com/reactwg/react-18/discussions/6)，在 examples 中使用了一个新的 api [startTransition](https://github.com/reactwg/react-18/discussions/41)

在 next.js 中，也是仅仅修改了这个地方 https://github.com/vercel/next.js/blob/b05719f928acc70c57c82978a9cb256bd93b0c61/packages/next/client/index.tsx#L509

##### examples

在 `examples/with-react18` 执行 `yarn install`，然后 link:umi 到当前分支。因为 umi 会优先使用项目中安装的 react 版本。

##### TODO

* [x] 环境变量 UMI_APP_USE_REACT18 ，应该由 umi 自动检测，最终的使用是，用户在项目中安装 react@alpha 就可以使用 react18.

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL


-----
[View rendered examples/with-react18/README.md](https://github.com/umijs/umi/blob/feat-with-react18/examples/with-react18/README.md)