### PR TITLE
feat: 增加非 css-module 的样式文件中对 `:global` 语法的支持

### DIFF
--- a/packages/bundler-webpack/src/getConfig/css.ts
+++ b/packages/bundler-webpack/src/getConfig/css.ts
@@ -82,6 +82,7 @@ export function createCSSRule({
       .loader(require.resolve('@umijs/deps/compiled/css-loader'))
       .options(
         deepmerge(
+          // @ts-ignore
           {
             importLoaders: 1,
             // https://webpack.js.org/loaders/css-loader/#onlylocals
@@ -92,7 +93,7 @@ export function createCSSRule({
                     localIdentName: '[local]___[hash:base64:5]',
                   },
                 }
-              : {}),
+              : { modules: 'global' }),
           },
           config.cssLoader || {},
         ),


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

之前使用 umi 2.x 时我记得 `import './styles.less'` 时（即非 css modules 的 `import` 时），`styles.less` 文件中是可以使用 `:global` 语法的，但 umi 3.x 不支持了，考虑应该是 `css-loader` 版本升级后出现的问题，经过一番尝试后发现可以通过将非 css modules 时的 `css-loader` 的 `options` 增加 `modules: 'global'` 配置就能解决问题。

虽然在非 css modules 导入的样式文件（即被当做 global 样式的样式文件）中使用 `:global` 的 scope 有点点累赘，但为了更好的向下兼容，建议加上此特性。

- 增加非 css-module 的样式文件中对 `:global` 语法的支持
- close https://github.com/umijs/umi/issues/7634
