### PR TITLE
feat(create-umi): improve git and monorepo init project

### DIFF
--- a/docs/docs/tutorials/getting-started.md
+++ b/docs/docs/tutorials/getting-started.md
@@ -118,6 +118,15 @@ info  - generate files
 
 国内建议选 **pnpm + taobao 源**，速度提升明显。这一步会自动安装依赖，同时安装成功后会自动执行 `umi setup` 做一些文件预处理等工作。
 
+### 参数选项
+
+使用 `create-umi` 创建项目时，可用的参数如下：
+
+option|description
+:-:|:-
+`--no-git`|创建项目，但不初始化 Git
+`--no-install`|创建项目，但不自动安装依赖
+
 ## 启动项目
 
 执行 `pnpm dev` 命令，

--- a/packages/create-umi/src/index.ts
+++ b/packages/create-umi/src/index.ts
@@ -29,6 +29,7 @@ interface IArgs extends yParser.Arguments {
   default?: boolean;
   plugin?: boolean;
   git?: boolean;
+  install?: boolean;
 }
 
 interface IContext {
@@ -193,8 +194,10 @@ export default async ({ cwd, args }: { cwd: string; args: IArgs }) => {
   }
 
   // install deps
-  if (!args.default) {
+  if (!args.default && args.install !== false) {
     installWithNpmClient({ npmClient, cwd: target });
+  } else {
+    logger.info(`Skip install deps`);
   }
 };
 

--- a/packages/create-umi/templates/app/.npmrc.tpl
+++ b/packages/create-umi/templates/app/.npmrc.tpl
@@ -1,1 +1,2 @@
 registry={{{ registry }}}
+{{{ extraNpmrc }}}

--- a/packages/create-umi/templates/max/.npmrc.tpl
+++ b/packages/create-umi/templates/max/.npmrc.tpl
@@ -1,1 +1,2 @@
 registry={{{ registry }}}
+{{{ extraNpmrc }}}

--- a/packages/create-umi/templates/max/package.json.tpl
+++ b/packages/create-umi/templates/max/package.json.tpl
@@ -4,8 +4,8 @@
   "scripts": {
     "dev": "max dev",
     "build": "max build",
-    "format": "prettier --cache --write .",
-    "prepare": "husky install",
+    "format": "prettier --cache --write .",{{#withHusky}}
+    "prepare": "husky install",{{/withHusky}}
     "postinstall": "max setup",
     "setup": "max setup",
     "start": "npm run dev"
@@ -18,8 +18,8 @@
   },
   "devDependencies": {
     "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0",
-    "husky": "^8.0.1",
+    "@types/react-dom": "^18.0.0",{{#withHusky}}
+    "husky": "^8.0.1",{{/withHusky}}
     "lint-staged": "^13.0.3",
     "prettier": "^2.7.1",
     "prettier-plugin-organize-imports": "^2",

--- a/packages/create-umi/templates/plugin/.npmrc.tpl
+++ b/packages/create-umi/templates/plugin/.npmrc.tpl
@@ -1,1 +1,2 @@
 registry={{{ registry }}}
+{{{ extraNpmrc }}}

--- a/packages/create-umi/templates/vue-app/.npmrc.tpl
+++ b/packages/create-umi/templates/vue-app/.npmrc.tpl
@@ -1,1 +1,2 @@
 registry={{{ registry }}}
+{{{ extraNpmrc }}}


### PR DESCRIPTION
### 以下均为 create-umi 的改动

#### auto install

创建项目时，支持 `--no-install` 关闭自动安装依赖。

#### husky

1. 新 feature ：支持自动 git init （可以 `--no-git` 关闭）。

    **原因**：husky 必须要 git init 后才能用，否则 install 会报错，fix #8681 

2. 在 monorepo 中创建子项目，这和项目根目录有关，所以默认关闭 husky 。

#### .npmrc

1. monorepo 里创建子项目，应该把 `.npmrc` 放到项目根目录（若没有则创建，若有则放弃）。

2. 使用 pnpm v7 时，需要额外的选项抑制 warning 。

-----
[View rendered docs/docs/tutorials/getting-started.md](https://github.com/MoeYc/umi/blob/fix/max-should-init-git/docs/docs/tutorials/getting-started.md)