### PR TITLE
feat: chainWebpack方法增加config参数

### DIFF
--- a/packages/bundler-webpack/src/getConfig/getConfig.ts
+++ b/packages/bundler-webpack/src/getConfig/getConfig.ts
@@ -119,7 +119,7 @@ export default async function getConfig(
     .path(absOutputPath)
     .filename(useHash ? `[name].[contenthash:8].js` : `[name].js`)
     .chunkFilename(useHash ? `[name].[contenthash:8].async.js` : `[name].js`)
-    .publicPath(config.publicPath! as unknown as string)
+    .publicPath((config.publicPath! as unknown) as string)
     .pathinfo(isDev || disableCompress);
 
   if (!isWebpack5) {
@@ -606,6 +606,7 @@ export default async function getConfig(
       mfsu,
       webpack: bundleImplementor,
       createCSSRule: createCSSRuleFn,
+      config,
     });
   }
   // 用户配置的 chainWebpack 优先级最高
@@ -617,6 +618,7 @@ export default async function getConfig(
       // @ts-ignore
       webpack: bundleImplementor,
       createCSSRule: createCSSRuleFn,
+      config,
     });
   }
   let ret = webpackConfig.toConfig() as defaultWebpack.Configuration;


### PR DESCRIPTION

##### Checklist
- [x] `npm test` passes
- [x] tests are included
- [x] commit message follows commit guidelines

##### Description of change
chainWebpack回调函数目前接收五个参数，分别为memo，env，webpack，createCSSRule，type。此次修改将config配置通过回调函数参数传出。在umi的config文件中，有些参数的值需要依赖一些接口或者其他方法动态获取，但是目前不支持动态修改，所以在chainWebpack中将config参数传出，即可动态修改config配置。
