### PR TITLE
optimize tip for `umi plugin`

### DIFF
--- a/packages/preset-built-in/src/plugins/commands/plugin/plugin.ts
+++ b/packages/preset-built-in/src/plugins/commands/plugin/plugin.ts
@@ -14,6 +14,15 @@ $ umi plugin list --key
     `.trim(),
     fn({ args }) {
       const command = args._[0];
+      
+      if (!command) {
+        throw new Error(`
+Sub command not found: umi plugin
+Did you mean:
+  umi plugin list
+        `)
+      }
+      
       switch (command) {
         case 'list':
           list();


### PR DESCRIPTION
if user just run `umi plugin`, they will get a more friendly error message