### PR TITLE
fix: Support for object square brackets

### DIFF
--- a/packages/preset-built-in/src/plugins/features/mfsu/utils.test.ts
+++ b/packages/preset-built-in/src/plugins/features/mfsu/utils.test.ts
@@ -100,6 +100,8 @@ test('cjs mode esm', () => {
   exports {Love};
 
   exportsILoveYou = "1";
+
+  exports["something"] = undefined;
   
   `;
 
@@ -109,5 +111,6 @@ test('cjs mode esm', () => {
     'bbbb',
     'Foo',
     'default',
+    'something',
   ]);
 });

--- a/packages/preset-built-in/src/plugins/features/mfsu/utils.ts
+++ b/packages/preset-built-in/src/plugins/features/mfsu/utils.ts
@@ -42,7 +42,13 @@ export const cjsModeEsmParser = (code: string) => {
     ),
   ]
     .map((result) => result[1])
-    .concat([...code.matchAll(/exports\.(\w+)/g)].map((result) => result[1]));
+    .concat(
+      [...code.matchAll(/exports(\.|\[(\'|\"))(\w+)(\s*|(\'|\")\])\s*\=/g)].map(
+        (result) => {
+          return result[Math.floor(result.length / 2)];
+        },
+      ),
+    );
 };
 
 export const filenameFallback = async (absPath: string): Promise<string> => {


### PR DESCRIPTION
- via #6769 
支持 `exports["foo"] = xxx;` 的导出识别