### PR TITLE
fix(preset-built-in): fix addRuntimePlugin use absolute path

### DIFF
--- a/packages/preset-built-in/src/plugins/generateFiles/core/plugin.ts
+++ b/packages/preset-built-in/src/plugins/generateFiles/core/plugin.ts
@@ -1,7 +1,7 @@
 import { IApi } from '@umijs/types';
 import { getFile, winPath } from '@umijs/utils';
 import { readFileSync } from 'fs';
-import { join } from 'path';
+import { join, relative } from 'path';
 import { runtimePath } from '../constants';
 
 export default function (api: IApi) {
@@ -24,15 +24,21 @@ export default function (api: IApi) {
       ],
     });
 
-    const appRuntimeFileName = getFile({
+    const appRuntimeFilePath = getFile({
       base: paths.absSrcPath!,
       fileNameWithoutExt: 'app',
       type: 'javascript',
-    })?.filename;
+    })?.path;
     const plugins = await api.applyPlugins({
       key: 'addRuntimePlugin',
       type: api.ApplyPluginsType.add,
-      initialValue: appRuntimeFileName ? [`../../${appRuntimeFileName}`] : [],
+      initialValue: appRuntimeFilePath
+        ? [
+            api.utils.winPath(
+              relative(join(api.paths.absTmpPath!, 'core'), appRuntimeFilePath),
+            ),
+          ]
+        : [],
     });
 
     api.writeTmpFile({

--- a/packages/preset-built-in/src/plugins/generateFiles/core/plugin.ts
+++ b/packages/preset-built-in/src/plugins/generateFiles/core/plugin.ts
@@ -23,17 +23,18 @@ export default function (api: IApi) {
         '__mfsu',
       ],
     });
+
+    const appRuntimeFileName = getFile({
+      base: paths.absSrcPath!,
+      fileNameWithoutExt: 'app',
+      type: 'javascript',
+    })?.filename;
     const plugins = await api.applyPlugins({
       key: 'addRuntimePlugin',
       type: api.ApplyPluginsType.add,
-      initialValue: [
-        getFile({
-          base: paths.absSrcPath!,
-          fileNameWithoutExt: 'app',
-          type: 'javascript',
-        })?.path,
-      ].filter(Boolean),
+      initialValue: appRuntimeFileName ? [`../../${appRuntimeFileName}`] : [],
     });
+
     api.writeTmpFile({
       path: 'core/plugin.ts',
       content: Mustache.render(


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm test` passes
- [X] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- close https://github.com/umijs/umi/issues/7000

解决了打包产物包含绝对路径的问题，我在app.ts和 plugin-dva遇到了，然后在issue里发现还有已知的plugin-locale
app.ts的在这个MR解决，另外两个在plugin的仓库提交PR解决

