### PR TITLE
build(package.json): 不锁定core-js 版本

### DIFF
--- a/packages/babel-plugin-lock-core-js-3/package.json
+++ b/packages/babel-plugin-lock-core-js-3/package.json
@@ -26,6 +26,6 @@
   },
   "dependencies": {
     "@umijs/utils": "3.5.26",
-    "core-js": "3.6.5"
+    "core-js": "^3.6.5"
   }
 }


### PR DESCRIPTION
为什么要锁定底层包版本啊?  缺少新的Array.prototype.at
