### PR TITLE
修复仅使用 package.json 的 exports 字段为导出项的模块引用报错

### DIFF
--- a/packages/preset-built-in/src/plugins/features/mfsu/getFilePath.ts
+++ b/packages/preset-built-in/src/plugins/features/mfsu/getFilePath.ts
@@ -37,6 +37,9 @@ function getPathWithPkgJSON(path: string) {
         (pkg.main &&
           (getPathWithExt(join(path, pkg.main)) ||
             getPathWithIndexFile(join(path, pkg.main)))) ||
+        (pkg.exports &&
+          (getPathWithExt(join(path, pkg.exports)) ||
+            getPathWithIndexFile(join(path, pkg.exports)))) ||
         getPathWithExt(indexTarget) ||
         getPathWithIndexFile(indexTarget)
       );


### PR DESCRIPTION
例如引用 lowdb 时会报错「filePath not found of lowdb」
