### PR TITLE
feat(loadable): replace loaded dynamic component ref to it's own ref

### DIFF
--- a/packages/runtime/src/dynamic/loadable.js
+++ b/packages/runtime/src/dynamic/loadable.js
@@ -29,6 +29,7 @@ import {
   useContext,
   useImperativeHandle,
   forwardRef,
+  useRef,
 } from 'react';
 import { useSubscription } from 'use-subscription';
 import { LoadableContext } from './loadable-context';
@@ -171,10 +172,11 @@ function createLoadableComponent(loadFn, options) {
 
     const context = useContext(LoadableContext);
     const state = useSubscription(subscription);
-
-    useImperativeHandle(ref, () => ({
+    const refObj = useRef({
       retry: subscription.retry,
-    }));
+    })
+
+    useImperativeHandle(ref, () => refObj.current);
 
     if (context && Array.isArray(opts.modules)) {
       opts.modules.forEach((moduleName) => {
@@ -186,6 +188,7 @@ function createLoadableComponent(loadFn, options) {
       if (process.env.NODE_ENV === 'development' && state.error) {
         console.error(`[@umijs/runtime] load component failed`, state.error);
       }
+
       return createElement(opts.loading, {
         isLoading: state.loading,
         pastDelay: state.pastDelay,
@@ -194,7 +197,7 @@ function createLoadableComponent(loadFn, options) {
         retry: subscription.retry,
       });
     } else if (state.loaded) {
-      return opts.render(state.loaded, props);
+      return opts.render(state.loaded, {...props, ref: refObj});
     } else {
       return null;
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

动态加载的组件之前无法获取到组件的ref，只能获取到dynamic的`retry`。

修改后如果组件未加载成功则获取到的ref与之前一样，加载成功后ref变为动态加载组件的ref。

相关问题：

#5658

#5287

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
