### PR TITLE
fix(preset-built-in): ssr failed with alinode 4

### DIFF
--- a/packages/preset-built-in/src/plugins/features/ssr/ssr.ts
+++ b/packages/preset-built-in/src/plugins/features/ssr/ssr.ts
@@ -12,7 +12,7 @@ import {
   winPath,
 } from '@umijs/utils';
 import assert from 'assert';
-import * as fs from 'fs';
+import fs from 'fs';
 import { EOL } from 'os';
 import * as path from 'path';
 import { performance } from 'perf_hooks';


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

实测下来 alinode v4 中 `promises` 在 `fs` 对象上是不可枚举的，和[文档](https://help.aliyun.com/document_detail/60811.html)中对应的 Node.js v10 的行为不一致，导致 `import * as fs from 'fs'` 经过 babel 编译后在 alinode 环境下无法取得 `fs.promises`、构建会报错，所以改为 `import fs from 'fs'` 以兼容 alinode

测试代码：
```js
// 在原生 Node.js v10.1.0 输出 true，在 alinode v4.8.0 下输出 false
console.log(require('fs').propertyIsEnumerable('promises'));
```