### PR TITLE
修复配置式路由中 redirect 不能正确处理 url params 的问题

### DIFF
--- a/packages/renderer-react/src/routes.tsx
+++ b/packages/renderer-react/src/routes.tsx
@@ -1,6 +1,6 @@
 // @ts-ignore
 import React from 'react';
-import { Navigate } from 'react-router-dom';
+import { generatePath, Navigate, useParams } from 'react-router-dom';
 import { RouteContext } from './routeContext';
 import { IClientRoute, IRoute, IRoutesById } from './types';
 
@@ -35,6 +35,15 @@ export function createClientRoutes(opts: {
     });
 }
 
+function NavigateWithParams(props: { to: string }) {
+  const params = useParams();
+  const propsWithParams = {
+    ...params,
+    to: generatePath(props.to, params),
+  };
+  return <Navigate {...propsWithParams} />;
+}
+
 function createClientRoute(opts: {
   route: IRoute;
   routeComponent: any;
@@ -44,7 +53,7 @@ function createClientRoute(opts: {
   const { redirect, ...props } = route;
   return {
     element: redirect ? (
-      <Navigate to={redirect} />
+      <NavigateWithParams to={redirect} />
     ) : (
       <RouteContext.Provider
         value={{


### PR DESCRIPTION
umijs@4的配置式路由中，如果 redirect 中带有 `:param`，将无法正确渲染，如下：

```
export default {
  routes: [{
    path: "/:id/",
    routes: [{
      path: "/:id/",
      redirect: "/:id/index"
    }, {
      path: "/:id/index",
    }]
  }]
};
```

此时路由 `/foo/` 将会被渲染为 `/:id/index` 而不是期望的 `/foo/index`。

PR 修复了这个问题。