### PR TITLE
fix: html default meta overrides

### DIFF
--- a/examples/boilerplate/.umirc.ts
+++ b/examples/boilerplate/.umirc.ts
@@ -83,5 +83,19 @@ export default {
     },
   },
   cacheDirectoryPath: 'node_modules/.cache1',
+  metas: [
+    {
+      name: 'viewport',
+      content: `width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no`,
+    },
+    {
+      'http-equiv': 'X-UA-Compatible',
+      content: 'IE=edge,chrome=1',
+    },
+    {
+      name: 'description',
+      content: 'umijs',
+    },
+  ],
   ...extraConfig,
 };

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -84,6 +84,26 @@ export async function getMarkup(
     return `<${opts.tagName} ${attrs} />`;
   }
 
+  function withDefaultMetas(metas: IOpts['metas'] = []) {
+    const hasAttr = (key: string, value?: string) =>
+      metas.some((m) => {
+        return value ? m[key]?.toLowerCase() === value.toLowerCase() : m[key];
+      });
+    return [
+      !hasAttr('charset') && { charset: 'utf-8' },
+      !hasAttr('name', 'viewport') && {
+        name: 'viewport',
+        content:
+          'width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0',
+      },
+      !hasAttr('http-equiv', 'X-UA-Compatible') && {
+        'http-equiv': 'X-UA-Compatible',
+        content: 'ie=edge',
+      },
+      ...metas,
+    ].filter(Boolean) as NonNullable<IOpts['metas']>;
+  }
+
   const favicons: string[] = [];
   if (Array.isArray(opts.favicons)) {
     opts.favicons.forEach((e) => {
@@ -91,7 +111,7 @@ export async function getMarkup(
     });
   }
   const title = opts.title ? `<title>${opts.title}</title>` : '';
-  const metas = (opts.metas || []).map((meta) =>
+  const metas = withDefaultMetas(opts.metas).map((meta) =>
     getTagContent({ attrs: meta, tagName: 'meta' }),
   );
   const links = (opts.links || []).map((link) =>
@@ -105,13 +125,7 @@ export async function getMarkup(
   markup = [
     `<!DOCTYPE html>
 <html>
-<head>
-<meta charset="UTF-8" />
-<meta
-  name="viewport"
-  content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
-/>
-<meta http-equiv="X-UA-Compatible" content="ie=edge" />`,
+<head>`,
     metas.join('\n'),
     favicons.join('\n'),
     title,


### PR DESCRIPTION
fix #8538

解决在 `metas` 里自定义 `viewport` 等不会覆盖默认值的问题。