### PR TITLE
fix(qiankun): master lazy load child app entry

### DIFF
--- a/packages/plugins/src/qiankun/master.ts
+++ b/packages/plugins/src/qiankun/master.ts
@@ -54,7 +54,8 @@ export default (api: IApi) => {
         );
         route.file = `(async () => {
           const { getMicroAppRouteComponent } = await import('@@/plugin-qiankun-master/getMicroAppRouteComponent');
-          return getMicroAppRouteComponent({ appName: '${appName}', base: '${base}', routePath: '${route.path}', masterHistoryType: '${masterHistoryType}', routeProps: ${normalizedRouteProps} })
+          const component = getMicroAppRouteComponent({ appName: '${appName}', base: '${base}', routePath: '${route.path}', masterHistoryType: '${masterHistoryType}', routeProps: ${normalizedRouteProps} });
+          return { default: component };
         })()`;
       }
     });

--- a/packages/plugins/src/qiankun/master.ts
+++ b/packages/plugins/src/qiankun/master.ts
@@ -54,8 +54,7 @@ export default (api: IApi) => {
         );
         route.file = `(async () => {
           const { getMicroAppRouteComponent } = await import('@@/plugin-qiankun-master/getMicroAppRouteComponent');
-          const component = getMicroAppRouteComponent({ appName: '${appName}', base: '${base}', routePath: '${route.path}', masterHistoryType: '${masterHistoryType}', routeProps: ${normalizedRouteProps} });
-          return { default: component };
+          return getMicroAppRouteComponent({ appName: '${appName}', base: '${base}', routePath: '${route.path}', masterHistoryType: '${masterHistoryType}', routeProps: ${normalizedRouteProps} })
         })()`;
       }
     });

--- a/packages/preset-umi/src/features/tmpFiles/routes.ts
+++ b/packages/preset-umi/src/features/tmpFiles/routes.ts
@@ -201,6 +201,8 @@ export async function getRouteComponents(opts: {
       // component: (() => () => <h1>foo</h1>)()
       if (route.file.startsWith('(')) {
         return useSuspense
+          // Compatible with none default route exports
+          // e.g. https://github.com/umijs/umi/blob/0d40a07bf28b0760096cbe2f22da4d639645b937/packages/plugins/src/qiankun/master.ts#L55
           ? `'${key}': React.lazy(
               () => Promise.resolve(${route.file}).then(e => e?.default ? e : ({ default: e }))
             ),`

--- a/packages/preset-umi/src/features/tmpFiles/routes.ts
+++ b/packages/preset-umi/src/features/tmpFiles/routes.ts
@@ -201,7 +201,9 @@ export async function getRouteComponents(opts: {
       // component: (() => () => <h1>foo</h1>)()
       if (route.file.startsWith('(')) {
         return useSuspense
-          ? `'${key}': React.lazy(() => Promise.resolve(${route.file})),`
+          ? `'${key}': React.lazy(
+              () => Promise.resolve(${route.file}).then(e => e?.default ? e : ({ default: e }))
+            ),`
           : `'${key}': () => Promise.resolve(${route.file}),`;
       }
 


### PR DESCRIPTION
这里 suspense lazy load 之后，只接受默认导出的组件，修复他。

https://github.com/umijs/umi/blob/b24a0781ff7167c3e5ede6f7fdf43922cc1f52e0/packages/preset-umi/src/features/tmpFiles/routes.ts#L199-L206