### PR TITLE
docs: patchClientRoutes params

### DIFF
--- a/docs/docs/api/runtime-config.md
+++ b/docs/docs/api/runtime-config.md
@@ -93,7 +93,7 @@ import Page from '@/extraRoutes/foo';
 export function patchClientRoutes({ routes }) {
   routes.unshift({
     path: '/foo',
-    component: <Page />
+    element: <Page />
   });
 }
 ```
@@ -109,7 +109,7 @@ export function patchClientRoutes({ routes }) {
 }
 
 export function render(oldRender) {
-  fetch('/api/routes').then(res=>res.json()).then((res) => {
+  fetch('/api/routes').then(res => res.json()).then((res) => {
     extraRoutes = res.routes;
     oldRender();
   })


### PR DESCRIPTION
resolve #8653

键写错了，应该和 react router v6 一致。

-----
[View rendered docs/docs/api/runtime-config.md](https://github.com/MoeYc/umi/blob/docs/path-routes-code/docs/docs/api/runtime-config.md)