### PR TITLE
feat: verify commit support git hooks

### DIFF
--- a/packages/preset-umi/src/commands/verify-commit.ts
+++ b/packages/preset-umi/src/commands/verify-commit.ts
@@ -22,7 +22,14 @@ export default (api: IApi) => {
     fn({ args }) {
       api.logger.info('verify-commit');
 
-      const msgPath = args._[0];
+      // support gitHooks
+      // package.json
+      // "gitHooks": {
+      //   "commit-msg": "umi verify-commit"
+      // }
+      const msgPath =
+        args._[0] || process.env.GIT_PARAMS || process.env.HUSKY_GIT_PARAMS;
+
       assert(msgPath, 'msgPath is required');
 
       let msg = readFileSync(msgPath!, 'utf-8').trim();

--- a/packages/preset-umi/src/commands/verify-commit.ts
+++ b/packages/preset-umi/src/commands/verify-commit.ts
@@ -27,8 +27,7 @@ export default (api: IApi) => {
       // "gitHooks": {
       //   "commit-msg": "umi verify-commit"
       // }
-      const msgPath =
-        args._[0] || process.env.GIT_PARAMS;
+      const msgPath = args._[0] || process.env.GIT_PARAMS;
 
       assert(msgPath, 'msgPath is required');
 

--- a/packages/preset-umi/src/commands/verify-commit.ts
+++ b/packages/preset-umi/src/commands/verify-commit.ts
@@ -28,7 +28,7 @@ export default (api: IApi) => {
       //   "commit-msg": "umi verify-commit"
       // }
       const msgPath =
-        args._[0] || process.env.GIT_PARAMS || process.env.HUSKY_GIT_PARAMS;
+        args._[0] || process.env.GIT_PARAMS;
 
       assert(msgPath, 'msgPath is required');
 


### PR DESCRIPTION
在 `package.json` 配置 `gitHooks` 时报错，`msgPath is required`
```json
"gitHooks": {
  "commit-msg": "umi verify-commit"
}
```
![image](https://user-images.githubusercontent.com/11746742/177733815-cba79734-6616-4bc1-9e26-4c2f808c1b7e.png)
