### PR TITLE
fix: add contentType for devScripts.js

### DIFF
--- a/packages/preset-built-in/src/plugins/features/devScripts.ts
+++ b/packages/preset-built-in/src/plugins/features/devScripts.ts
@@ -34,6 +34,7 @@ export default (api: IApi) => {
                 : [],
           })
           .then((scripts) => {
+            res.set('content-type', 'application/javascript');
             res.end(
               scripts
                 .join('\r\n\r\n')


### PR DESCRIPTION
Incase Chrome strict MIME type checking may block the script from executing under domains except 'localhost'.