### PR TITLE
docs: add clickToComponent doc

### DIFF
--- a/docs/docs/api/config.md
+++ b/docs/docs/api/config.md
@@ -109,7 +109,7 @@ export default {
 - 类型: `{ editor?: string }`
 - 默认值: `false`
 
-> 当前仅 React 项目支持
+> 当前仅 React 项目支持。
 
 开启后，可通过 `Option+Click/Alt+Click` 点击组件跳转至编辑器源码位置，`Option+Right-click/Alt+Right-click` 可以打开上下文，查看父组件。
 

--- a/docs/docs/api/config.md
+++ b/docs/docs/api/config.md
@@ -109,7 +109,9 @@ export default {
 - 类型: `{ editor?: string }`
 - 默认值: `false`
 
-开启后，可通过 `Option+Click` 点击组件跳转至编辑器源码位置，`Option+Right-click` 可以打开上下文，查看父组件。
+> 当前仅 React 项目支持
+
+开启后，可通过 `Option+Click/Alt+Click` 点击组件跳转至编辑器源码位置，`Option+Right-click/Alt+Right-click` 可以打开上下文，查看父组件。
 
 关于参数。`editor` 为编辑器名称，默认为 'vscode'，支持 `vscode` & `vscode-insiders`。
 


### PR DESCRIPTION
看了下，目前该配置仅支持 `React`

增加了在 `win` 电脑的快捷键

-----
[View rendered docs/docs/api/config.md](https://github.com/ahwgs/umi-start/blob/feat_doc/docs/docs/api/config.md)