### PR TITLE
feat: 更改stylelint规则,允许小驼峰和中划线命名

### DIFF
--- a/packages/lint/src/config/stylelint/index.ts
+++ b/packages/lint/src/config/stylelint/index.ts
@@ -23,6 +23,12 @@ module.exports = {
     // webcomponent
     'selector-type-no-unknown': null,
     'value-keyword-case': ['lower', { ignoreProperties: ['composes'] }],
+    'selector-class-pattern': [
+      '(^([a-z][a-z0-9]*)(-[a-z0-9]+)*$)|(^[a-z][a-zA-Z0-9]+$)',
+      {
+        message: 'Expected class selector to be kebab-case or lowerCamelCase',
+      },
+    ],
   },
   customSyntax: require.resolve('../../../compiled/postcss-less'),
   ignoreFiles: ['node_modules'],

--- a/packages/lint/src/config/stylelint/index.ts
+++ b/packages/lint/src/config/stylelint/index.ts
@@ -24,7 +24,7 @@ module.exports = {
     'selector-type-no-unknown': null,
     'value-keyword-case': ['lower', { ignoreProperties: ['composes'] }],
     'selector-class-pattern': [
-      '(^([a-z][a-z0-9]*)(-[a-z0-9]+)*$)|(^[a-z][a-zA-Z0-9]+$)',
+      '^([a-z][a-z0-9]*(-[a-z0-9]+)*|[a-z][a-zA-Z0-9]+)$',
       {
         message: 'Expected class selector to be kebab-case or lowerCamelCase',
       },


### PR DESCRIPTION
stylelint对类名的命名强限制为中划线，但是使用css modules 很多项目都直接用小驼峰命名class名，这样进行lint时会报很多错误，希望将规则改为中划线或小驼峰