### PR TITLE
fix(mfsu): exports space optional when only has exports dep

### DIFF
--- a/packages/mfsu/src/dep/getExposeFromContent.ts
+++ b/packages/mfsu/src/dep/getExposeFromContent.ts
@@ -56,7 +56,9 @@ export default _;`.trim();
     if (
       hasNonDefaultExports(exports) ||
       // export * from 不会有 exports，只会有 imports
-      /export\s+\*\s+from/.test(opts.content)
+      // case: export*from'.'
+      //       export * from '.'
+      /export\s*\*\s*from/.test(opts.content)
     ) {
       ret.push(`export * from '${opts.dep.file}';`);
       hasExports = true;


### PR DESCRIPTION
fix #8564

比如 `@headlessui/react` 这个包的 esm 产物是：

```ts
export*from'some'
```

这样的，空格可有可无。

FYI：

 - https://cdn.jsdelivr.net/npm/@headlessui/react@1.6.6/dist/headlessui.esm.js