### PR TITLE
docs: history

### DIFF
--- a/docs/docs/api/api.md
+++ b/docs/docs/api/api.md
@@ -85,19 +85,29 @@ TODO: SUPPORT
 获取当前路由信息。
 
 ```ts
-import { history } from 'umi';
-
-// // history 栈里的实体个数
-history.length;
-
-// 当前 history 跳转的 action，有 PUSH、REPLACE 和 POP 三种类型
-history.action;
-
 // location 对象，包含 pathname、search 和 hash
-history.location.pathname;
-history.location.search;
-history.location.hash;
+window.location.pathname;
+window.location.search;
+window.location.hash;
 ```
+
+或者
+
+```ts
+// 建议组件或 hooks 里用 useLocation 取
+import { useLocation } from 'umi';
+export default function Page() {
+  let location = useLocation();
+  return (
+    <div>
+     { location.pathname }
+     { location.search }
+     { location.hash }
+    </div>
+  );
+}
+```
+
 
 命令式路由跳转。
 
@@ -447,7 +457,7 @@ import { useMatch } from 'umi';
 
 // when url = '/events/12'
 const match = useMatch('/events/:eventId');
-console.log(match?.pathname, match?.params.eventId); 
+console.log(match?.pathname, match?.params.eventId);
 // '/events/12 12'
 ```
 
@@ -490,7 +500,7 @@ navigate(-1);
 `useOutlet` 返回当前匹配的子路由元素，`<Outlet>` 内部使用的就是此 hook 。
 
 类型定义如下：
-```ts 
+```ts
 declare function useOutlet(): React.ReactElement | null;
 ```
 
@@ -512,7 +522,7 @@ const Layout = ()=>{
 `useOutletContext` 用于返回 `Outlet` 组件上挂载的 `context` 。
 
 类型定义如下：
-```ts 
+```ts
 declare function useOutlet(): React.ReactElement | null;
 ```
 
@@ -529,7 +539,7 @@ const Layout = () => {
 const SomeRouteComponentUnderLayout = () => {
   const layoutContext = useOutletContext();
 
-  return JSON.stringify(layoutContext)   // {"prop":"from Layout"} 
+  return JSON.stringify(layoutContext)   // {"prop":"from Layout"}
 }
 ```
 
@@ -552,7 +562,7 @@ import { useParams } from 'umi';
 // 假设有路由配置  user/:uId/repo/:rId
 // 当前路径       user/abc/repo/def
 const params = useParams()
-/* params 
+/* params
 { uId: 'abc', rId: 'def'}
 */
 ```
@@ -572,7 +582,7 @@ declare function useResolvedPath(to: To): Path;
 import { useResolvedPath } from 'umi';
 
 const path = useResolvedPath('docs')
-/* path 
+/* path
 { pathname: '/a/new/page/docs', search: '', hash: '' }
 */
 ```
@@ -660,7 +670,7 @@ declare function useSearchParams(defaultInit?: URLSearchParamsInit): [
   ) => void
 ];
 
-type URLSearchParamsInit = 
+type URLSearchParamsInit =
   | string
   | ParamKeyValuePair[]
   | Record<string, string | string[]>

--- a/docs/docs/introduce/upgrade-to-umi-4.md
+++ b/docs/docs/introduce/upgrade-to-umi-4.md
@@ -19,7 +19,7 @@
 ```diff
 {
   "devDependencies": {
-+   "@umijs/max": "^4.0.0",  
++   "@umijs/max": "^4.0.0",
 -   "umi": "^3.0.0",
 -   "@umijs/preset-react": "^1.2.2"
   }
@@ -173,8 +173,8 @@ import React from 'react';
 export default function Page(props) {
   return (
     <div onClick={()=>{
--          props.history.push('list'); 
-+          history.push('list'); 
+-          props.history.push('list');
++          history.push('list');
     }}>
     </div>
   );
@@ -183,13 +183,15 @@ export default function Page(props) {
 
 #### location
 
+> 建议组件或 hooks 里用 useLocation 取，其他地方就用 window.location 获取。
+
 ```diff
-+ import { history } from 'umi';
 export default function Page(props) {
++  const { location } = window;
   return (
     <div>
 -     { props.location }
-+     { history.location }
++     { location }
     </div>
   );
 }


### PR DESCRIPTION
 目前设计的是import { history } from 'umi';用来做命令式路由跳转，这里面的获取的信息就没有价值了吗。uselocation和window.location获取location信息。以前堆栈长度那些怎么获取呢