### PR TITLE
refactor(babel-preset-umi): enable unicode-regex

### DIFF
--- a/packages/babel-preset-umi/src/index.ts
+++ b/packages/babel-preset-umi/src/index.ts
@@ -35,7 +35,6 @@ export default (context: any, opts: IOpts = {}) => {
   const defaultEnvConfig = {
     exclude: [
       'transform-typeof-symbol',
-      'transform-unicode-regex',
       'transform-sticky-regex',
       'transform-new-target',
       'transform-modules-umd',

--- a/packages/bundler-webpack/src/fixtures/unicode-regex/expect.ts
+++ b/packages/bundler-webpack/src/fixtures/unicode-regex/expect.ts
@@ -1,0 +1,7 @@
+import { IExpectOpts } from '../types';
+
+export default ({ indexJS }: IExpectOpts) => {
+  // no unicode regex
+  expect(indexJS).not.toContain(`/u);`);
+  expect(indexJS).not.toContain(`/ug);`);
+};

--- a/packages/bundler-webpack/src/fixtures/unicode-regex/index.ts
+++ b/packages/bundler-webpack/src/fixtures/unicode-regex/index.ts
@@ -1,0 +1,5 @@
+// unicode character syntax
+console.log(/[\u{20000}-\u{2a6df}]/u);
+
+// unicode mark syntax
+console.log(/\p{Script=Han}+|\p{Punctuation}/ug);


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

目前遇到两个 cases 会用到这个插件，所以重新开启：
1. IE11 等传统浏览器对 unicode 字符集的支持问题，`Invalid range in character set error`，refer: https://stackoverflow.com/a/51031050
2. 常规 Umi 项目中如果使用了部分 unicode 正则写法（例如：`/\p{Script=Han}+|\p{Punctuation}/ug`）也会导致 babel 编译失败