### PR TITLE
feat(plugin-docs): external-link-support-dark

### DIFF
--- a/packages/plugin-docs/client/theme-doc/NavBar.tsx
+++ b/packages/plugin-docs/client/theme-doc/NavBar.tsx
@@ -27,8 +27,7 @@ interface NavItemProps {
 }
 
 function NavItem(props: NavItemProps) {
-  const { components, ...rest } = useThemeContext()!;
-  console.log(rest);
+  const { components } = useThemeContext()!;
   const { nav } = props;
   const lang = useLanguage();
   const [isExpanded, setExpanded] = useState(false);

--- a/packages/plugin-docs/client/theme-doc/NavBar.tsx
+++ b/packages/plugin-docs/client/theme-doc/NavBar.tsx
@@ -27,7 +27,8 @@ interface NavItemProps {
 }
 
 function NavItem(props: NavItemProps) {
-  const { components } = useThemeContext()!;
+  const { components, ...rest } = useThemeContext()!;
+  console.log(rest);
   const { nav } = props;
   const lang = useLanguage();
   const [isExpanded, setExpanded] = useState(false);
@@ -48,7 +49,7 @@ function NavItem(props: NavItemProps) {
         <a href={nav.path} target="_blank">
           <span className="flex">
             {nav.title}
-            <img src={ExternalLink} alt="ExternalLink" />
+            <img className="link-icon" src={ExternalLink} alt="ExternalLink" />
           </span>
         </a>
       ) : (
@@ -77,7 +78,11 @@ function NavItem(props: NavItemProps) {
                     >
                       {nav.title}
                     </span>
-                    <img src={ExternalLink} alt="ExternalLink" />
+                    <img
+                      className="link-icon"
+                      src={ExternalLink}
+                      alt="ExternalLink"
+                    />
                   </span>
                 </a>
               ) : (

--- a/packages/plugin-docs/client/theme-doc/ThemeSwitch.tsx
+++ b/packages/plugin-docs/client/theme-doc/ThemeSwitch.tsx
@@ -39,6 +39,10 @@ export default () => {
         '--color-scheme',
         'light',
       );
+      // @ts-ignore
+      document.querySelectorAll('.link-icon')?.forEach((el: HTMLElement) => {
+        el.style.setProperty('filter', 'invert(0)');
+      });
     } else {
       document.body.classList.add('dark');
       localStorage.setItem('theme', 'dark');
@@ -46,6 +50,12 @@ export default () => {
         '--color-scheme',
         'dark',
       );
+      // @ts-ignore
+      document
+        .querySelectorAll('.link-icon')
+        ?.forEach((el: HTMLImageElement) => {
+          el.style.setProperty('filter', 'invert(1)');
+        });
     }
   }, [toggle]);
 

--- a/packages/plugin-docs/client/theme-doc/ThemeSwitch.tsx
+++ b/packages/plugin-docs/client/theme-doc/ThemeSwitch.tsx
@@ -51,11 +51,9 @@ export default () => {
         'dark',
       );
       // @ts-ignore
-      document
-        .querySelectorAll('.link-icon')
-        ?.forEach((el: HTMLImageElement) => {
-          el.style.setProperty('filter', 'invert(1)');
-        });
+      document.querySelectorAll('.link-icon')?.forEach((el: HTMLElement) => {
+        el.style.setProperty('filter', 'invert(1)');
+      });
     }
   }, [toggle]);
 


### PR DESCRIPTION
- [x] 外跳链接的icon兼容文档的dark模式


![image](https://user-images.githubusercontent.com/29126094/175496763-2f450d7e-5dfc-48ec-8383-f32578ac8a47.png)
