### PR TITLE
fix: 🐛 walkaround wdm path issue, if cwd contains %xx throw Error.

### DIFF
--- a/packages/bundler-webpack/src/index.ts
+++ b/packages/bundler-webpack/src/index.ts
@@ -200,9 +200,10 @@ class Bundler {
 
     if (cwd !== unescaped) {
       console.error(
-        'Project directory path contains escaped characters, please remove that.\n ref: https://github.com/umijs/umi/issues/8084',
+        `Project directory path "${cwd}" contains escaped characters, please remove that.
+ ref: https://github.com/umijs/umi/issues/8084`,
       );
-      throw Error('path contains escaped char');
+      throw Error('path contains escaped characters');
     }
   }
 }


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes

- [x] commit message follows commit guidelines

##### Description of change

- close https://github.com/umijs/umi/issues/8084

When project cwd path contains escaped characters,  `umi dev ` exits and log the error
