### PR TITLE
fix(plugins): antd user config be overwritten by env config

### DIFF
--- a/packages/plugins/src/antd.ts
+++ b/packages/plugins/src/antd.ts
@@ -57,11 +57,11 @@ export default (api: IApi) => {
   api.modifyConfig((memo) => {
     checkPkgPath();
 
-    const antd = memo.antd || {};
+    let antd = memo.antd || {};
     // defaultConfig 的取值在 config 之后，所以改用环境变量传默认值
     if (process.env.UMI_PLUGIN_ANTD_ENABLE) {
       const { defaultConfig } = JSON.parse(process.env.UMI_PLUGIN_ANTD_ENABLE);
-      Object.assign(antd, defaultConfig);
+      antd = Object.assign(defaultConfig, antd);
     }
 
     // antd import


### PR DESCRIPTION
修复 antd 插件通过 `UMI_PLUGIN_ANTD_ENABLE` 环境变量开启时，用户的配置会被强制覆盖的问题