### PR TITLE
feat(preset-umi): babel preset config support custom

### DIFF
--- a/packages/babel-preset-umi/src/index.ts
+++ b/packages/babel-preset-umi/src/index.ts
@@ -52,10 +52,6 @@ export default (_context: any, opts: IOpts) => {
           '@umijs/bundler-utils/compiled/babel/preset-typescript',
         ),
         {
-          // 支持 vue 后缀
-          allExtensions: true,
-          // 支持 tsx
-          isTSX: true,
           allowNamespaces: true,
           allowDeclareFields: true,
           // Why false?

--- a/packages/preset-umi/src/commands/dev/getBabelOpts.ts
+++ b/packages/preset-umi/src/commands/dev/getBabelOpts.ts
@@ -4,9 +4,9 @@ import { IApi } from '../../types';
 export async function getBabelOpts(opts: { api: IApi }) {
   // TODO: 支持用户自定义
   const isGTEReact17 = semver.gte(opts.api.appData.react.version, '17.0.0');
-  const babelPreset = [
-    require.resolve('@umijs/babel-preset-umi'),
-    {
+  const babelPresetOpts = await opts.api.applyPlugins({
+    key: 'modifyBabelPresetOpts',
+    initialValue: {
       presetEnv: {},
       presetReact: {
         runtime: isGTEReact17 ? 'automatic' : 'classic',
@@ -19,6 +19,11 @@ export async function getBabelOpts(opts: { api: IApi }) {
       pluginDynamicImportNode: false,
       pluginAutoCSSModules: opts.api.config.autoCSSModules,
     },
+  });
+
+  const babelPreset = [
+    require.resolve('@umijs/babel-preset-umi'),
+    babelPresetOpts,
   ];
   const extraBabelPresets = await opts.api.applyPlugins({
     key: 'addExtraBabelPresets',

--- a/packages/preset-umi/src/registerMethods.ts
+++ b/packages/preset-umi/src/registerMethods.ts
@@ -55,6 +55,7 @@ export default (api: IApi) => {
     'modifyRendererPath',
     'modifyServerRendererPath',
     'modifyRoutes',
+    'modifyBabelPresetOpts',
   ].forEach((name) => {
     api.registerMethod({ name });
   });

--- a/packages/preset-umi/src/types.ts
+++ b/packages/preset-umi/src/types.ts
@@ -102,6 +102,7 @@ export type IApi = PluginAPI &
         ): void;
       }): void;
     };
+    modifyBabelPresetOpts: IModify<any, null>;
     modifyHTML: IModify<CheerioAPI, { path: string }>;
     modifyHTMLFavicon: IModify<string[], {}>;
     modifyRendererPath: IModify<string, {}>;

--- a/packages/preset-vue/src/features/default.ts
+++ b/packages/preset-vue/src/features/default.ts
@@ -58,6 +58,16 @@ export default (api: IApi) => {
     dirname(require.resolve('@umijs/renderer-vue/package.json')),
   );
 
+  api.modifyBabelPresetOpts((memo) => {
+    memo.presetTypeScript = {
+      // 支持 vue 后缀
+      allExtensions: true,
+      // 支持 tsx
+      isTSX: true,
+    };
+    return memo;
+  });
+
   // 增加运行时key
   api.addRuntimePluginKey(() => [
     'router',


### PR DESCRIPTION
babel 配置支持自定义解 老项目使用 TS 尖括号断言导致的编译错误

## 变更

- babel-preset-umi  移除 vue 特有配置
- preset-umi 支持自定义babel 预设配置
- preset-vue 传入vue 特有预设配置

增加 `modifyBabelPresetOpts` 的 原因是 想在 支持时自定义这个配置(之前计划想实现 vue jsx 支持会需要, 或者一些vue 独有但是react 不需要的配置)