### PR TITLE
fix(preset-built-in): fix mfsu assets mismatch with various publicPath (#7013)

### DIFF
--- a/packages/preset-built-in/src/plugins/features/mfsu/mfsu.test.ts
+++ b/packages/preset-built-in/src/plugins/features/mfsu/mfsu.test.ts
@@ -1,6 +1,6 @@
 import { winPath } from '@umijs/utils';
 import { IApi } from 'umi';
-import { getMfsuPath } from './mfsu';
+import { getMfsuPath, normalizeReqPath } from './mfsu';
 
 test('functions: get mfsu path', () => {
   // @ts-ignore
@@ -24,4 +24,103 @@ test('functions: get mfsu path', () => {
   expect(winPath(getMfsuPath(api, { mode: 'production' }))).toEqual(
     '/work/xxx/yyy/zzz',
   );
+});
+
+test('normalizeReqPath', () => {
+  // publicPath should be normalized as '/'
+  expect(normalizeReqPath('/', '/mf-va_xxxxxxxxxxx.js')).toStrictEqual({
+    isMfAssets: true,
+    normalPublicPath: '/',
+    fileRelativePath: 'mf-va_xxxxxxxxxxx.js',
+  });
+
+  expect(normalizeReqPath('./', '/mf-dep_xxxxxx.js')).toStrictEqual({
+    isMfAssets: true,
+    normalPublicPath: '/',
+    fileRelativePath: 'mf-dep_xxxxxx.js',
+  });
+
+  expect(normalizeReqPath('../../../', '/mf-dep_xxxxxx.js')).toStrictEqual({
+    isMfAssets: true,
+    normalPublicPath: '/',
+    fileRelativePath: 'mf-dep_xxxxxx.js',
+  });
+
+  // not mfsu asserts
+  expect(
+    normalizeReqPath('../../../', '/a/b/c/mf-dep_xxxxxx.js'),
+  ).toStrictEqual({
+    isMfAssets: false,
+    normalPublicPath: '/',
+    fileRelativePath: 'a/b/c/mf-dep_xxxxxx.js',
+  });
+
+  // publicPath should be normalized as '/xxx/xxx/'
+  expect(
+    normalizeReqPath('./public_path/', '/public_path/mf-dep_xxxxxx.js'),
+  ).toStrictEqual({
+    isMfAssets: true,
+    normalPublicPath: '/public_path/',
+    fileRelativePath: 'mf-dep_xxxxxx.js',
+  });
+
+  expect(
+    normalizeReqPath('../../public_path/', '/public_path/mf-dep_xxxxxx.js'),
+  ).toStrictEqual({
+    isMfAssets: true,
+    normalPublicPath: '/public_path/',
+    fileRelativePath: 'mf-dep_xxxxxx.js',
+  });
+
+  expect(
+    normalizeReqPath(
+      './public_path/a/b/c/',
+      '/public_path/a/b/c/mf-static/cfile.html',
+    ),
+  ).toStrictEqual({
+    isMfAssets: true,
+    normalPublicPath: '/public_path/a/b/c/',
+    fileRelativePath: 'mf-static/cfile.html',
+  });
+
+  // not mfsu asserts
+  expect(
+    normalizeReqPath('./public_path/', '/public_path/a/b/c/mf-dep_xxxxxx.js'),
+  ).toStrictEqual({
+    isMfAssets: false,
+    normalPublicPath: '/public_path/',
+    fileRelativePath: 'a/b/c/mf-dep_xxxxxx.js',
+  });
+
+  // publicPath with hosts
+  expect(
+    normalizeReqPath(
+      'http://10.0.0.111/public_path/a/b/c/',
+      '/public_path/a/b/c/mf-static/cfile.html',
+    ),
+  ).toStrictEqual({
+    isMfAssets: true,
+    normalPublicPath: '/public_path/a/b/c/',
+    fileRelativePath: 'mf-static/cfile.html',
+  });
+
+  expect(
+    normalizeReqPath(
+      'http://umijs.org/public_path/a/b/c/',
+      '/public_path/a/b/c/mf-static/cfile.html',
+    ),
+  ).toStrictEqual({
+    isMfAssets: true,
+    normalPublicPath: '/public_path/a/b/c/',
+    fileRelativePath: 'mf-static/cfile.html',
+  });
+
+  // not mfsu asserts
+  expect(
+    normalizeReqPath('http://umijs.org/', '/a/b/c/mf-static/cfile.html'),
+  ).toStrictEqual({
+    isMfAssets: false,
+    normalPublicPath: '/',
+    fileRelativePath: 'a/b/c/mf-static/cfile.html',
+  });
 });

--- a/packages/preset-built-in/src/plugins/features/mfsu/mfsu.test.ts
+++ b/packages/preset-built-in/src/plugins/features/mfsu/mfsu.test.ts
@@ -28,27 +28,46 @@ test('functions: get mfsu path', () => {
 
 test('normalizeReqPath', () => {
   // publicPath should be normalized as '/'
-  expect(normalizeReqPath('/', '/mf-va_xxxxxxxxxxx.js')).toStrictEqual({
+  expect(
+    normalizeReqPath(
+      { config: { publicPath: '/' } } as IApi,
+      '/mf-va_xxxxxxxxxxx.js',
+    ),
+  ).toStrictEqual({
     isMfAssets: true,
     normalPublicPath: '/',
     fileRelativePath: 'mf-va_xxxxxxxxxxx.js',
   });
 
-  expect(normalizeReqPath('./', '/mf-dep_xxxxxx.js')).toStrictEqual({
+  expect(
+    normalizeReqPath(
+      { config: { publicPath: './' } } as IApi,
+      '/mf-dep_xxxxxx.js',
+    ),
+  ).toStrictEqual({
     isMfAssets: true,
     normalPublicPath: '/',
     fileRelativePath: 'mf-dep_xxxxxx.js',
   });
 
-  expect(normalizeReqPath('../../../', '/mf-dep_xxxxxx.js')).toStrictEqual({
+  expect(
+    normalizeReqPath(
+      { config: { publicPath: '../../../' } } as IApi,
+      '/mf-dep_xxxxxx.js',
+    ),
+  ).toStrictEqual({
     isMfAssets: true,
     normalPublicPath: '/',
     fileRelativePath: 'mf-dep_xxxxxx.js',
   });
 
   // not mfsu asserts
+
   expect(
-    normalizeReqPath('../../../', '/a/b/c/mf-dep_xxxxxx.js'),
+    normalizeReqPath(
+      { config: { publicPath: '../../../' } } as IApi,
+      '/a/b/c/mf-dep_xxxxxx.js',
+    ),
   ).toStrictEqual({
     isMfAssets: false,
     normalPublicPath: '/',
@@ -57,15 +76,10 @@ test('normalizeReqPath', () => {
 
   // publicPath should be normalized as '/xxx/xxx/'
   expect(
-    normalizeReqPath('./public_path/', '/public_path/mf-dep_xxxxxx.js'),
-  ).toStrictEqual({
-    isMfAssets: true,
-    normalPublicPath: '/public_path/',
-    fileRelativePath: 'mf-dep_xxxxxx.js',
-  });
-
-  expect(
-    normalizeReqPath('../../public_path/', '/public_path/mf-dep_xxxxxx.js'),
+    normalizeReqPath(
+      { config: { publicPath: './public_path/' } } as IApi,
+      '/public_path/mf-dep_xxxxxx.js',
+    ),
   ).toStrictEqual({
     isMfAssets: true,
     normalPublicPath: '/public_path/',
@@ -74,7 +88,18 @@ test('normalizeReqPath', () => {
 
   expect(
     normalizeReqPath(
-      './public_path/a/b/c/',
+      { config: { publicPath: '../../public_path/' } } as IApi,
+      '/public_path/mf-dep_xxxxxx.js',
+    ),
+  ).toStrictEqual({
+    isMfAssets: true,
+    normalPublicPath: '/public_path/',
+    fileRelativePath: 'mf-dep_xxxxxx.js',
+  });
+
+  expect(
+    normalizeReqPath(
+      { config: { publicPath: './public_path/a/b/c/' } } as IApi,
       '/public_path/a/b/c/mf-static/cfile.html',
     ),
   ).toStrictEqual({
@@ -84,8 +109,12 @@ test('normalizeReqPath', () => {
   });
 
   // not mfsu asserts
+
   expect(
-    normalizeReqPath('./public_path/', '/public_path/a/b/c/mf-dep_xxxxxx.js'),
+    normalizeReqPath(
+      { config: { publicPath: './public_path/' } } as IApi,
+      '/public_path/a/b/c/mf-dep_xxxxxx.js',
+    ),
   ).toStrictEqual({
     isMfAssets: false,
     normalPublicPath: '/public_path/',
@@ -95,7 +124,9 @@ test('normalizeReqPath', () => {
   // publicPath with hosts
   expect(
     normalizeReqPath(
-      'http://10.0.0.111/public_path/a/b/c/',
+      {
+        config: { publicPath: 'http://10.0.0.111/public_path/a/b/c/' },
+      } as IApi,
       '/public_path/a/b/c/mf-static/cfile.html',
     ),
   ).toStrictEqual({
@@ -106,7 +137,7 @@ test('normalizeReqPath', () => {
 
   expect(
     normalizeReqPath(
-      'http://umijs.org/public_path/a/b/c/',
+      { config: { publicPath: 'http://umijs.org/public_path/a/b/c/' } } as IApi,
       '/public_path/a/b/c/mf-static/cfile.html',
     ),
   ).toStrictEqual({
@@ -116,8 +147,12 @@ test('normalizeReqPath', () => {
   });
 
   // not mfsu asserts
+
   expect(
-    normalizeReqPath('http://umijs.org/', '/a/b/c/mf-static/cfile.html'),
+    normalizeReqPath(
+      { config: { publicPath: 'http://umijs.org/' } } as IApi,
+      '/a/b/c/mf-static/cfile.html',
+    ),
   ).toStrictEqual({
     isMfAssets: false,
     normalPublicPath: '/',

--- a/packages/preset-built-in/src/plugins/features/mfsu/mfsu.ts
+++ b/packages/preset-built-in/src/plugins/features/mfsu/mfsu.ts
@@ -51,12 +51,12 @@ export const getMfsuPath = (api: IApi, { mode }: { mode: TMode }) => {
   }
 };
 
-export const normalizeReqPath = (configPublicPath: string, reqPath: string) => {
-  let normalPublicPath = '';
-  if (configPublicPath.startsWith('http')) {
-    normalPublicPath = new URL(configPublicPath).pathname;
+export const normalizeReqPath = (api: IApi, reqPath: string) => {
+  let normalPublicPath = api.config.publicPath as string;
+  if (/^https?\:\/\//.test(normalPublicPath)) {
+    normalPublicPath = new URL(normalPublicPath).pathname;
   } else {
-    normalPublicPath = configPublicPath.replace(/^(?:\.+\/?)+/, '/'); // normalPublicPath should start with '/'
+    normalPublicPath = normalPublicPath.replace(/^(?:\.+\/?)+/, '/'); // normalPublicPath should start with '/'
   }
   const isMfAssets =
     reqPath.startsWith(`${normalPublicPath}mf-va_`) ||
@@ -277,10 +277,7 @@ export default function (api: IApi) {
   api.addBeforeMiddlewares(() => {
     return (req, res, next) => {
       const path = req.path;
-      const { isMfAssets, fileRelativePath } = normalizeReqPath(
-        api.config.publicPath as string,
-        req.path,
-      );
+      const { isMfAssets, fileRelativePath } = normalizeReqPath(api, req.path);
       if (isMfAssets) {
         depBuilder.onBuildComplete(() => {
           const mfsuPath = getMfsuPath(api, { mode: 'development' });

--- a/packages/preset-built-in/src/plugins/features/mfsu/mfsu.ts
+++ b/packages/preset-built-in/src/plugins/features/mfsu/mfsu.ts
@@ -51,6 +51,27 @@ export const getMfsuPath = (api: IApi, { mode }: { mode: TMode }) => {
   }
 };
 
+export const normalizeReqPath = (configPublicPath: string, reqPath: string) => {
+  let normalPublicPath = '';
+  if (configPublicPath.startsWith('http')) {
+    normalPublicPath = new URL(configPublicPath).pathname;
+  } else {
+    normalPublicPath = configPublicPath.replace(/^(?:\.+\/?)+/, '/'); // normalPublicPath should start with '/'
+  }
+  const isMfAssets =
+    reqPath.startsWith(`${normalPublicPath}mf-va_`) ||
+    reqPath.startsWith(`${normalPublicPath}mf-dep_`) ||
+    reqPath.startsWith(`${normalPublicPath}mf-static/`);
+  const fileRelativePath = reqPath
+    .replace(new RegExp(`^${normalPublicPath}`), '/')
+    .slice(1);
+  return {
+    isMfAssets,
+    normalPublicPath,
+    fileRelativePath,
+  };
+};
+
 export default function (api: IApi) {
   const webpackAlias = {};
   const webpackExternals = {};
@@ -256,21 +277,17 @@ export default function (api: IApi) {
   api.addBeforeMiddlewares(() => {
     return (req, res, next) => {
       const path = req.path;
-      // we should remove the first "." to prevent incorrect target such as: ./mf-va_.
-      // because we usually set publicPath: ./ for electron app
-      const publicPath = (api.config.publicPath as string).startsWith('./') ? '/' : api.config.publicPath;
-
-      if (
-        path.startsWith(`${publicPath}mf-va_`) ||
-        path.startsWith(`${publicPath}mf-dep_`) ||
-        path.startsWith(`${publicPath}mf-static/`)
-      ) {
+      const { isMfAssets, fileRelativePath } = normalizeReqPath(
+        api.config.publicPath as string,
+        req.path,
+      );
+      if (isMfAssets) {
         depBuilder.onBuildComplete(() => {
-          const filePath = path
-            .replace(new RegExp(`^${publicPath}`), '/')
-            .slice(1);
           const mfsuPath = getMfsuPath(api, { mode: 'development' });
-          const content = readFileSync(join(mfsuPath, filePath), 'utf-8');
+          const content = readFileSync(
+            join(mfsuPath, fileRelativePath),
+            'utf-8',
+          );
           res.setHeader('content-type', mime.lookup(parse(path || '').ext));
           // 排除入口文件，因为 hash 是入口文件控制的
           if (!/remoteEntry.js/.test(req.url)) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

-  添加更为通用的`publicPath`适配
mfsu模式下, 由于`api.config.publicPath = 'http://10.0.0.1:10086/'`导致开发环境无法获取`mfsu`相关静态资源.

与 #7013 遇到的情况是一类问题, 只是我这边的情况更为特殊, `publicPath`需要设置成本机`ip`对应的绝对地址, 不能直接设置成`./`或`/`.


说一下我的使用场景:

1.  微前端qiankun主容器是常年部署到一个固定的环境中, 域名是`http://a.work.co`
2.  开发子应用时是在本地启动的服务,  假设本地ip是`10.0.0.1`
3.  如果`publicPath`设置成了`/`或者`./`等相对路径, `webpack runtime`在请求资源时会以`http://a.work.co`为base, 导致无法请求本机上的资源.
      -  我的项目也不方便开启`runTimePublicPath`配置. (因为我的项目中`html`文件不是`umi`自动生成的, 所以开了也不顶用)
4. 所以直截了当的方式是在开发环境把`publicPath`设置一个绝对地址, 比如: `http://10.0.0.1:10086/`这种形式顺利访问本机资源

