### PR TITLE
fix: mock file reload fail

### DIFF
--- a/packages/preset-umi/src/features/mock/getMockData.ts
+++ b/packages/preset-umi/src/features/mock/getMockData.ts
@@ -38,6 +38,7 @@ export function getMockData(opts: {
       const mockFile = `${opts.cwd}/${file}`;
       let m;
       try {
+        delete require.cache[mockFile];
         m = require(mockFile);
       } catch (e) {
         throw new Error(
@@ -71,9 +72,6 @@ export function getMockData(opts: {
       }
       return memo;
     }, {});
-  for (const file of register.getFiles()) {
-    delete require.cache[file];
-  }
   register.restore();
   return ret;
 }


### PR DESCRIPTION
fix #8499

改动点：mock file 加载逻辑

- 改动前：只有当每次 `require` 完 mock file 并且解析成功才会删除 mock file 的 `require.cache` 缓存，导致当解析 mock file 出错时无法热重载修改后的的 mock file。
- 改动后：每次 `require` mock file 前，先删除对应文件的 `require.cache` 缓存。
