### PR TITLE
doc: fix config history link typo

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -720,7 +720,7 @@ export default {
 - Type: `object`
 - Default: `{ type: 'browser' }`
 
-配置 [history 类型和配置项](https://github.com/ReactTraining/history/blob/master/docs/GettingStarted.md)。
+配置 [history 类型和配置项](https://github.com/ReactTraining/history/blob/master/docs/getting-started.md)。
 
 包含以下子配置项：
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- 修正` history 类型和配置项`链接（依赖仓库在[这次commit](https://github.com/ReactTraining/history/commit/9532fb2170ab8000bddf69116661a9cb400c1ed6#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3)有做重命名）


-----
[View rendered docs/config/README.md](https://github.com/careteenL/umi-1/blob/master/docs/config/README.md)