### PR TITLE
fix: The parameter [res] is not passed (#8259)

### DIFF
--- a/packages/bundler-webpack/src/server/server.ts
+++ b/packages/bundler-webpack/src/server/server.ts
@@ -172,9 +172,10 @@ export async function createServer(opts: IOpts) {
           createProxyMiddleware(key, {
             ...proxy[key],
             // Add x-real-url in response header
-            onProxyRes(proxyRes, req: any) {
+            onProxyRes(proxyRes, req: any, res) {
               proxyRes.headers['x-real-url'] =
                 new URL(req.url || '', target as string)?.href || '';
+              proxyConfig.onProxyRes?.(proxyRes, req, res);
             },
           }),
         );

--- a/packages/preset-umi/src/commands/preview.ts
+++ b/packages/preset-umi/src/commands/preview.ts
@@ -66,10 +66,10 @@ umi preview --port [port]
               createProxyMiddleware(key, {
                 ...proxy[key],
                 // Add x-real-url in response header
-                onProxyRes(proxyRes, req: any) {
+                onProxyRes(proxyRes, req: any, res) {
                   proxyRes.headers['x-real-url'] =
                     new URL(req.url || '', target as string)?.href || '';
-                  proxyConfig.onProxyRes?.(proxyRes, req);
+                  proxyConfig.onProxyRes?.(proxyRes, req, res);
                 },
               }),
             );


### PR DESCRIPTION
From
```
onProxyRes(proxyRes, req: any) 
```
to
```
onProxyRes(proxyRes, req: any, res) 
```
