### PR TITLE
chore(assets): improve svg assets

### DIFF
--- a/docs/docs/api/config.md
+++ b/docs/docs/api/config.md
@@ -910,6 +910,26 @@ styles: [`body { color: red; }`, `https://a.com/b.css`];
 
 配置构建时转译 js/ts 的工具。
 
+## svgr
+
+- 类型：`object`
+- 默认值：`{}`
+
+svgr 默认开启，支持如下方式使用 React svg 组件：
+
+```ts
+import SmileUrl, { ReactComponent as SvgSmile } from './smile.svg';
+```
+
+可配置 svgr 的行为，配置项详见 [@svgr/core > Config](https://github.com/gregberge/svgr/blob/main/packages/core/src/config.ts#L9)。
+
+## svgo
+
+- 类型：`object`
+- 默认值：`{}`
+
+默认使用 svgo 来优化 svg 资源，配置项详见 [svgo](https://github.com/svg/svgo#configuration) 。
+
 ## targets
 
 - 类型：`object`

--- a/packages/bundler-webpack/src/config/assetRules.ts
+++ b/packages/bundler-webpack/src/config/assetRules.ts
@@ -24,9 +24,6 @@ export async function addAssetRules(opts: IOpts) {
       dataUrlCondition: {
         maxSize: inlineLimit,
       },
-    })
-    .generator({
-      filename: `${opts.staticPathPrefix}[name].[hash:8].[ext]`,
     });
 
   rule
@@ -37,9 +34,6 @@ export async function addAssetRules(opts: IOpts) {
       dataUrlCondition: {
         maxSize: inlineLimit,
       },
-    })
-    .generator({
-      filename: `${opts.staticPathPrefix}[name].[hash:8].[ext]`,
     });
 
   const fallback = rule
@@ -52,10 +46,5 @@ export async function addAssetRules(opts: IOpts) {
   if (userConfig.mdx) {
     fallback.add(/\.mdx?$/);
   }
-  fallback
-    .end()
-    .type('asset/resource')
-    .generator({
-      filename: `${opts.staticPathPrefix}[name].[hash:8].[ext]`,
-    });
+  fallback.end().type('asset/resource');
 }

--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -114,7 +114,11 @@ export async function getConfig(opts: IOpts): Promise<Configuration> {
       useHash ? `[name].[contenthash:8].async.js` : `[name].async.js`,
     )
     .publicPath(userConfig.publicPath || 'auto')
-    .pathinfo(isDev || disableCompress);
+    .pathinfo(isDev || disableCompress)
+    .set(
+      'assetModuleFilename',
+      `${applyOpts.staticPathPrefix}[name].[hash:8][ext]`,
+    );
 
   // resolve
   // prettier-ignore

--- a/packages/bundler-webpack/src/config/svgRules.ts
+++ b/packages/bundler-webpack/src/config/svgRules.ts
@@ -44,19 +44,13 @@ export async function addSVGRules(opts: IOpts) {
       .loader(require.resolve('@umijs/bundler-webpack/compiled/url-loader'))
       .end();
   }
-  if (svgo === false) {
+  if (svgo !== false) {
     const svgRule = config.module.rule('svg');
     svgRule
       .test(/\.svg$/)
-      .use('url-loader')
-      .loader(require.resolve('@umijs/bundler-webpack/compiled/url-loader'));
-    return;
+      .use('svgo-loader')
+      .loader(require.resolve('@umijs/bundler-webpack/compiled/svgo-loader'))
+      .options({ configFile: false, ...svgo })
+      .end();
   }
-  const svgRule = config.module.rule('svg');
-  svgRule
-    .test(/\.svg$/)
-    .use('svgo-loader')
-    .loader(require.resolve('@umijs/bundler-webpack/compiled/svgo-loader'))
-    .options({ configFile: false, ...svgo })
-    .end();
 }


### PR DESCRIPTION
1. assets 的名字在 webpack5 全局配置，不需要写重复的配置了。See https://webpack.js.org/guides/asset-modules/#custom-output-filename

2. `svgr: false` 的时候不需要用 url-loader 了，直接会 fallback 到 assets 兜底逻辑

3. 补全 svgr 、svgo 文档