### PR TITLE
fix: Solved types error.

### DIFF
--- a/packages/plugins/src/layout.ts
+++ b/packages/plugins/src/layout.ts
@@ -277,6 +277,9 @@ const { formatMessage } = useIntl();
       initData: InitDataType,
     ) => ProLayoutProps & {
       childrenRender?: (dom: JSX.Element, props: ProLayoutProps) => React.ReactNode,
+      rightRender?: (initialState: any, setInitialState: any, runtimeConfig: any) => React.ReactNode,
+      logout?: (initialState: any) => void,
+      rightContentRender?: (props: ProLayoutProps, dom: JSX.Element, config: RunTimeLayoutConfig) => React.ReactNode,
       unAccessible?: JSX.Element,
       noFound?: JSX.Element,
     };


### PR DESCRIPTION
#8606 

这部分类型拿不准先写的any
```
rightRender?: (initialState: any, setInitialState: any, runtimeConfig: any) => React.ReactNode,
 logout?: (initialState: any) => void,
```

initialState会是InitDataType['initialState']中的么？再或者 setInitialState会是InitDataType['setInitialState']