### PR TITLE
fix(bundler-webpack): terser sourcmap option

### DIFF
--- a/packages/bundler-webpack/src/getConfig/getConfig.ts
+++ b/packages/bundler-webpack/src/getConfig/getConfig.ts
@@ -574,7 +574,7 @@ export default async function getConfig(
                 terserOptions,
                 config.terserOptions || {},
               ),
-              sourceMap: config.devtool !== false,
+              sourceMap: Boolean(config.devtool),
               cache: process.env.TERSER_CACHE !== 'none',
               // 兼容内部流程系统，读到的 cpu 数并非真实的
               // 使用 SIGMA_MAX_PROCESSORS_LIMIT 指定真核数


### PR DESCRIPTION
修正 `terser-webpack-plugin` 的 `sourcemap` 参数，用户没配置 `devtool` 的时候默认不开启