### PR TITLE
fix: allowDeclareFields to support declare

### DIFF
--- a/packages/babel-preset-umi/src/index.ts
+++ b/packages/babel-preset-umi/src/index.ts
@@ -62,6 +62,7 @@ export default (context: any, opts: IOpts = {}) => {
         {
           // https://babeljs.io/docs/en/babel-plugin-transform-typescript#impartial-namespace-support
           allowNamespaces: true,
+          allowDeclareFields: true,
         },
       ],
     ].filter(Boolean),


### PR DESCRIPTION
use declare to type context is recommend after ts 3.7, but in @babel/preset-typescript@7.x, it will be supported after enable allowDeclareFields
https://babeljs.io/docs/en/babel-preset-typescript#allowdeclarefields

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
