### PR TITLE
fix: g tsconfig

### DIFF
--- a/packages/preset-umi/src/commands/generators/tsconfig.ts
+++ b/packages/preset-umi/src/commands/generators/tsconfig.ts
@@ -1,7 +1,7 @@
 import { GeneratorType } from '@umijs/core';
 import { logger } from '@umijs/utils';
 import { existsSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { join, relative } from 'path';
 import { IApi } from '../../types';
 import { GeneratorHelper } from './utils';
 
@@ -26,6 +26,9 @@ export default (api: IApi) => {
       h.addDevDeps({
         typescript: '^4',
       });
+      // '' => '/' 'src' => '/src/'
+      let relativePath = relative(api.cwd, api.paths?.absSrcPath);
+      relativePath = relativePath ? `/${relativePath}/` : '/';
 
       writeFileSync(
         join(api.cwd, 'tsconfig.json'),
@@ -42,8 +45,8 @@ export default (api: IApi) => {
     "baseUrl": ".",
     "strict": true,
     "paths": {
-      "@/*": ["*"],
-      "@@/*": [".umi/*"]
+      "@/*": [".${relativePath}*"],
+      "@@/*": [".${relativePath}.umi/*"]
     },
     "allowSyntheticDefaultImports": true
   }


### PR DESCRIPTION
## 修改前

当前生成的全是

```json
    "paths": {
      "@/*": ["*"],
      "@@/*": [".umi/*"]
    },
```
在 vscode 中是不识别的。

## 修改后

### 有 src 目录

```json
    "paths": {
      "@/*": ["./src/*"],
      "@@/*": ["./src/.umi/*"]
    },
```

### 无 src 目录

```json
    "paths": {
      "@/*": ["./*"],
      "@@/*": ["./.umi/*"]
    },
```