### PR TITLE
fix(favicon): post favicon middleware

### DIFF
--- a/packages/preset-umi/src/commands/dev/dev.ts
+++ b/packages/preset-umi/src/commands/dev/dev.ts
@@ -280,12 +280,14 @@ PORT=8888 umi dev
         extraBabelPresets,
         beforeMiddlewares: ([] as RequestHandler[]).concat([
           ...beforeMiddlewares,
-          faviconMiddleware,
         ]),
         // vite 模式使用 ./plugins/ViteHtmlPlugin.ts 处理
         afterMiddlewares: enableVite
           ? []
-          : middlewares.concat(createRouteMiddleware({ api })),
+          : middlewares.concat([
+              createRouteMiddleware({ api }),
+              faviconMiddleware,
+            ]),
         onDevCompileDone(opts: any) {
           debouncedPrintMemoryUsage;
           // debouncedPrintMemoryUsage();


### PR DESCRIPTION
fix https://github.com/umijs/umi/issues/8024#issuecomment-1173556943

兜底后置 umi 的 favicon ，防止用户自己配了 `/favicon.ico` 被先拦截到。
