### PR TITLE
fix(external): external compatible when react < 18

### DIFF
--- a/packages/preset-umi/src/features/configPlugins/configPlugins.ts
+++ b/packages/preset-umi/src/features/configPlugins/configPlugins.ts
@@ -19,6 +19,7 @@ function resolveProjectDep(opts: { pkg: any; cwd: string; dep: string }) {
 }
 
 export default (api: IApi) => {
+  const { userConfig } = api;
   const reactDOMPath =
     resolveProjectDep({
       pkg: api.pkg,
@@ -47,7 +48,15 @@ export default (api: IApi) => {
         require.resolve('react-router-dom/package.json'),
       ),
     },
-    externals: {},
+    externals: {
+      // Keep the `react-dom/client` external consistent with the `react-dom` external when react < 18.
+      // Otherwise, `react-dom/client` will still bundled in the outputs.
+      ...(isLT18 && userConfig.externals?.['react-dom']
+        ? {
+            'react-dom/client': userConfig.externals['react-dom'],
+          }
+        : {}),
+    },
     autoCSSModules: true,
     publicPath: '/',
     mountElementId: 'root',


### PR DESCRIPTION
fix #8572

react < 18 时由于兼容了 `react-dom/client` 的导入，所以这要求他和 `react-dom` 的 `external` 一致（如果有），否则 `react-dom` 仍将打包进产物。