### PR TITLE
feat: auto-generate snapshot paths from pkg deps for tnpm project

### DIFF
--- a/packages/bundler-webpack/src/build.ts
+++ b/packages/bundler-webpack/src/build.ts
@@ -18,7 +18,7 @@ type IOpts = {
   extraBabelPlugins?: any[];
   extraBabelPresets?: any[];
   clean?: boolean;
-} & Pick<IConfigOpts, 'cache'>;
+} & Pick<IConfigOpts, 'cache' | 'pkg'>;
 
 export async function build(opts: IOpts): Promise<webpack.Stats> {
   const cacheDirectoryPath = resolve(
@@ -50,6 +50,7 @@ export async function build(opts: IOpts): Promise<webpack.Stats> {
           cacheDirectory: join(cacheDirectoryPath, 'bundler-webpack'),
         }
       : undefined,
+    pkg: opts.pkg,
   });
   let isFirstCompile = true;
   return new Promise((resolve, reject) => {

--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -1,4 +1,5 @@
 import CaseSensitivePaths from '@umijs/case-sensitive-paths-webpack-plugin';
+import { logger, resolve as resolveModule } from '@umijs/utils';
 import { join, resolve } from 'path';
 import webpack, { Configuration } from '../../compiled/webpack';
 import Config from '../../compiled/webpack-5-chain';
@@ -53,6 +54,7 @@ export interface IOpts {
     buildDependencies?: string[];
     cacheDirectory?: string;
   };
+  pkg?: Record<string, any>;
 }
 
 export async function getConfig(opts: IOpts): Promise<Configuration> {
@@ -233,10 +235,36 @@ export async function getConfig(opts: IOpts): Promise<Configuration> {
       const nodeModulesPath =
         opts.cache.absNodeModulesPath ||
         join(opts.rootDir || opts.cwd, 'node_modules');
+      // 寻找本地 link 的 node_modules 目录，避免 NPM 包 link 场景下导致缓存生成 OOM
+      const localLinkedNodeModules = Object.keys(
+        Object.assign(
+          {},
+          opts.pkg?.dependencies,
+          opts.pkg?.peerDependencies,
+          opts.pkg?.devDependencies,
+        ),
+      )
+        .map((pkg: string) =>
+          resolve(
+            resolveModule.sync(`${pkg}/package.json`, {
+              basedir: opts.rootDir || opts.cwd,
+              preserveSymlinks: false,
+            }),
+            '../node_modules',
+          ),
+        )
+        .filter((pkg: string) => !pkg.startsWith(opts.rootDir || opts.cwd));
+
+      if (localLinkedNodeModules.length) {
+        logger.info(
+          `Detected local linked tnpm node_modules, to avoid oom, they will be treated as immutablePaths & managedPaths in webpack snapshot:`,
+        );
+        localLinkedNodeModules.forEach((p) => logger.info(`  ${p}`));
+      }
 
       config.snapshot({
-        immutablePaths: [nodeModulesPath],
-        managedPaths: [nodeModulesPath],
+        immutablePaths: [nodeModulesPath, ...localLinkedNodeModules],
+        managedPaths: [nodeModulesPath, ...localLinkedNodeModules],
       });
     }
 

--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -244,15 +244,20 @@ export async function getConfig(opts: IOpts): Promise<Configuration> {
           opts.pkg?.devDependencies,
         ),
       )
-        .map((pkg: string) =>
-          resolve(
-            resolveModule.sync(`${pkg}/package.json`, {
-              basedir: opts.rootDir || opts.cwd,
-              preserveSymlinks: false,
-            }),
-            '../node_modules',
-          ),
-        )
+        .map((pkg: string) => {
+          try {
+            return resolve(
+              resolveModule.sync(`${pkg}/package.json`, {
+                basedir: opts.rootDir || opts.cwd,
+                preserveSymlinks: false,
+              }),
+              '../node_modules',
+            );
+          } catch {
+            // will be filtered below
+            return opts.rootDir || opts.cwd;
+          }
+        })
         .filter((pkg: string) => !pkg.startsWith(opts.rootDir || opts.cwd));
 
       if (localLinkedNodeModules.length) {

--- a/packages/bundler-webpack/src/dev.ts
+++ b/packages/bundler-webpack/src/dev.ts
@@ -30,7 +30,7 @@ type IOpts = {
   mfsuStrategy?: 'eager' | 'normal';
   mfsuInclude?: string[];
   srcCodeCache?: any;
-} & Pick<IConfigOpts, 'cache'>;
+} & Pick<IConfigOpts, 'cache' | 'pkg'>;
 
 export function stripUndefined(obj: any) {
   Object.keys(obj).forEach((key) => {
@@ -112,6 +112,7 @@ export async function dev(opts: IOpts) {
           cacheDirectory: join(cacheDirectoryPath, 'bundler-webpack'),
         }
       : undefined,
+    pkg: opts.pkg,
   });
 
   const depConfig = await getConfig({
@@ -128,6 +129,7 @@ export async function dev(opts: IOpts) {
       buildDependencies: opts.cache?.buildDependencies,
       cacheDirectory: join(cacheDirectoryPath, 'mfsu-deps'),
     },
+    pkg: opts.pkg,
   });
 
   webpackConfig.resolve!.alias ||= {};

--- a/packages/preset-umi/src/commands/dev/dev.ts
+++ b/packages/preset-umi/src/commands/dev/dev.ts
@@ -264,6 +264,7 @@ PORT=8888 umi dev
 
       const opts = {
         config: api.config,
+        pkg: api.pkg,
         cwd: api.cwd,
         rootDir: process.cwd(),
         entry: {


### PR DESCRIPTION
在 tnpm 安装的项目中，自动根据项目的依赖扫描 link 的本地 NPM 包，避免 tnpm 的 node_modules 目录结构导致 webpack 缓存序列化 OOM