### PR TITLE
fix: support json import in mfsu

### DIFF
--- a/packages/preset-built-in/src/plugins/features/mfsu/getDepReExportContent.test.ts
+++ b/packages/preset-built-in/src/plugins/features/mfsu/getDepReExportContent.test.ts
@@ -193,3 +193,28 @@ test('cjs mode esm parser', () => {
     'eeeeee',
   ]);
 });
+
+test('import a json file', async () => {
+  expect(
+    await getDepReExportContent({
+      content: `
+{
+  "name": "test"
+}
+`,
+      importFrom: 'test/package.json',
+      filePath: '/test/package.json',
+    }),
+  ).toEqual(`import _ from 'test/package.json';\nexport default _;`);
+});
+
+test('import a json but with invalid JSON content', async () => {
+  expect(
+    await getDepReExportContent({
+      content: `
+export const name = "test";
+`,
+      importFrom: 'test/package.json',
+    }),
+  ).toEqual(`export * from 'test/package.json';`);
+});

--- a/packages/preset-built-in/src/plugins/features/mfsu/getDepReExportContent.ts
+++ b/packages/preset-built-in/src/plugins/features/mfsu/getDepReExportContent.ts
@@ -16,12 +16,19 @@ export async function getDepReExportContent(opts: {
   }
 
   try {
-    if (opts.filePath && !/\.(js|jsx|mjs|ts|tsx)$/.test(opts.filePath)) {
+    if (opts.filePath && !/\.(js|jsx|mjs|ts|tsx|json)$/.test(opts.filePath)) {
       const matchResult = opts.filePath.match(/\.([a-zA-Z]+)$/);
       throw new Error(
         `${matchResult ? matchResult[0] : 'file type'} not support!`,
       );
     }
+
+    if (isJsonFile(opts.filePath)) {
+      return [`import _ from '${opts.importFrom}';`, `export default _;`].join(
+        '\n',
+      );
+    }
+
     const { exports, isCJS } = await parseWithCJSSupport(
       opts.content,
       opts.filePath,
@@ -129,6 +136,10 @@ export const cjsModeEsmParser = (code: string) => {
     )
     .map((result) => result[1]);
 };
+
+function isJsonFile(filePath?: string) {
+  return filePath && filePath.endsWith('.json');
+}
 
 async function parseWithCJSSupport(content: string, filePath?: string) {
   // Support tsx and jsx


### PR DESCRIPTION

##### Checklist


- [x] `npm test` passes
- [x] tests are included
- [x] commit message follows commit guidelines

##### Description of change

`json` as dependency used in `mfsu` should be supported

for example, following code would cause exception while enable `mfsu`

```ts
import pkg from 'antd/package.json'

console.log(pkg)
```

- close https://github.com/umijs/umi/issues/6923
