### PR TITLE
dep: upgrade @types/react-router-*

### DIFF
--- a/packages/preset-built-in/package.json
+++ b/packages/preset-built-in/package.json
@@ -25,7 +25,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@types/react-router-config": "5.0.2",
+    "@types/react-router-config": "5.0.6",
     "@umijs/babel-preset-umi": "3.5.20",
     "@umijs/bundler-webpack": "3.5.20",
     "@umijs/deps": "3.5.20",

--- a/packages/renderer-react/package.json
+++ b/packages/renderer-react/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@types/react": "^16.9.43",
     "@types/react-dom": "^16.9.8",
-    "@types/react-router-config": "^5.0.2",
+    "@types/react-router-config": "^5.0.6",
     "@umijs/runtime": "3.5.20",
     "react-router-config": "5.1.1"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -25,8 +25,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@types/react-router": "5.1.12",
-    "@types/react-router-dom": "5.1.7",
+    "@types/react-router": "5.1.18",
+    "@types/react-router-dom": "5.3.3",
     "history-with-query": "4.10.4",
     "react-router": "5.2.0",
     "react-router-dom": "5.2.0",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->


[@types/history](https://www.npmjs.com/package/@types/history) has been deprecated, and the related changes which were made in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58216 would cause installation of wrong version of `history` (always the latest).

Related packages were upgraded to make sure that correct version of `@types/history` would be installed.

@types/react-router             -> 5.1.18
@types/react-router-dom    -> 5.3.3
@types/react-router-config -> 5.0.6

