### PR TITLE
feat: plugin helmet

### DIFF
--- a/examples/helmet/package.json
+++ b/examples/helmet/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@example/helmet",
+  "private": true,
+  "scripts": {
+    "build": "max build",
+    "dev": "max dev",
+    "start": "npm run dev"
+  },
+  "dependencies": {
+    "@umijs/max": "4.0.0-canary.20220718.1",
+    "react": "18.1.0",
+    "react-dom": "18.1.0"
+  }
+}

--- a/examples/helmet/src/pages/index.tsx
+++ b/examples/helmet/src/pages/index.tsx
@@ -1,0 +1,12 @@
+import { Helmet } from '@umijs/max';
+export default () => {
+  return (
+    <div>
+      <Helmet>
+        <title>Helmet</title>
+        <meta name="description" content="Helmet" />
+      </Helmet>
+      <h1>Helmet</h1>
+    </div>
+  );
+};

--- a/examples/helmet/tsconfig.json
+++ b/examples/helmet/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./src/.umi/tsconfig.json"
+}

--- a/packages/max/src/preset.ts
+++ b/packages/max/src/preset.ts
@@ -13,6 +13,7 @@ export default () => {
       require.resolve('@umijs/plugins/dist/locale'),
       require.resolve('@umijs/plugins/dist/qiankun'),
       require.resolve('@umijs/plugins/dist/tailwindcss'),
+      require.resolve('@umijs/plugins/dist/helmet'),
       require.resolve('./plugins/maxAlias'),
       require.resolve('./plugins/maxAppData'),
       require.resolve('./plugins/maxChecker'),

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -38,6 +38,7 @@
     "lodash": "^4.17.21",
     "moment": "^2.29.3",
     "qiankun": "^2.7.0",
+    "react-helmet-async": "^1.3.0",
     "react-intl": "3.12.1",
     "react-redux": "^8.0.2",
     "redux": "^4.2.0",

--- a/packages/plugins/src/helmet.ts
+++ b/packages/plugins/src/helmet.ts
@@ -1,0 +1,47 @@
+import { Mustache, winPath } from '@umijs/utils';
+import type { IApi } from 'umi';
+
+import { dirname } from 'path';
+import { withTmpPath } from './utils/withTmpPath';
+
+export default (api: IApi) => {
+  const helmetPkgPath = winPath(
+    dirname(require.resolve('react-helmet-async/package')),
+  );
+
+  api.modifyConfig((memo) => {
+    // import from react-helmet-async
+    memo.alias['react-helmet$'] = helmetPkgPath;
+    memo.alias['react-helmet-async$'] = helmetPkgPath;
+    return memo;
+  });
+
+  api.onGenerateFiles(async () => {
+    api.writeTmpFile({
+      path: 'index.ts',
+      content: Mustache.render(
+        `export { Helmet, HelmetProvider, HelmetData } from '{{{ HelmetPkg }}}';`,
+        {
+          HelmetPkg: helmetPkgPath,
+        },
+      ),
+    });
+
+    // runtime.tsx
+    api.writeTmpFile({
+      path: 'runtime.tsx',
+      content: `
+import React from 'react';
+import { HelmetProvider } from '${helmetPkgPath}';
+
+export function rootContainer(container, opts) {
+  return React.createElement(HelmetProvider, opts, container);
+}
+      `,
+    });
+  });
+
+  api.addRuntimePlugin(() => {
+    return [withTmpPath({ api, path: 'runtime.tsx' })];
+  });
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,16 @@ importers:
     dependencies:
       umi: link:../../packages/umi
 
+  examples/helmet:
+    specifiers:
+      '@umijs/max': 4.0.0-canary.20220718.1
+      react: 18.1.0
+      react-dom: 18.1.0
+    dependencies:
+      '@umijs/max': link:../../packages/max
+      react: 18.1.0
+      react-dom: 18.1.0_react@18.1.0
+
   examples/libs:
     specifiers:
       '@codesandbox/sandpack-react': 1.0.1
@@ -1175,6 +1185,7 @@ importers:
       lodash: ^4.17.21
       moment: ^2.29.3
       qiankun: ^2.7.0
+      react-helmet-async: ^1.3.0
       react-intl: 3.12.1
       react-redux: ^8.0.2
       redux: ^4.2.0
@@ -1197,6 +1208,7 @@ importers:
       lodash: 4.17.21
       moment: 2.29.3
       qiankun: 2.7.3
+      react-helmet-async: 1.3.0
       react-intl: 3.12.1
       react-redux: 8.0.2_redux@4.2.0
       redux: 4.2.0
@@ -10796,7 +10808,7 @@ packages:
   /axios/0.21.4_debug@4.3.2:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.1
+      follow-redirects: 1.15.1_debug@4.3.2
     transitivePeerDependencies:
       - debug
     dev: true
@@ -10813,7 +10825,7 @@ packages:
   /axios/0.27.2_debug@4.3.4:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
-      follow-redirects: 1.15.1
+      follow-redirects: 1.15.1_debug@4.3.2
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
@@ -15377,6 +15389,18 @@ packages:
       debug:
         optional: true
 
+  /follow-redirects/1.15.1_debug@4.3.2:
+    resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dependencies:
+      debug: 4.3.2
+    dev: true
+
   /for-each/0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
     dependencies:
@@ -16415,7 +16439,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.1
+      follow-redirects: 1.15.1_debug@4.3.2
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -22636,6 +22660,7 @@ packages:
     peerDependencies:
       prettier: '>=2.0'
       typescript: '>=2.9'
+    dev: false
 
   /prettier-plugin-organize-imports/2.3.4_gd3y7r3s3evy6b2vthd7dmacga:
     resolution: {integrity: sha512-R8o23sf5iVL/U71h9SFUdhdOEPsi3nm42FD/oDYIZ2PQa4TNWWuWecxln6jlIQzpZTDMUeO1NicJP6lLn2TtRw==}
@@ -22653,6 +22678,7 @@ packages:
       prettier: '>= 1.16.0'
     dependencies:
       sort-package-json: 1.57.0
+    dev: false
 
   /prettier-plugin-packagejson/2.2.18_prettier@2.7.1:
     resolution: {integrity: sha512-iBjQ3IY6IayFrQHhXvg+YvKprPUUiIJ04Vr9+EbeQPfwGajznArIqrN33c5bi4JcIvmLHGROIMOm9aYakJj/CA==}
@@ -24694,6 +24720,24 @@ packages:
 
   /react-fast-compare/3.2.0:
     resolution: {integrity: sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==}
+    dev: false
+
+  /react-helmet-async/1.3.0:
+    resolution: {integrity: sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==}
+    peerDependencies:
+      react: ^16.6.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.6.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.18.3
+      invariant: 2.2.4
+      prop-types: 15.8.1
+      react-fast-compare: 3.2.0
+      shallowequal: 1.1.0
     dev: false
 
   /react-helmet/6.1.0:


### PR DESCRIPTION
把 helmet 功能加回来，不然代码迁移还要处理它。
从 react-helmet 改成了 react-helmet-async，其他逻辑照旧。
执行 `cd examples/helmet && pnpm dev`

![image](https://user-images.githubusercontent.com/11746742/179488305-41cd8b0c-f85d-417d-9cc7-f8c0b46bf76d.png)
