### PR TITLE
fix(babel-preset-umi): declare @umijs/utils in dependencies

### DIFF
--- a/packages/babel-preset-umi/package.json
+++ b/packages/babel-preset-umi/package.json
@@ -32,6 +32,7 @@
     "@umijs/babel-plugin-import-to-await-require": "3.5.26",
     "@umijs/babel-plugin-lock-core-js-3": "3.5.26",
     "@umijs/babel-plugin-no-anonymous-default-export": "3.5.26",
-    "@umijs/deps": "3.5.26"
+    "@umijs/deps": "3.5.26",
+    "@umijs/utils": "3.5.26"
   }
 }


### PR DESCRIPTION
给 `@umijs/babel-preset-umi` 添加缺失的 `@umijs/utils` 依赖，避免使用幽灵依赖，`app.js` 和 `node.js` 里有用到