### PR TITLE
fix(renderer-react): propsWithParams should be {...props, to} , not {...params, to}

### DIFF
--- a/packages/renderer-react/src/routes.tsx
+++ b/packages/renderer-react/src/routes.tsx
@@ -38,7 +38,7 @@ export function createClientRoutes(opts: {
 function NavigateWithParams(props: { to: string }) {
   const params = useParams();
   const propsWithParams = {
-    ...params,
+    ...props,
     to: generatePath(props.to, params),
   };
   return <Navigate {...propsWithParams} />;


### PR DESCRIPTION
处理 Navigate 时有个误拼，传入 `<Navigate />` 中的参数应该为传入 `<NavigateWithParams />` 的原始参数 `props` 加上渲染后的 `to`，而不是 `params` 和 `to`。。。