### PR TITLE
feat(api-route): parse request body in type of form

### DIFF
--- a/packages/preset-umi/src/features/apiRoute/request.test.ts
+++ b/packages/preset-umi/src/features/apiRoute/request.test.ts
@@ -4,7 +4,10 @@ test('parse multipart/form-data of api route request into object', () => {
   // Example from Postman request
   const contentType =
     'multipart/form-data; boundary=--------------------------644202596647731933964997';
-  const body = `"----------------------------644202596647731933964997\r\nContent-Disposition: form-data; name=\"username\"\r\n\r\nyuaanlin\r\n----------------------------644202596647731933964997\r\nContent-Disposition: form-data; name=\"gender\"\r\n\r\nmale\r\n----------------------------644202596647731933964997\r\nContent-Disposition: form-data; name=\"bio\"\r\n\r\nHello~\nMy name is yuanlin~\r\n----------------------------644202596647731933964997--\r\n"`;
+  const body = Buffer.from(
+    `"----------------------------644202596647731933964997\r\nContent-Disposition: form-data; name=\"username\"\r\n\r\nyuaanlin\r\n----------------------------644202596647731933964997\r\nContent-Disposition: form-data; name=\"gender\"\r\n\r\nmale\r\n----------------------------644202596647731933964997\r\nContent-Disposition: form-data; name=\"bio\"\r\n\r\nHello~\nMy name is yuanlin~\r\n----------------------------644202596647731933964997--\r\n"`,
+    'utf-8',
+  );
 
   const boundary = contentType.split('boundary=')[1];
   const parsed = parseMultipart(body, boundary);

--- a/packages/preset-umi/src/features/apiRoute/request.test.ts
+++ b/packages/preset-umi/src/features/apiRoute/request.test.ts
@@ -1,0 +1,31 @@
+import { parseMultipart, parseUrlEncoded } from './request';
+
+test('parse multipart/form-data of api route request into object', () => {
+  // Example from Postman request
+  const contentType =
+    'multipart/form-data; boundary=--------------------------644202596647731933964997';
+  const body = `"----------------------------644202596647731933964997\r\nContent-Disposition: form-data; name=\"username\"\r\n\r\nyuaanlin\r\n----------------------------644202596647731933964997\r\nContent-Disposition: form-data; name=\"gender\"\r\n\r\nmale\r\n----------------------------644202596647731933964997\r\nContent-Disposition: form-data; name=\"bio\"\r\n\r\nHello~\nMy name is yuanlin~\r\n----------------------------644202596647731933964997--\r\n"`;
+
+  const boundary = contentType.split('boundary=')[1];
+  const parsed = parseMultipart(body, boundary);
+
+  expect(parsed).toStrictEqual({
+    username: 'yuaanlin',
+    gender: 'male',
+    bio: `Hello~\nMy name is yuanlin~`,
+  });
+});
+
+test('parse urlencoded form of api route request into object', () => {
+  // Example from Postman request
+  const body =
+    'username=yuaanlin&bio=Hello~%0AMy%20name%20is%20yuanlin~&gender=male';
+
+  const parsed = parseUrlEncoded(body);
+
+  expect(parsed).toStrictEqual({
+    username: 'yuaanlin',
+    gender: 'male',
+    bio: `Hello~\nMy name is yuanlin~`,
+  });
+});

--- a/packages/preset-umi/src/features/apiRoute/response.ts
+++ b/packages/preset-umi/src/features/apiRoute/response.ts
@@ -22,6 +22,11 @@ class UmiApiResponse {
     return this;
   }
 
+  public end(data: any) {
+    this._res.end(data);
+    return this;
+  }
+
   public text(data: string) {
     this._res.setHeader('Content-Type', 'text/plain; charset=utf-8');
     this._res.end(data);


### PR DESCRIPTION
#8410 

为 API 路由功能添加了 request body 是 `multipart/form-data` 和 `application/x-www-form-urlencoded` 时的请求体解析支持。

当 request body 是上述两种格式时且请求头带有正确的 `Content-Type` 时，可以直接在 API 路由用 `req.body` 访问解析完成的 object 格式的请求体。