### PR TITLE
fix/jest module mapping

### DIFF
--- a/examples/test-test/.umirc.ts
+++ b/examples/test-test/.umirc.ts
@@ -1,3 +1,10 @@
 export default {
   npmClient: 'pnpm',
+  plugins: ['@umijs/plugins/dist/dva'],
+  dva: {
+    immer: {
+      enableES5: true,
+      enableAllPlugins: true,
+    },
+  },
 };

--- a/examples/test-test/bar.test.ts
+++ b/examples/test-test/bar.test.ts
@@ -1,0 +1,5 @@
+import { useAppData } from 'umi';
+
+test('import from umi works', () => {
+  expect(useAppData).toBeDefined();
+});

--- a/examples/test-test/components/Greet/Greet.test.tsx
+++ b/examples/test-test/components/Greet/Greet.test.tsx
@@ -33,7 +33,7 @@ test('Greet click', async () => {
   render(<Greet onClick={onClick} />);
 
   screen.getByText('Anonymous');
-  await fireEvent.click(screen.getByText(/hello/i));
+  fireEvent.click(screen.getByText(/hello/i));
 
   expect(onClick).toBeCalledTimes(1);
 });

--- a/examples/test-test/components/Greet/Greet.test.tsx
+++ b/examples/test-test/components/Greet/Greet.test.tsx
@@ -1,6 +1,4 @@
-import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import Greet from './Greet';
 
 test('renders Greet without name by inline snapshot', () => {
@@ -24,7 +22,7 @@ test('renders Greet without name by snapshot', () => {
 });
 
 test('renders Greet without name assert by testing-library', () => {
-  const { container } = render(<Greet />);
+  render(<Greet />);
 
   const greetDom = screen.getByText('Anonymous');
   expect(greetDom).toBeInTheDocument();
@@ -32,9 +30,9 @@ test('renders Greet without name assert by testing-library', () => {
 
 test('Greet click', async () => {
   const onClick = jest.fn();
-  const { container } = render(<Greet onClick={onClick} />);
+  render(<Greet onClick={onClick} />);
 
-  const greetDom = screen.getByText('Anonymous');
+  screen.getByText('Anonymous');
   await fireEvent.click(screen.getByText(/hello/i));
 
   expect(onClick).toBeCalledTimes(1);

--- a/examples/test-test/components/Greet/Greet.test.tsx
+++ b/examples/test-test/components/Greet/Greet.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
 import Greet from './Greet';
 
 test('renders Greet without name by inline snapshot', () => {

--- a/examples/test-test/importFromUmiSmoke.test.ts
+++ b/examples/test-test/importFromUmiSmoke.test.ts
@@ -1,5 +1,8 @@
+// @ts-ignore
+import { connect } from 'dva';
 import { useAppData } from 'umi';
 
 test('import from umi works', () => {
   expect(useAppData).toBeDefined();
+  expect(connect).toBeDefined();
 });

--- a/examples/test-test/jest-setup.ts
+++ b/examples/test-test/jest-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/examples/test-test/jest.config.ts
+++ b/examples/test-test/jest.config.ts
@@ -7,5 +7,6 @@ const jestConfig = createConfig({
 export default async () => {
   return (await configUmiAlias({
     ...jestConfig,
+    setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],
   })) as Config.InitialOptions;
 };

--- a/examples/test-test/package.json
+++ b/examples/test-test/package.json
@@ -6,6 +6,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@umijs/plugins": "workspace:4.0.0-canary.20220628.2",
     "umi": "4.0.0-canary.20220628.2"
   },
   "devDependencies": {

--- a/examples/test-test/package.json
+++ b/examples/test-test/package.json
@@ -10,8 +10,9 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.4",
-    "@testing-library/react": "^12",
+    "@testing-library/react": "^13",
     "@types/jest": "^27.5.1",
+    "@types/testing-library__jest-dom": "^5.14.5",
     "jest": "^27",
     "ts-node": "^10",
     "typescript": "^4.7.2"

--- a/examples/test-test/tsconfig.json
+++ b/examples/test-test/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "./.umi/tsconfig.json"
+  "extends": "./.umi/tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react"
+  }
 }

--- a/examples/test-test/tsconfig.json
+++ b/examples/test-test/tsconfig.json
@@ -1,4 +1,3 @@
 {
-  "extends": "./.umi/tsconfig.json",
-  "include": ["./jest-setup.ts"]
+  "extends": "./.umi/tsconfig.json"
 }

--- a/examples/test-test/tsconfig.json
+++ b/examples/test-test/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./.umi/tsconfig.json",
+  "include": ["./jest-setup.ts"]
+}

--- a/packages/preset-umi/src/commands/generators/jest.ts
+++ b/packages/preset-umi/src/commands/generators/jest.ts
@@ -43,11 +43,22 @@ export default (api: IApi) => {
       const packageToInstall: Record<string, string> = res.willUseTLR
         ? {
             ...basicDeps,
-            '@testing-library/react': '^12',
+            '@testing-library/react': '^13',
+            '@testing-library/jest-dom': '^5.16.4',
+            '@types/testing-library__jest-dom': '^5.14.5',
           }
         : basicDeps;
       h.addDevDeps(packageToInstall);
       h.addScript('test', 'jest');
+
+      if (res.willUseTLR) {
+        writeFileSync(
+          join(api.cwd, 'jest-setup.ts'),
+          `import '@testing-library/jest-dom';
+          `.trimLeft(),
+        );
+        logger.info('Write jest-setup.ts');
+      }
 
       const importSource = api.appData.umi.importSource;
       writeFileSync(
@@ -60,6 +71,7 @@ export default async () => {
     ...createConfig({
       target: 'browser',
     }),
+    ${res.willUseTLR ? `setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],` : ''}
     // if you require some es-module npm package, please uncomment below line and insert your package name
     // transformIgnorePatterns: ['node_modules/(?!.*(lodash-es|your-es-pkg-name)/)']
   })) as Config.InitialOptions;

--- a/packages/umi/src/test.test.ts
+++ b/packages/umi/src/test.test.ts
@@ -4,6 +4,8 @@ const alias = {
   'react-dom': '/project/node_modules/react-dom',
   umi: '@@/exports',
   react: '/project/node_modules/react',
+  dva$: '@@/dva-plugin/dva/index.js',
+  'dva/lib': '@@/dva-plugin/dva/lib',
   '@': '/project/src',
   '@@': '/project/src/.umi-test',
 };
@@ -16,4 +18,14 @@ test('simple alias to jest moduleNameMapper', () => {
 test('double alias path', () => {
   const p = getAliasPathWithKey(alias, 'umi');
   expect(p).toBe('/project/src/.umi-test/exports');
+});
+
+test('double alias path suffixed $', () => {
+  const p = getAliasPathWithKey(alias, 'dva$');
+  expect(p).toBe('/project/src/.umi-test/dva-plugin/dva/index.js');
+});
+
+test('overlapped alias paths', () => {
+  const p = getAliasPathWithKey(alias, 'dva/lib');
+  expect(p).toBe('/project/src/.umi-test/dva-plugin/dva/lib');
 });

--- a/packages/umi/src/test.test.ts
+++ b/packages/umi/src/test.test.ts
@@ -1,0 +1,19 @@
+import { getAliasPathWithKey } from './test';
+
+const alias = {
+  'react-dom': '/project/node_modules/react-dom',
+  umi: '@@/exports',
+  react: '/project/node_modules/react',
+  '@': '/project/src',
+  '@@': '/project/src/.umi-test',
+};
+
+test('simple alias to jest moduleNameMapper', () => {
+  const p = getAliasPathWithKey(alias, 'react-dom');
+  expect(p).toBe('/project/node_modules/react-dom');
+});
+
+test('double alias path', () => {
+  const p = getAliasPathWithKey(alias, 'umi');
+  expect(p).toBe('/project/src/.umi-test/exports');
+});

--- a/packages/umi/src/test.test.ts
+++ b/packages/umi/src/test.test.ts
@@ -1,31 +1,43 @@
 import { getAliasPathWithKey } from './test';
 
-const alias = {
-  'react-dom': '/project/node_modules/react-dom',
-  umi: '@@/exports',
-  react: '/project/node_modules/react',
-  dva$: '@@/dva-plugin/dva/index.js',
-  'dva/lib': '@@/dva-plugin/dva/lib',
-  '@': '/project/src',
-  '@@': '/project/src/.umi-test',
-};
-
 test('simple alias to jest moduleNameMapper', () => {
-  const p = getAliasPathWithKey(alias, 'react-dom');
-  expect(p).toBe('/project/node_modules/react-dom');
+  const p = getAliasPathWithKey(
+    {
+      'react-dom': '/path/to/react-dom',
+    },
+    'react-dom',
+  );
+  expect(p).toBe('/path/to/react-dom');
 });
 
 test('double alias path', () => {
-  const p = getAliasPathWithKey(alias, 'umi');
-  expect(p).toBe('/project/src/.umi-test/exports');
+  const p = getAliasPathWithKey(
+    {
+      alias1: 'alias2/lib',
+      alias2: '/path/to/module',
+    },
+    'alias1',
+  );
+  expect(p).toBe('/path/to/module/lib');
 });
 
 test('double alias path suffixed $', () => {
-  const p = getAliasPathWithKey(alias, 'dva$');
-  expect(p).toBe('/project/src/.umi-test/dva-plugin/dva/index.js');
+  const p = getAliasPathWithKey(
+    {
+      endWith$: '/path/to/index.js',
+    },
+    'endWith$',
+  );
+  expect(p).toBe('/path/to/index.js');
 });
 
 test('overlapped alias paths', () => {
-  const p = getAliasPathWithKey(alias, 'dva/lib');
-  expect(p).toBe('/project/src/.umi-test/dva-plugin/dva/lib');
+  const p = getAliasPathWithKey(
+    {
+      common$: '/path/to/index.js',
+      'common/lib': '/path/to/lib',
+    },
+    'common/lib',
+  );
+  expect(p).toBe('/path/to/lib');
 });

--- a/packages/umi/src/test.ts
+++ b/packages/umi/src/test.ts
@@ -4,15 +4,28 @@ import { Service } from './service/service';
 
 export * from '@umijs/test';
 
-function getAliasPathWithKey(
+export function getAliasPathWithKey(
   alias: Record<string, string>,
   key: string,
 ): string {
-  const thePath = alias[key];
-  if (alias[thePath]) {
-    return getAliasPathWithKey(alias, thePath);
+  const aliasKeys = Object.keys(alias);
+
+  const unaliased = aliasKeys
+    .filter((k) => key.startsWith(k))
+    .sort((k1, k2) => {
+      return k2.length - k1.length;
+    });
+
+  if (unaliased.length) {
+    const bestKey = unaliased[0];
+    const realPath = alias[bestKey];
+
+    const newKey = key.replace(new RegExp(`^${bestKey}`), realPath);
+
+    return getAliasPathWithKey(alias, newKey);
+  } else {
+    return key;
   }
-  return thePath;
 }
 
 let service: Service;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,8 +385,9 @@ importers:
   examples/test-test:
     specifiers:
       '@testing-library/jest-dom': ^5.16.4
-      '@testing-library/react': ^12
+      '@testing-library/react': ^13
       '@types/jest': ^27.5.1
+      '@types/testing-library__jest-dom': ^5.14.5
       jest: ^27
       ts-node: ^10
       typescript: ^4.7.2
@@ -395,8 +396,9 @@ importers:
       umi: link:../../packages/umi
     devDependencies:
       '@testing-library/jest-dom': 5.16.4
-      '@testing-library/react': 12.1.5
+      '@testing-library/react': 13.3.0
       '@types/jest': 27.5.2
+      '@types/testing-library__jest-dom': 5.14.5
       jest: 27.5.1_ts-node@10.8.1
       ts-node: 10.8.1_typescript@4.7.4
       typescript: 4.7.4
@@ -8293,7 +8295,7 @@ packages:
     engines: {node: '>=8', npm: '>=6', yarn: '>=1'}
     dependencies:
       '@babel/runtime': 7.18.3
-      '@types/testing-library__jest-dom': 5.14.4
+      '@types/testing-library__jest-dom': 5.14.5
       aria-query: 5.0.0
       chalk: 3.0.0
       css: 3.0.0
@@ -8303,12 +8305,12 @@ packages:
       redent: 3.0.0
     dev: true
 
-  /@testing-library/react/12.1.5:
-    resolution: {integrity: sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==}
+  /@testing-library/react/13.3.0:
+    resolution: {integrity: sha512-DB79aA426+deFgGSjnf5grczDPiL4taK3hFaa+M5q7q20Kcve9eQottOG5kZ74KEr55v0tU2CQormSSDK87zYQ==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: <18.0.0
-      react-dom: <18.0.0
+      react: ^18.0.0
+      react-dom: ^18.0.0
     peerDependenciesMeta:
       react:
         optional: true
@@ -8317,7 +8319,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.18.3
       '@testing-library/dom': 8.14.0
-      '@types/react-dom': 17.0.17
+      '@types/react-dom': 18.0.5
     dev: true
 
   /@tootallnate/once/1.1.2:
@@ -8755,12 +8757,6 @@ packages:
   /@types/range-parser/1.2.4:
     resolution: {integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==}
 
-  /@types/react-dom/17.0.17:
-    resolution: {integrity: sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==}
-    dependencies:
-      '@types/react': 17.0.47
-    dev: true
-
   /@types/react-dom/18.0.5:
     resolution: {integrity: sha512-OWPWTUrY/NIrjsAPkAk1wW9LZeIjSvkXRhclsFO8CZcZGCOg2G0YZy4ft+rOyYxy8B7ui5iZzi9OkDebZ7/QSA==}
     dependencies:
@@ -8782,14 +8778,6 @@ packages:
     resolution: {integrity: sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==}
     dependencies:
       '@types/react': 18.0.14
-    dev: true
-
-  /@types/react/17.0.47:
-    resolution: {integrity: sha512-mk0BL8zBinf2ozNr3qPnlu1oyVTYq+4V7WA76RgxUAtf0Em/Wbid38KN6n4abEkvO4xMTBWmnP1FtQzgkEiJoA==}
-    dependencies:
-      '@types/prop-types': 15.7.5
-      '@types/scheduler': 0.16.2
-      csstype: 3.1.0
     dev: true
 
   /@types/react/18.0.14:
@@ -8892,8 +8880,8 @@ packages:
       '@types/node': 18.0.0
     dev: true
 
-  /@types/testing-library__jest-dom/5.14.4:
-    resolution: {integrity: sha512-EUCs9PTBOEyfRtLKkKd31YrRCx/9Wxjy2Uqb6IH/KAOr7/vP0i8iClOyxQqjm/UxMGU5r5s2vOBM7vSPQVmabg==}
+  /@types/testing-library__jest-dom/5.14.5:
+    resolution: {integrity: sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==}
     dependencies:
       '@types/jest': 27.5.2
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,11 +388,13 @@ importers:
       '@testing-library/react': ^13
       '@types/jest': ^27.5.1
       '@types/testing-library__jest-dom': ^5.14.5
+      '@umijs/plugins': workspace:4.0.0-canary.20220628.2
       jest: ^27
       ts-node: ^10
       typescript: ^4.7.2
       umi: 4.0.0-canary.20220628.2
     dependencies:
+      '@umijs/plugins': link:../../packages/plugins
       umi: link:../../packages/umi
     devDependencies:
       '@testing-library/jest-dom': 5.16.4


### PR DESCRIPTION
当在用例中有 import from umi 会有一下错误

![image](https://user-images.githubusercontent.com/415655/176340991-1d652069-e53b-4e1f-9df6-c7cb9dd317e5.png)

原因是 jest 的 moduleNameMapper 只做一次 key value 的 map [参考](https://github.com/facebook/jest/blob/bf88f76864fe98ec45ae5035762a16e2dd03120a/packages/jest-resolve/src/resolver.ts#L716)，导致需要两次 alias 的 umi 不能正常 resolve

其他，升级了 testing-library/react 版本去除 warning，和 在 jest config 中配置  testing-library/js-dom
generator-jest 跟进改动。
