### PR TITLE
fix(favicon): typo

### DIFF
--- a/packages/preset-umi/src/features/favicons/favicons.ts
+++ b/packages/preset-umi/src/features/favicons/favicons.ts
@@ -25,7 +25,7 @@ export default (api: IApi) => {
   });
 
   api.modifyAppData(async (memo) => {
-    if (api.config.favicon) return memo;
+    if (api.config.favicons) return memo;
     const faviconFiles = getFaviconFiles(api.paths.absSrcPath);
     if (faviconFiles) {
       memo.faviconFiles = faviconFiles;


### PR DESCRIPTION
一个 favicon 插件的 typo ，没有 `api.config.favicon` 这个东西。

这导致用户配了自己的 `favicons` ，还会收集 `src/favicon` ，这是不对的。