### PR TITLE
docs: umi site isn't md docs in plugin-antd

### DIFF
--- a/docs/plugins/plugin-antd.md
+++ b/docs/plugins/plugin-antd.md
@@ -4,7 +4,6 @@ translateHelp: true
 
 # @umijs/plugin-antd
 
-
 整合 antd 组件库。
 
 ## 启用方式
@@ -17,8 +16,8 @@ translateHelp: true
 
 1. 内置 [antd](https://ant.design/)，目前内置版本是 `^4.0.0`
 2. 内置 [antd-mobile](https://mobile.ant.design/)，目前内置版本是 `^2.3.1`
-2. 基于 [babel-plugin-import](https://github.com/ant-design/babel-plugin-import) 做按需编译
-3. 使用 antd@4 时，可一键切换为暗色主题，见下图
+3. 基于 [babel-plugin-import](https://github.com/ant-design/babel-plugin-import) 做按需编译
+4. 使用 antd@4 时，可一键切换为暗色主题，见下图
 
 ![](https://gw.alipayobjects.com/mdn/rms_08e378/afts/img/A*mYU9R4YFxscAAAAAAAAAAABkARQnAQ)
 
@@ -28,15 +27,15 @@ translateHelp: true
 
 开启暗色主题。
 
-* Type: `boolean`
-* Default: `false`
+- Type: `boolean`
+- Default: `false`
 
 ### compact
 
 开启紧凑主题。
 
-* Type: `boolean`
-* Default: `false`
+- Type: `boolean`
+- Default: `false`
 
 比如：
 
@@ -46,7 +45,7 @@ export default {
     dark: true,
     compact: true,
   },
-}
+};
 ```
 
 启用暗色主题，只有 antd 使用版本 4 时才支持。紧凑主题在 `antd@>4.1.0` 时支持。
@@ -55,8 +54,8 @@ export default {
 
 使用 antd 的全局化配置。
 
-* Type: `object`
-* Default: `{}`
+- Type: `object`
+- Default: `{}`
 
 支持 [ConfigProvider](https://ant.design/components/config-provider-cn/) 的配置。
 
@@ -65,23 +64,25 @@ export default {
 ```js
 export default {
   antd: {
-    config:{
-        componentSize:'small'
-    }
+    config: {
+      componentSize: 'small',
+      prefixCls: 'ant',
+    },
   },
-}
+};
 ```
+
 #### 运行时配置
 
 ##### antd
 
-* Type: `object`
+- Type: `object`
 
 ```typescript
 // src/app.ts
 export const antd = {
-  componentSize:'small'
-}
+  componentSize: 'small',
+};
 ```
 
 ## FAQ


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
https://umijs.org/zh-CN/plugins/plugin-antd 文档不是最新的，缺少 `config`、`antd` 相关配置，需要更新。
- any feature?
- close https://github.com/umijs/umi/ISSUE_URL


-----
[View rendered docs/plugins/plugin-antd.md](https://github.com/thinkingc/umi/blob/docs-antd/docs/plugins/plugin-antd.md)