### PR TITLE
fix(plugin/locale): add getIntl api

### DIFF
--- a/packages/plugins/src/locale.ts
+++ b/packages/plugins/src/locale.ts
@@ -237,7 +237,7 @@ export default (api: IApi) => {
     api.writeTmpFile({
       path: 'index.ts',
       content: `
-export { setLocale, getLocale, useIntl, injectIntl, formatMessage, FormattedMessage } from './localeExports.ts';
+export { setLocale, getLocale, useIntl, injectIntl, formatMessage, FormattedMessage, getIntl } from './localeExports.ts';
 export { SelectLang } from './SelectLang.tsx';
 `,
     });

--- a/packages/plugins/src/locale.ts
+++ b/packages/plugins/src/locale.ts
@@ -237,7 +237,7 @@ export default (api: IApi) => {
     api.writeTmpFile({
       path: 'index.ts',
       content: `
-export { setLocale, getLocale, useIntl, injectIntl, formatMessage, FormattedMessage, getIntl } from './localeExports.ts';
+export { setLocale, getLocale, getIntl, useIntl, injectIntl, formatMessage, FormattedMessage } from './localeExports.ts';
 export { SelectLang } from './SelectLang.tsx';
 `,
     });


### PR DESCRIPTION
```typescript
import { getIntl, getLocale } from 'umi';

function test() {
  const intl = getIntl(getLocale());
  console.log(
           intl.formatMessage({
              id: 'system.hello',
              description: 'Hello',
            })
  );
}
```

Closes: https://github.com/umijs/umi/issues/8263