### PR TITLE
fix: 🐛  debug js file middleware should mounted eariler

### DIFF
--- a/packages/bundler-webpack/src/server/server.ts
+++ b/packages/bundler-webpack/src/server/server.ts
@@ -42,23 +42,25 @@ export async function createServer(opts: IOpts) {
   // compression
   app.use(require('@umijs/bundler-webpack/compiled/compression')());
 
-  // TODO: headers
-
-  // before middlewares
-  (opts.beforeMiddlewares || []).forEach((m) => app.use(m));
-
-  // TODO: add to before middleware
+  // debug all js file
   app.use((req, res, next) => {
     const file = req.path;
     const filePath = join(opts.cwd, file);
     const ext = extname(filePath);
 
     if (ext === '.js' && existsSync(filePath)) {
+      logger.info(
+        '[dev]',
+        `${file} is responded with ${filePath}, remove it to use original file`,
+      );
       res.sendFile(filePath);
     } else {
       next();
     }
   });
+
+  // before middlewares
+  (opts.beforeMiddlewares || []).forEach((m) => app.use(m));
 
   // webpack dev middleware
   const configs = Array.isArray(webpackConfig)


### PR DESCRIPTION
debug  mfsu 的 `mf-va_remoteEntry.js` 发现这个 middleware 应该尽早安装，
不然无法拦截到 beforeMiddlewares 里面提供的 js 资源请求。