### PR TITLE
fix: importing modules with exports field of package.json would cause fatal error

### DIFF
--- a/packages/preset-built-in/src/plugins/features/mfsu/getFilePath.ts
+++ b/packages/preset-built-in/src/plugins/features/mfsu/getFilePath.ts
@@ -37,6 +37,9 @@ function getPathWithPkgJSON(path: string) {
         (pkg.main &&
           (getPathWithExt(join(path, pkg.main)) ||
             getPathWithIndexFile(join(path, pkg.main)))) ||
+        (pkg.exports &&
+          (getPathWithExt(join(path, pkg.exports)) ||
+            getPathWithIndexFile(join(path, pkg.exports)))) ||
         getPathWithExt(indexTarget) ||
         getPathWithIndexFile(indexTarget)
       );


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] commit message follows commit guidelines
![image](https://user-images.githubusercontent.com/12469549/136540136-9b438022-3994-4568-98ba-6d4755d9a19d.png)

##### Description of change

例如引用 lowdb 时会报错「filePath not found of lowdb」
For example: importing module `lowdb` would cause fatal error
