### PR TITLE
fix(babel-preset-umi): correct absoluteRuntime option

### DIFF
--- a/packages/babel-preset-umi/src/index.ts
+++ b/packages/babel-preset-umi/src/index.ts
@@ -128,9 +128,10 @@ export default (context: any, opts: IOpts = {}) => {
           // https://babeljs.io/docs/en/babel-plugin-transform-runtime#absoluteruntime
           // lock the version of @babel/runtime
           // make sure we are using the correct version
-          absoluteRuntime: dirname(
-            require.resolve('@babel/runtime/package.json'),
-          ),
+          // this path will be used by babel like `require.resolve(path, { paths: [absoluteRuntime] })`
+          // so we need to place the absolute path of this package
+          // refer: https://github.com/babel/babel/blob/v7.16.12/packages/babel-plugin-transform-runtime/src/get-runtime-path/index.ts#L19
+          absoluteRuntime: dirname(require.resolve('../package.json')),
           // https://babeljs.io/docs/en/babel-plugin-transform-runtime#useesmodules
           useESModules: true,
           ...toObject(opts.transformRuntime),


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

修复 `src/.umi` 下 babel 缓存过期导致项目启动失败的问题，过期的原因是 cache 中记录的 `@babel/runtime` 版本是用户上一次安装的版本，在重装依赖后 cache 继续找上一个版本，但包已经没有了。

但这里有另一个问题，Umi 层对 `@babel/runtime` 做过[锁定](https://github.com/umijs/umi/blob/master/packages/babel-preset-umi/src/index.ts#L131)但并未生效，原因是 `@babel/plugin-transform-runtime` 内部在使用 `absoluteRuntime` 这项配置时用了 `require.resolve(path, { paths: [absoluteRuntime] })` 的方式，所以要传入锁定 `@babel/runtime` 的包（即 `@umijs/babel-preset-umi`）的绝对路径才能奏效。

refer: https://github.com/babel/babel/blob/v7.16.12/packages/babel-plugin-transform-runtime/src/get-runtime-path/index.ts#L19