### PR TITLE
fix(deps): unicode regex compile failed due to phantom dep

### DIFF
--- a/packages/deps/package.json
+++ b/packages/deps/package.json
@@ -41,7 +41,8 @@
     "clipboardy": "2.3.0",
     "esbuild": "0.12.15",
     "jest-worker": "24.9.0",
-    "prettier": "2.2.1"
+    "prettier": "2.2.1",
+    "regenerate-unicode-properties": "9.0.0"
   },
   "devDependencies": {
     "@babel/code-frame": "7.12.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15116,6 +15116,13 @@ redeyed@~2.1.0:
   dependencies:
     esprima "~4.0.0"
 
+regenerate-unicode-properties@9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-9.0.0.tgz#54d09c7115e1f53dc2314a974b32c1c344efe326"
+  integrity sha512-3E12UeNSPfjrgwjkR81m5J7Aw/T55Tu7nUyZVQYCKEOs+2dkxEY+DpPtZzO4YruuiPb7NkYLVcyJC4+zCbk5pA==
+  dependencies:
+    regenerate "^1.4.2"
+
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz#e5de7111d655e7ba60c057dbe9ff37c87e65cdec"
@@ -15123,7 +15130,7 @@ regenerate-unicode-properties@^8.2.0:
   dependencies:
     regenerate "^1.4.0"
 
-regenerate@^1.4.0:
+regenerate@^1.4.0, regenerate@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Description of change

修复由于幽灵依赖 `regenerate-unicode-properties` 引起的 unicode 正则编译失败的问题，锁定 `regenerate-unicode-properties` 在依赖预打包时的 `9.0.0` 版本，确保 `compiled/babel/bundle.js` 中的代码始终能 require 到正确的版本

ref: #7837 
