### PR TITLE
fix: get preload key always ends with css

### DIFF
--- a/packages/renderer-react/src/browser.tsx
+++ b/packages/renderer-react/src/browser.tsx
@@ -134,11 +134,15 @@ export function renderClient(opts: {
               const keys = Object.keys(manifest).filter((k) =>
                 k.startsWith(routeIdReplaced + '.'),
               );
-              if (!keys.length) return;
+              const supportFile = ['.css', '.js'];
               keys.forEach((key) => {
+                if (!supportFile.includes(key)) {
+                  throw Error(`preload not support ${key} file`);
+                }
                 let file = manifest[key];
                 const link = document.createElement('link');
                 link.rel = 'preload';
+                link.as = 'style';
                 if (key.endsWith('.js')) {
                   link.as = 'script';
                   link.id = preloadId;

--- a/packages/renderer-react/src/browser.tsx
+++ b/packages/renderer-react/src/browser.tsx
@@ -129,29 +129,32 @@ export function renderClient(opts: {
           const manifest = window.__umi_manifest__;
           if (manifest) {
             const routeIdReplaced = id.replace(/[\/\-]/g, '_');
-            const preloadId = 'preload-' + routeIdReplaced;
+            const preloadId = `preload-${routeIdReplaced}.js`;
             if (!document.getElementById(preloadId)) {
-              const reg = new RegExp(`^${routeIdReplaced}.\.*js$`)
-              const key = Object.keys(manifest).find((k) =>
-                k.match(reg),
+              const keys = Object.keys(manifest).filter((k) =>
+                k.startsWith(routeIdReplaced + '.'),
               );
-              if (!key) return;
-              let file = manifest[key];
-              const link = document.createElement('link');
-              link.id = preloadId;
-              link.rel = 'preload';
-              link.as = 'script';
-              // publicPath already in the manifest,
-              // but if runtimePublicPath is true, we need to replace it
-              if (opts.runtimePublicPath) {
-                file = file.replace(
-                  new RegExp(`^${opts.publicPath}`),
-                  // @ts-ignore
-                  window.publicPath,
-                );
-              }
-              link.href = file;
-              document.head.appendChild(link);
+              if (!keys.length) return;
+              keys.forEach((key) => {
+                let file = manifest[key];
+                const link = document.createElement('link');
+                link.rel = 'preload';
+                if (key.endsWith('.js')) {
+                  link.as = 'script';
+                  link.id = preloadId;
+                }
+                // publicPath already in the manifest,
+                // but if runtimePublicPath is true, we need to replace it
+                if (opts.runtimePublicPath) {
+                  file = file.replace(
+                    new RegExp(`^${opts.publicPath}`),
+                    // @ts-ignore
+                    window.publicPath,
+                  );
+                }
+                link.href = file;
+                document.head.appendChild(link);
+              });
             }
           }
           // server loader

--- a/packages/renderer-react/src/browser.tsx
+++ b/packages/renderer-react/src/browser.tsx
@@ -134,9 +134,8 @@ export function renderClient(opts: {
               const keys = Object.keys(manifest).filter((k) =>
                 k.startsWith(routeIdReplaced + '.'),
               );
-              const supportFile = ['.css', '.js'];
               keys.forEach((key) => {
-                if (!supportFile.includes(key)) {
+                if (!key.match(/.(js|css)$/)) {
                   throw Error(`preload not support ${key} file`);
                 }
                 let file = manifest[key];

--- a/packages/renderer-react/src/browser.tsx
+++ b/packages/renderer-react/src/browser.tsx
@@ -132,7 +132,7 @@ export function renderClient(opts: {
             const preloadId = 'preload-' + routeIdReplaced;
             if (!document.getElementById(preloadId)) {
               const key = Object.keys(manifest).find((k) =>
-                k.startsWith(routeIdReplaced + '.'),
+                k.startsWith(routeIdReplaced + '.js'),
               );
               if (!key) return;
               let file = manifest[key];

--- a/packages/renderer-react/src/browser.tsx
+++ b/packages/renderer-react/src/browser.tsx
@@ -135,7 +135,7 @@ export function renderClient(opts: {
                 k.startsWith(routeIdReplaced + '.'),
               );
               keys.forEach((key) => {
-                if (!key.match(/.(js|css)$/)) {
+                if (!/\.(js|css)$/.test(key)) {
                   throw Error(`preload not support ${key} file`);
                 }
                 let file = manifest[key];

--- a/packages/renderer-react/src/browser.tsx
+++ b/packages/renderer-react/src/browser.tsx
@@ -131,8 +131,9 @@ export function renderClient(opts: {
             const routeIdReplaced = id.replace(/[\/\-]/g, '_');
             const preloadId = 'preload-' + routeIdReplaced;
             if (!document.getElementById(preloadId)) {
+              const reg = new RegExp(`^${routeIdReplaced}.\.*js$`)
               const key = Object.keys(manifest).find((k) =>
-                k.startsWith(routeIdReplaced + '.js'),
+                k.match(reg),
               );
               if (!key) return;
               let file = manifest[key];


### PR DESCRIPTION
如果 `window.__umi_manifest__` 为以下代码：

```js
window.__umi_manifest__ = {
  "umi.css": "/umi.aa4342fc.css",
  "umi.js": "/umi.ffdad893.js",
  "1.css": "/1.f5fecf30.chunk.css",
  "1.js": "/1.57fecd0a.async.js",
  "2.css": "/2.f5fecf30.chunk.css",
  "2.js": "/2.0f29443f.async.js",
  "3.css": "/3.f5fecf30.chunk.css",
  "3.js": "/3.405c6284.async.js",
  "4.css": "/4.f8550f09.chunk.css",
  "4.js": "/4.3a0a27b4.async.js",
  "@@_global_layout.js": "/@@_global_layout.fb948677.async.js",
  "258.1df5da00.async.js": "/258.1df5da00.async.js",
  "62.02fa153b.async.js": "/62.02fa153b.async.js",
  "37.fd560c60.async.js": "/37.fd560c60.async.js",
  "376.009af299.async.js": "/376.009af299.async.js"
}
```

那么 `Object.keys(manifest)` 获得的数组中 css 文件名永远在 js 文件名之前，这样就导致 `k.startsWith(routeIdReplaced + '.')` 一直获得是 css 文件名。