### PR TITLE
fix: fix use useSearchParams in useModel (#8545)

### DIFF
--- a/packages/renderer-react/src/browser.tsx
+++ b/packages/renderer-react/src/browser.tsx
@@ -79,17 +79,7 @@ export function renderClient(opts: {
       routes: clientRoutes,
     },
   });
-  let rootContainer = (
-    <BrowserRoutes
-      basename={basename}
-      pluginManager={opts.pluginManager}
-      routes={opts.routes}
-      clientRoutes={clientRoutes}
-      history={opts.history}
-    >
-      <Routes />
-    </BrowserRoutes>
-  );
+  let routesChildren = <Routes />;
   for (const key of [
     // Lowest to the highest priority
     'innerProvider',
@@ -99,13 +89,24 @@ export function renderClient(opts: {
     'outerProvider',
     'rootContainer',
   ]) {
-    rootContainer = opts.pluginManager.applyPlugins({
+    routesChildren = opts.pluginManager.applyPlugins({
       type: 'modify',
       key: key,
-      initialValue: rootContainer,
+      initialValue: routesChildren,
       args: {},
     });
   }
+  const rootContainer = (
+    <BrowserRoutes
+      basename={basename}
+      pluginManager={opts.pluginManager}
+      routes={opts.routes}
+      clientRoutes={clientRoutes}
+      history={opts.history}
+    >
+      {routesChildren}
+    </BrowserRoutes>
+  );
 
   const Browser = () => {
     const [clientLoaderData, setClientLoaderData] = useState<ILoaderData>({});


### PR DESCRIPTION
Close #8545 

由于 BrowserRoutes 作为 children 传给 dataflow plugin，在 useModel 使用 useSearchParams，会导致无法获取 router context。修复方式为，将 BrowserRoutes 放置在外层，使 dataflow 相关 plugin 中都能够获取到 router context，从而顺利使用 router 相关 hooks