### PR TITLE
refactor(server): always return html for base path request

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -142,7 +142,10 @@ export function createRequestHandler(opts: IOpts): RequestHandler {
     ) {
       // 如果是 browser，并且配置了非 / base，访问 / 时 redirect 到 base 路径
       res.redirect(opts.base);
-    } else if (req.headers.accept?.includes('text/html')) {
+    } else if (
+      req.headers.accept?.includes('text/html') ||
+      req.path === opts.base
+    ) {
       // 匹配路由，不匹配走 next()
       // const routes = createServerRoutes({
       //   routesById: opts.routes,

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -144,6 +144,7 @@ export function createRequestHandler(opts: IOpts): RequestHandler {
       res.redirect(opts.base);
     } else if (
       req.headers.accept?.includes('text/html') ||
+      req.headers.accept === '*/*' ||
       req.path === opts.base
     ) {
       // 匹配路由，不匹配走 next()


### PR DESCRIPTION
1. `base` 请求的时候 dev server 始终返回 `index.html`、不校验 `headers.accept`
2. 参考 `webpack-dev-server` 使用的 [`connect-history-api-fallback` 的行为](https://github.com/bripkens/connect-history-api-fallback#htmlacceptheaders)，在 `accpet: */*` 的时候也返回 HTML

Close #8427 