### PR TITLE
fix(plugins): workaround for circular dep in locale plugin

### DIFF
--- a/packages/plugins/libs/locale/localeExports.tpl
+++ b/packages/plugins/libs/locale/localeExports.tpl
@@ -3,7 +3,6 @@ import {
   IntlShape,
   MessageDescriptor,
 } from '{{{ reactIntlPkgPath }}}';
-import { ApplyPluginsType } from 'umi';
 import { getPluginManager } from '../core/plugin';
 import EventEmitter from '{{{EventEmitterPkg}}}';
 // @ts-ignore
@@ -153,7 +152,8 @@ export const setIntl = (locale: string) => {
 export const getLocale = () => {
   const runtimeLocale = getPluginManager().applyPlugins({
     key: 'locale',
-    type: ApplyPluginsType.modify,
+    // workaround: 不使用 ApplyPluginsType.modify 是为了避免循环依赖，与 fast-refresh 一起用时会有问题
+    type: 'modify',
     initialValue: {},
   });
   // runtime getLocale for user define
@@ -201,7 +201,8 @@ export const setLocale = (lang: string, realReload: boolean = true) => {
   //const { pluginManager } = useAppContext();
   //const runtimeLocale = pluginManagerapplyPlugins({
   //  key: 'locale',
-  //  type: ApplyPluginsType.modify,
+  //  workaround: 不使用 ApplyPluginsType.modify 是为了避免循环依赖，与 fast-refresh 一起用时会有问题
+  //  type: 'modify',
   //  initialValue: {},
   //});
 


### PR DESCRIPTION
workaround 修复 locale 插件 exports 循环依赖有几率导致 fast-refresh 运行时报错的问题，真实原因待排查