### PR TITLE
chore: improve release script

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -139,6 +139,16 @@ async function release() {
   const releasePkgs = pkgs.sort((a) => {
     return a === 'umi' ? 1 : -1;
   });
+  // one-time password from your authenticator
+  let otp = '';
+  if (args.otp) {
+    ({ otp } = await inquirer.prompt({
+      name: 'otp',
+      type: 'input',
+      message: 'This operation requires a one-time password:',
+      validate: (msg) => !!msg,
+    }));
+  }
   for (const [index, pkg] of releasePkgs.entries()) {
     const pkgPath = join(cwd, 'packages', pkg);
     const { name, version } = require(join(pkgPath, 'package.json'));
@@ -148,16 +158,9 @@ async function release() {
           isNext ? 'with next tag' : ''
         }`,
       );
-      let cliArgs = isNext ? ['publish', '--tag', 'next'] : ['publish'];
-      // one-time password from your authenticator
-      if (args.otp) {
-        const { otp } = await inquirer.prompt({
-          name: 'otp',
-          type: 'input',
-          message: 'This operation requires a one-time password:',
-          validate: (msg) => !!msg,
-        });
-        cliArgs = cliArgs.concat(['--otp', otp]);
+      const cliArgs = ['publish', '--tag', isNext ? 'next-3' : '3.x'];
+      if (otp) {
+        cliArgs.push('--otp', otp);
       }
       const { stdout } = execa.sync('npm', cliArgs, {
         cwd: pkgPath,


### PR DESCRIPTION
优化 Umi 3 的发布脚本：
1. 默认发 `3.x` 和 `next-3` tag，避免影响 Umi 4 的 latest
2. `otp` 是一段时间内有效、只需要询问一次，现在要输入 21 遍 otp...