### PR TITLE
fix: docs max dva typo

### DIFF
--- a/docs/docs/max/dva.md
+++ b/docs/docs/max/dva.md
@@ -20,7 +20,7 @@ React 的组件只是通过 jsx 以及样式按照 state 构建最终的 UI，�
 
 ### 配置 dva
 
-首先你需要配置 `dva: {}` 打开 Umi 内置的 [dva 插件](plugin-dva)。
+首先你需要配置 `dva: {}` 打开 Umi 内置的 [dva 插件](dva)。
 
 ### 添加 model
 


### PR DESCRIPTION
> 首先你需要配置 dva: {} 打开 Umi 内置的 [dva 插件](https://umijs.org/docs/max/plugin-dva)。

链接错误

-----
[View rendered docs/docs/max/dva.md](https://github.com/wanghaida/umi/blob/fix/maxDvaTypo/docs/docs/max/dva.md)