### PR TITLE
ci: add package size analyze

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ env:
 on:
   push:
     branches:
-      - master
+      - ci/compress-size
     paths-ignore:
       - 'examples/**'
       - 'docs/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ env:
 on:
   push:
     branches:
-      - ci/compress-size
+      - master
     paths-ignore:
       - 'examples/**'
       - 'docs/**'
@@ -15,6 +15,7 @@ on:
     types:
       - 'opened'
       - 'synchronize'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ on:
     types:
       - 'opened'
       - 'synchronize'
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -6,7 +6,7 @@ env:
 on:
   push:
     branches:
-      - master
+      - ci/compress-size
     paths-ignore:
       - 'examples/**'
       - 'docs/**'
@@ -15,7 +15,6 @@ on:
     types:
       - 'opened'
       - 'synchronize'
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -34,4 +33,3 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           pattern: "./packages/*/{dist,compiled}/**/*.js"
           compression: "none"
-          

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -47,4 +47,4 @@ jobs:
         with:
           build-script: "build"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          pattern: "./packages/*/{dist,compiled}/**/*.js"
+          pattern: "./packages/*/{dist,compiled}/**/*.{js,d.ts}"

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -27,6 +27,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2.2.2
+        with:
+          run_install: false
+          
       - uses: preactjs/compressed-size-action@v2
         with:
           build-script: "build"

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -4,17 +4,14 @@ env:
   NODE_OPTIONS: --max-old-space-size=6144
 
 on:
-  push:
-    branches:
-      - ci/compress-size
-    paths-ignore:
-      - 'examples/**'
-      - 'docs/**'
-      - '**/*.md'
   pull_request:
     types:
       - 'opened'
       - 'synchronize'
+    paths-ignore:
+      - 'examples/**'
+      - 'docs/**'
+      - '**/*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -32,7 +29,7 @@ jobs:
         uses: pnpm/action-setup@v2.2.2
         with:
           run_install: false
-          
+
       - uses: preactjs/compressed-size-action@v2
         with:
           build-script: "build"

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -1,0 +1,37 @@
+name: Compressed Size
+
+env:
+  NODE_OPTIONS: --max-old-space-size=6144
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'examples/**'
+      - 'docs/**'
+      - '**/*.md'
+  pull_request:
+    types:
+      - 'opened'
+      - 'synchronize'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: preactjs/compressed-size-action@v2
+        with:
+          build-script: "build"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          pattern: "./packages/*/{dist,compiled}/**/*.js"
+          compression: "none"
+          

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -30,9 +30,21 @@ jobs:
         with:
           run_install: false
 
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: |
+          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          key: ${{ runner.os }}-pnpm-store-compressed-size-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-compressed-size-
+
       - uses: preactjs/compressed-size-action@v2
         with:
           build-script: "build"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           pattern: "./packages/*/{dist,compiled}/**/*.js"
-          compression: "none"


### PR DESCRIPTION
新增 ci 自动检测 `dist`、`compiled` 下文件体积的变动。

<img src='https://user-images.githubusercontent.com/59400654/178122427-337b3a21-56b4-4ef5-a795-e49f56ec5449.png' width='80%' />

这可以从一定程度衡量 npm 下载该包的成本。

这近似可以代表安装 umi 时下载的所有 `@umijs/*` 包的成本，也就是：

<img src='https://user-images.githubusercontent.com/59400654/178122398-6d759d0b-6e73-4e1c-b24c-59465b989671.png' width='70%' />
