### PR TITLE
feat: enable case-sensitive-paths-webpack-plugin

### DIFF
--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@umijs/bundler-utils": "3.5.30",
+    "@umijs/case-sensitive-paths-webpack-plugin": "^1.0.1",
     "@umijs/deps": "3.5.30",
     "@umijs/types": "3.5.30",
     "@umijs/utils": "3.5.30",

--- a/packages/bundler-webpack/src/getConfig/getConfig.ts
+++ b/packages/bundler-webpack/src/getConfig/getConfig.ts
@@ -4,6 +4,7 @@ import {
   getBabelPresetOpts,
   getTargetsAndBrowsersList,
 } from '@umijs/bundler-utils';
+import CaseSensitivePaths from '@umijs/case-sensitive-paths-webpack-plugin';
 import * as defaultWebpack from '@umijs/deps/compiled/webpack';
 import {
   BundlerConfigType,
@@ -513,6 +514,9 @@ export default async function getConfig(
       }),
     );
   }
+
+  // case-sensitive-paths
+  webpackConfig.plugin('case-sensitive-paths').use(new CaseSensitivePaths());
 
   const enableManifest = () => {
     // manifest

--- a/packages/preset-built-in/src/plugins/commands/dev/devCompileDone/devCompileDone.ts
+++ b/packages/preset-built-in/src/plugins/commands/dev/devCompileDone/devCompileDone.ts
@@ -35,7 +35,10 @@ export default (api: IApi) => {
                   console.error(chalk.red(e.stack));
                 });
             },
-            onCompileFail() {
+            onCompileFail({ stats }) {
+              if (stats.hasErrors()) {
+                console.error(stats.toString('errors-only'));
+              }
               printHelp.feedback();
             },
           }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4525,6 +4525,11 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@umijs/case-sensitive-paths-webpack-plugin@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@umijs/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-1.0.1.tgz#02655299f52912289f2df28fbeaea636e748c1df"
+  integrity sha512-kDKJ8yTarxwxGJDInG33hOpaQRZ//XpNuuznQ/1Mscypw6kappzFmrBr2dOYave++K7JHouoANF354UpbEQw0Q==
+
 "@umijs/plugin-analytics@^0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@umijs/plugin-analytics/-/plugin-analytics-0.2.2.tgz#575fd231d4327ea13413217aa1b5fc6bdd89465e"


### PR DESCRIPTION
## Changes
1. dev 编译错误的时候输出错误信息
2. 启用 `@umijs/case-sensitive-paths-webpack-plugin`

效果截图：
![图片](https://user-images.githubusercontent.com/5035925/179188065-c36783ae-92ea-44fe-99d5-db9ff8f3f65c.png)
