### PR TITLE
feat: mfsu and webpack5 support configure enable in modifyDefaultConfig

### DIFF
--- a/packages/preset-built-in/src/plugins/features/mfsu/mfsu.test.ts
+++ b/packages/preset-built-in/src/plugins/features/mfsu/mfsu.test.ts
@@ -5,7 +5,7 @@ import { getMfsuPath } from './mfsu';
 test('functions: get mfsu path', () => {
   // @ts-ignore
   let api: IApi = {
-    userConfig: {
+    config: {
       mfsu: {
         development: {
           output: './foo/bar',

--- a/packages/preset-built-in/src/plugins/features/mfsu/mfsu.ts
+++ b/packages/preset-built-in/src/plugins/features/mfsu/mfsu.ts
@@ -40,12 +40,12 @@ export const checkConfig = (api: IApi) => {
 
 export const getMfsuPath = (api: IApi, { mode }: { mode: TMode }) => {
   if (mode === 'development') {
-    const configPath = api.userConfig.mfsu?.development?.output;
+    const configPath = api.config.mfsu?.development?.output;
     return configPath
       ? join(api.cwd, configPath)
       : join(api.paths.absTmpPath!, '.cache', '.mfsu');
   } else {
-    const configPath = api.userConfig.mfsu?.production?.output;
+    const configPath = api.config.mfsu?.production?.output;
     return configPath
       ? join(api.cwd, configPath)
       : join(api.cwd, './.mfsu-production');
@@ -126,8 +126,8 @@ export default function (api: IApi) {
     },
     enableBy() {
       return (
-        (api.env === 'development' && api.userConfig.mfsu) ||
-        (api.env === 'production' && api.userConfig.mfsu?.production) ||
+        (api.env === 'development' && api.config.mfsu) ||
+        (api.env === 'production' && api.config.mfsu?.production) ||
         process.env.MFSUC
       );
     },
@@ -217,7 +217,7 @@ export default function (api: IApi) {
     return (req, res, next) => {
       const { pathname } = url.parse(req.url);
       if (
-        !api.userConfig.mfsu ||
+        !api.config.mfsu ||
         req.url === '/' ||
         !existsSync(
           join(getMfsuPath(api, { mode: 'development' }), '.' + pathname),
@@ -248,6 +248,9 @@ export default function (api: IApi) {
 
         if (!mfsu) {
           const remotePath = api.config.publicPath;
+          // Cannot read property 'ModuleFederationPlugin' of undefined
+          // webpack5 has to be used, but it's not.
+          // It can be opened through environment variable USE_WEBPACK_5
           memo.plugins.push(
             new webpack.container.ModuleFederationPlugin({
               name: 'umi-app',

--- a/packages/preset-built-in/src/plugins/features/mfsu/mfsu.ts
+++ b/packages/preset-built-in/src/plugins/features/mfsu/mfsu.ts
@@ -40,11 +40,13 @@ export const checkConfig = (api: IApi) => {
 
 export const getMfsuPath = (api: IApi, { mode }: { mode: TMode }) => {
   if (mode === 'development') {
+    //@ts-ignore
     const configPath = api.config.mfsu?.development?.output;
     return configPath
       ? join(api.cwd, configPath)
       : join(api.paths.absTmpPath!, '.cache', '.mfsu');
   } else {
+    //@ts-ignore
     const configPath = api.config.mfsu?.production?.output;
     return configPath
       ? join(api.cwd, configPath)
@@ -127,6 +129,7 @@ export default function (api: IApi) {
     enableBy() {
       return (
         (api.env === 'development' && api.config.mfsu) ||
+        //@ts-ignore
         (api.env === 'production' && api.config.mfsu?.production) ||
         process.env.MFSUC
       );

--- a/packages/preset-built-in/src/plugins/features/webpack5.ts
+++ b/packages/preset-built-in/src/plugins/features/webpack5.ts
@@ -4,7 +4,9 @@ import { join } from 'path';
 export default (api: IApi) => {
   api.describe({
     key: 'webpack5',
-    enableBy: api.EnableBy.config,
+    // support configure enable in modifyDefaultConfig
+    // It needs to be combined with USE_WEBPACK_5 for normal use
+    // enableBy: api.EnableBy.config,
     config: {
       schema(joi) {
         return joi.object().keys({
@@ -35,7 +37,7 @@ export default (api: IApi) => {
   api.modifyBundleConfig((memo) => {
     // lazy compilation
     // @ts-ignore
-    if (api.env === 'development' && api.config.webpack5.lazyCompilation) {
+    if (api.env === 'development' && api.config?.webpack5?.lazyCompilation) {
       // @ts-ignore
       memo.experiments = {
         // @ts-ignore


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->
让 mfsu 和 webpack5 配置可以通过插件 API modifyDefaultConfig 修改开启或者关闭。

webpack5 有点特殊，它需要很前置来指定使用 webpack5，不然有些插件会提示不存在。
所以如果没在config中显示写明的话，需要通过最前置的环境变量来指定。
支持如下使用方式 

.umirc.js

```js
export default {
  plugins: ['./plugin.js'],
}
```
plugin.js
```js
export default (api) => {
  api.modifyDefaultConfig({
    fn: (memo) => {
      return {
        ...memo,
        webpack5: {},
        dynamicImport: {},
        mfsu: {},
      };
    },
  });
};
```
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
