### PR TITLE
feat(babel-preset-umi): ✨ 添加react版本检测

### DIFF
--- a/packages/babel-preset-umi/node.js
+++ b/packages/babel-preset-umi/node.js
@@ -1,14 +1,14 @@
 const { semver } = require('@umijs/utils')
 
 const isReact17 = () => {
-  let react;
+  let _react;
   try {
-    react = require(require.resolve('react', {paths: [api.cwd]}));
+    _react = require(require.resolve('react', {paths: [api.cwd]}));
   } catch (e) {
   }
   return (
-    semver.valid(react.version) &&
-    semver.gte(react.version, '17.0.0-alpha.0')
+    semver.valid(_react && _react.version) &&
+    semver.gte(_react.version, '17.0.0-alpha.0')
   );
 };
 

--- a/packages/babel-preset-umi/node.js
+++ b/packages/babel-preset-umi/node.js
@@ -1,3 +1,17 @@
+const { semver } = require('@umijs/utils')
+
+const isReact17 = () => {
+  let react;
+  try {
+    react = require(require.resolve('react', {paths: [api.cwd]}));
+  } catch (e) {
+  }
+  return (
+    semver.valid(react.version) &&
+    semver.gte(react.version, '17.0.0-alpha.0')
+  );
+};
+
 module.exports = function (api, opts) {
   return {
     presets: [
@@ -6,7 +20,7 @@ module.exports = function (api, opts) {
         require('@umijs/utils').deepmerge(
           {
             typescript: true,
-            react: true,
+            react: isReact17() ? {runtime: 'automatic'} : true,
             env: {
               targets: {
                 node: 'current',


### PR DESCRIPTION
✨ 在node.js文件的配置中添加对当前react是否>=17版本的检测，以添加对react17版本JSX转译的支持

silence_zhpf

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] commit message follows commit guidelines

##### Description of change

✨ 在node.js文件的配置中添加对当前react是否>=17版本的检测，以添加对react17版本JSX转译的支持