### PR TITLE
docs: change pro-layout links

### DIFF
--- a/docs/plugins/plugin-layout.md
+++ b/docs/plugins/plugin-layout.md
@@ -8,7 +8,7 @@ The configuration is turned on.
 
 In order to further reduce the cost of research and development, we tried to build the layout through the umi plug-in. You can have Ant Design's Layout through simple configuration, including navigation and sidebar. So that users do not need to care about the layout.
 
-- The default is Ant Design's Layout [@ant-design/pro-layout](https://www.npmjs.com/package/@ant-design/pro-layout), which supports all its configuration items.
+- The default is Ant Design's Layout [@ant-design/pro-layout](https://procomponents.ant.design/en-US/components/layout), which supports all its configuration items.
 - The sidebar menu data is automatically generated according to the configuration in the route.
 - By default, it supports 403/404 processing and Error Boundary for routing.
 - Used together with @umijs/plugin-access plug-in, you can control routing permissions.

--- a/docs/plugins/plugin-layout.zh-CN.md
+++ b/docs/plugins/plugin-layout.zh-CN.md
@@ -8,7 +8,7 @@
 
 为了进一步降低研发成本，我们尝试将布局通过 umi 插件的方式内置，只需通过简单的配置即可拥有 Ant Design 的 Layout，包括导航以及侧边栏。从而做到用户无需关心布局。
 
-- 默认为 Ant Design 的 Layout [@ant-design/pro-layout](https://www.npmjs.com/package/@ant-design/pro-layout)，支持它全部配置项。
+- 默认为 Ant Design 的 Layout [@ant-design/pro-layout](https://procomponents.ant.design/components/layout/#prolayout)，支持它全部配置项。
 - 侧边栏菜单数据根据路由中的配置自动生成。
 - 默认支持对路由的 403/404 处理和 Error Boundary。
 - 搭配 @umijs/plugin-access 插件一起使用，可以完成对路由权限的控制。


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
<img width="945" alt="WX20211105-135951@2x" src="https://user-images.githubusercontent.com/8730698/140465410-08f9435a-c9be-4a03-86cf-228baa08bf49.png">

pro-layout链接应该跳转到使用文档，而不是npm包链接
