### PR TITLE
插件开发处的文档关于 config 的描述不清

### DIFF
--- a/docs/plugins/api.zh-CN.md
+++ b/docs/plugins/api.zh-CN.md
@@ -1027,7 +1027,7 @@ api.onGenerateFiles(() => {
 
 注：
 
-- 注册阶段不能获取到，所以不能在外面 `const { config } = api;` 然后在函数体里使用，而是需要在里面通过 `api.paths.cwd` 使用
+- 注册阶段不能获取到，所以不能在外面 `const { config } = api;` 然后在函数体里使用，而是需要在里面通过 `api.config` 使用
 
 ### cwd
 


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

我理解的一个典型自定义插件应该如下，

```javascript
"use strict";

Object.defineProperty(exports, "__esModule", {
  value: true
});
exports.default = _default;

function _default(api) {
 // 启动的时候，比如 $ umi build 会从上往下依次执行
 // 因此 api.describe 执行了，即注册了自己
 // api.modifyHTML 也执行了，但仅注册进回调队列（plugin hooks？），没有实际执行 
  api.describe({
    key: 'mykey',
    config: {
      schema(joi) {
        return joi.object()
          .description('This is my plugin');
      },
    },
  });

  // console.log(api.env);
  // 因此这个时刻没有 api.config，但是有 api.userConfig，即文档中提到的「注」
  console.log(api.config);
  console.log(api.userConfig.head);

  api.modifyHTML(($, { route }) => {
     // umi 会做一系列准备工作，然后依次调用队列里的回调，所以这个时刻 api.config 有了
     console.log(api.config);
     $('h2').addClass('welcome');
     return $;
  });
}
```

文档中可能是笔误和混用了 `const { config } = api` 用法，这个问题没讲清楚。

问题确认的话，我可以来调整一下 commit 格式，还有把另外一个暂时没翻译的英文文档也改了。


-----
[View rendered docs/plugins/api.zh-CN.md](https://github.com/hbrls/umi/blob/patch-1/docs/plugins/api.zh-CN.md)