### PR TITLE
fix(bundler-utils): change `mkcert --version` to `mkcert -help`

### DIFF
--- a/packages/bundler-utils/src/https.ts
+++ b/packages/bundler-utils/src/https.ts
@@ -16,7 +16,7 @@ export type { Server as SpdyServer } from 'spdy';
 export async function resolveHttpsConfig(httpsConfig: HttpsServerOptions) {
   // Check if mkcert is installed
   try {
-    await execa.execa('mkcert', ['--version']);
+    await execa.execa('mkcert', ['-help']);
   } catch (e) {
     logger.error('[HTTPS] The mkcert has not been installed.');
     logger.info('[HTTPS] Please follow the guide to install manually.');

--- a/packages/bundler-utils/src/https.ts
+++ b/packages/bundler-utils/src/https.ts
@@ -16,6 +16,7 @@ export type { Server as SpdyServer } from 'spdy';
 export async function resolveHttpsConfig(httpsConfig: HttpsServerOptions) {
   // Check if mkcert is installed
   try {
+    // use mkcert -help instead of mkcert --version for checking if mkcert is installed, cause mkcert --version does not exists in Linux
     await execa.execa('mkcert', ['-help']);
   } catch (e) {
     logger.error('[HTTPS] The mkcert has not been installed.');


### PR DESCRIPTION
### Description
Change `mkcert --version` to `mkcert -help`  for checking if mkcert is installed, cause `mkcert --version` not exists in Linux.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other