### PR TITLE
fix: resolve publicPath properly especially for electron env

### DIFF
--- a/packages/preset-built-in/src/plugins/features/mfsu/mfsu.ts
+++ b/packages/preset-built-in/src/plugins/features/mfsu/mfsu.ts
@@ -256,10 +256,14 @@ export default function (api: IApi) {
   api.addBeforeMiddlewares(() => {
     return (req, res, next) => {
       const path = req.path;
+      // we should remove the first "." to prevent incorrect target such as: ./mf-va_.
+      // because we usually set publicPath: ./ for electron app
+      const publicPath = (api.config.publicPath as string).startsWith('./') ? '/' : api.config.publicPath;
+
       if (
-        path.startsWith(`${api.config.publicPath}mf-va_`) ||
-        path.startsWith(`${api.config.publicPath}mf-dep_`) ||
-        path.startsWith(`${api.config.publicPath}mf-static/`)
+        path.startsWith(`${publicPath}mf-va_`) ||
+        path.startsWith(`${publicPath}mf-dep_`) ||
+        path.startsWith(`${publicPath}mf-static/`)
       ) {
         depBuilder.onBuildComplete(() => {
           const filePath = path


### PR DESCRIPTION


##### Checklist

- [x] `npm test` passes
- [x] tests are included
- [x] commit message follows commit guidelines

##### Description of change

在配合`electron`做开发时，`publicPath` 不能使用默认值或者 以 `/` 之类绝对路径的值，这样会导致打包后的文件加载不正常（electron应用启动并不是web 容器）。

所以在`electron`开发下，`publicPath` 需要设置成 `./`之类相对路径。

然后问题就来了，`mfsu` 在dev serve 文件时，直接字符串拼接`${api.config.publicPath}mf-va_` 是match不到文件的。就出现了如下错误：


```
Unhandled Rejection (ScriptExternalLoadError): Loading script failed.
(missing: http://localhost:8000/mf-va_remoteEntry.js)
while loading "./core-js" from webpack/container/reference/mf
while loading ".//Users/howard.zuo/github/electron-awesome/node_modules/@umijs/runtime" from webpack/container/reference/mf
while loading "./react" from webpack/container/reference/mf
```

可复现repo: https://github.com/leftstick/electron-awesome

复现步骤：

```
yarn

yarn start
```

就会看到上述错误