### PR TITLE
添加SockJS 超时时间

### DIFF
--- a/packages/bundler-webpack/src/webpackHotDevClient/webpackHotDevClient.ts
+++ b/packages/bundler-webpack/src/webpackHotDevClient/webpackHotDevClient.ts
@@ -178,7 +178,7 @@ function getSocketHost() {
 
 function initSocket() {
   const host = getSocketHost();
-  sock = new SockJS(`${host}/dev-server`);
+  sock = new SockJS(`${host}/dev-server`, undefined, { timeout: 5000 });
 
   sock.onopen = () => {
     retries = 0;


### PR DESCRIPTION
使用 ASP.NET CORE SpaServices 时因为使用了代理转了一层，导致超时了，然后HMR失效了
