### PR TITLE
fix(bundler-webpack): runtimePublicPath compatibility

### DIFF
--- a/packages/bundler-webpack/src/plugins/RuntimePublicPathPlugin.ts
+++ b/packages/bundler-webpack/src/plugins/RuntimePublicPathPlugin.ts
@@ -18,7 +18,7 @@ export class RuntimePublicPathPlugin {
           )
             return;
           // @ts-ignore
-          module._cachedGeneratedCode = `__webpack_require__.p = (globalThis || window).publicPath || '/';`;
+          module._cachedGeneratedCode = `__webpack_require__.p = (typeof globalThis !== undefined ? globalThis : window).publicPath || '/';`;
         }
       });
     });


### PR DESCRIPTION
修复 `runtimePublicPath` 注入代码在旧版本浏览器上的兼容性，`globalThis is not defined`