### PR TITLE
fix(preset-umi): lint-staged args not working bug for lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@umijs/bundler-utils": "workspace:*",
     "@umijs/bundler-vite": "workspace:*",
     "@umijs/bundler-webpack": "workspace:*",
+    "@umijs/lint": "workspace:*",
     "@umijs/plugin-docs": "workspace:*",
     "@umijs/plugins": "workspace:*",
     "@umijs/server": "workspace:*",

--- a/packages/preset-umi/src/commands/lint.ts
+++ b/packages/preset-umi/src/commands/lint.ts
@@ -1,3 +1,4 @@
+import { yParser } from '@umijs/utils';
 import { IApi } from '../types';
 
 export default (api: IApi) => {
@@ -18,6 +19,11 @@ umi lint --stylelint-only
 umi lint --fix
 `,
     fn: async function () {
+      // re-parse cli args to process boolean flags, for get the lint-staged args
+      const args = yParser(process.argv.slice(3), {
+        boolean: ['fix', 'eslint-only', 'stylelint-only'],
+      });
+
       try {
         require.resolve('@umijs/lint/package.json');
       } catch (err) {
@@ -26,12 +32,12 @@ umi lint --fix
         );
       }
 
-      if (api.args._.length === 0) {
-        api.args._.unshift('{src,test}/**/*.{js,jsx,ts,tsx,less,css}');
+      if (args._.length === 0) {
+        args._.unshift('{src,test}/**/*.{js,jsx,ts,tsx,less,css}');
       }
 
       // lazy require for CLI performance
-      require('@umijs/lint').default({ cwd: api.cwd }, api.args);
+      require('@umijs/lint').default({ cwd: api.cwd }, args);
     },
   });
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ importers:
       '@umijs/bundler-utils': workspace:*
       '@umijs/bundler-vite': workspace:*
       '@umijs/bundler-webpack': workspace:*
+      '@umijs/lint': workspace:*
       '@umijs/plugin-docs': workspace:*
       '@umijs/plugins': workspace:*
       '@umijs/server': workspace:*
@@ -64,6 +65,7 @@ importers:
       '@umijs/bundler-utils': link:packages/bundler-utils
       '@umijs/bundler-vite': link:packages/bundler-vite
       '@umijs/bundler-webpack': link:packages/bundler-webpack
+      '@umijs/lint': link:packages/lint
       '@umijs/plugin-docs': link:packages/plugin-docs
       '@umijs/plugins': link:packages/plugins
       '@umijs/server': link:packages/server


### PR DESCRIPTION
## Description

修复 `umi lint` 在结合 `lint-staged` 使用时，没有 lint 指定文件的 bug