### PR TITLE
chore: add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: 'Bug report（缺陷问题反馈）'
+about: 'Report a bug to help us improve'
+title: '[Bug] say something'
+labels: ''
+assignees: ''
+---
+
+<!--
+⚠️ ⚠️ ⚠️ 注意：讨论和提问请到讨论区（https://github.com/umijs/umi/discussions），否则会被直接关掉。 ⚠️ ⚠️ ⚠️
+-->
+<!--
+感谢您向我们反馈问题，为了高效的解决问题，我们期望你能提供以下信息：
+-->
+
+## What happens?
+
+<!-- A clear and concise description of what the bug is. -->
+<!-- 清晰的描述下遇到的问题。-->
+
+## Mini Showcase Repository(REQUIRED)
+
+> Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) then upload to your GitHub. 请提供 [最小重现](https://stackoverflow.com/help/minimal-reproducible-example)，并上传到你的 GitHub 仓库
+
+<!-- 为节约大家的时间，无复现步骤的 ISSUE 会被关闭，提供之后再 REOPEN -->
+<!-- https://github.com/YOUR_REPOSITORY_URL -->
+
+## How To Reproduce
+
+**Steps to reproduce the behavior:** 1. 2.
+
+**Expected behavior** 1. 2.
+
+<!-- 请提供复现链接/步骤，错误日志以及相关配置 -->
+
+## Context
+
+- **Umi Version**:
+- **Node Version**:
+- **Platform**:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+
+blank_issues_enabled: true
+contact_links:
+  - name: Ask a question（提问和讨论）
+    url: https://github.com/umijs/umi/discussions
+    about: Ask questions and discuss with other community members

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: 'Feature request（新需求）'
+about: 'Suggest an idea for this project'
+title: '[Feature Request] say something'
+labels: ''
+assignees: ''
+---
+
+## Background
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## Proposal
+
+Describe the solution you'd like, better to provide some pseudo code.
+
+## Additional context
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
防止 3 、4 版本的 issue 分不清，3.x 的 issue 模板搬过来了。

-----
[View rendered .github/ISSUE_TEMPLATE/bug_report.md](https://github.com/MoeYc/umi/blob/chore/issue-tpl/.github/ISSUE_TEMPLATE/bug_report.md)
[View rendered .github/ISSUE_TEMPLATE/feature_request.md](https://github.com/MoeYc/umi/blob/chore/issue-tpl/.github/ISSUE_TEMPLATE/feature_request.md)