### PR TITLE
fix: mfsu problem with node built-in modules

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -830,6 +830,7 @@ Contains sub-attributes
 - mfName： `string`。指定预编译依赖的变量名，默认为 `mf`，比如可在 qiankun 主应用里配置
 - exportAllMembers
 - chunks: `string[]`。mfsu 阶段的 chunks 写死了 `['umi']`，可通过此配置项强行修改
+- ignoreNodeBuiltInModules: `boolean`。配为 `true` 时不预编译 node 原生包，适用于 electron renderer
 
 ```js
 mfsu: {

--- a/docs/config/README.zh-CN.md
+++ b/docs/config/README.zh-CN.md
@@ -829,6 +829,7 @@ export default {
 - mfName： `string`。指定预编译依赖的变量名，默认为 `mf`，比如可在 qiankun 主应用里配置
 - exportAllMembers
 - chunks: `string[]`。mfsu 阶段的 chunks 写死了 `['umi']`，可通过此配置项强行修改
+- ignoreNodeBuiltInModules: `boolean`。配为 `true` 时不预编译 node 原生包，适用于 electron renderer
 
 ```js
 mfsu: {

--- a/packages/preset-built-in/src/plugins/features/mfsu/DepBuilder.ts
+++ b/packages/preset-built-in/src/plugins/features/mfsu/DepBuilder.ts
@@ -105,7 +105,15 @@ export default class DepBuilder {
               normalizeDepPath(`${MF_VA_PREFIX}${dep}.js`, this.api.cwd),
             ),
           ),
-          [await figureOutExport(this.api.cwd, winPath(requireFrom)), '']
+          [
+            await figureOutExport(
+              this.api.cwd,
+              winPath(requireFrom),
+              // @ts-ignore
+              !!this.api.config.mfsu!.ignoreNodeBuiltInModules,
+            ),
+            '',
+          ]
             .join('\n')
             .trimLeft(),
           'utf-8',

--- a/packages/preset-built-in/src/plugins/features/mfsu/mfsu.ts
+++ b/packages/preset-built-in/src/plugins/features/mfsu/mfsu.ts
@@ -171,6 +171,7 @@ export default function (api: IApi) {
             mfName: joi.string(),
             exportAllMembers: joi.object(),
             chunks: joi.array().items(joi.string()),
+            ignoreNodeBuiltInModules: joi.boolean(),
           })
           .description('open mfsu feature');
       },

--- a/packages/preset-built-in/src/plugins/features/mfsu/utils.ts
+++ b/packages/preset-built-in/src/plugins/features/mfsu/utils.ts
@@ -40,6 +40,7 @@ export const copy = (fromDir: string, toDir: string) => {
 export const figureOutExport = async (
   cwd: string,
   importFrom: string,
+  ignoreNodeBuiltInModules?: boolean,
 ): Promise<string> => {
   const absImportFrom = isAbsolute(importFrom)
     ? importFrom
@@ -51,10 +52,18 @@ export const figureOutExport = async (
 
   // useful while running with target = electron-renderer
   if (isNodeBuiltinModule) {
-    return Promise.resolve(`
-    const _ = require('${importFrom}');
-    module.exports = _;
-    `);
+    if (ignoreNodeBuiltInModules) {
+      return `
+const _ = require('${importFrom}');
+module.exports = _;
+      `;
+    } else {
+      return [
+        `import _ from '${importFrom}';`,
+        `export default _;`,
+        `export * from '${importFrom}';`,
+      ].join('\n');
+    }
   }
 
   assert(filePath, `filePath not found of ${importFrom}`);

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -377,6 +377,7 @@ export interface BaseIConfig extends IConfigCore {
     exportAllMembers?: Record<string, string[]>;
     mfName?: string;
     chunks?: string[];
+    ignoreNodeBuiltInModules?: boolean;
   };
   metas?: Partial<HTMLMetaElement>[];
   mpa?: object;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- ref: #6932
- 解的问题是 `import { EventEmitter } from 'events'; console.log(EventEmitter);` 拿到 `undefined` 的问题
- 提供 `mfsu.ignoreNodeBuiltInModules` 配置，忽略 node 原生库


-----
[View rendered docs/config/README.md](https://github.com/umijs/umi/blob/fix/mfsu-node-builtin-modules/docs/config/README.md)
[View rendered docs/config/README.zh-CN.md](https://github.com/umijs/umi/blob/fix/mfsu-node-builtin-modules/docs/config/README.zh-CN.md)