### PR TITLE
chore(jsMinifier): ie is not supported esbuild tips

### DIFF
--- a/packages/bundler-webpack/src/config/compressPlugin.ts
+++ b/packages/bundler-webpack/src/config/compressPlugin.ts
@@ -33,6 +33,7 @@ export async function addCompressPlugin(opts: IOpts) {
   // esbuild transform only allow `string[]` as target
   const esbuildTarget = getEsBuildTarget({
     targets: userConfig.targets || {},
+    jsMinifier,
   });
 
   let minify: any;

--- a/packages/bundler-webpack/src/utils/getEsBuildTarget.test.ts
+++ b/packages/bundler-webpack/src/utils/getEsBuildTarget.test.ts
@@ -3,15 +3,17 @@ import { getEsBuildTarget } from './getEsBuildTarget';
 test('normal', () => {
   expect(
     getEsBuildTarget({
-      targets: { chrome: 80 },
+      targets: { chrome: 80, firefox: 100 },
+      jsMinifier: 'esbuild',
     }),
-  ).toEqual(['chrome80']);
+  ).toEqual(['chrome80', 'firefox100']);
 });
 
-test('not ie', () => {
-  expect(
+test('ie is not supported esbuild minify', () => {
+  expect(() =>
     getEsBuildTarget({
-      targets: { chrome: 80, ie: 8, edge: 11 },
+      targets: { ie: 11 },
+      jsMinifier: 'esbuild',
     }),
-  ).toEqual(['chrome80', 'edge11']);
+  ).toThrow('IE is not supported');
 });

--- a/packages/bundler-webpack/src/utils/getEsBuildTarget.ts
+++ b/packages/bundler-webpack/src/utils/getEsBuildTarget.ts
@@ -12,7 +12,7 @@ export function getEsBuildTarget({ targets, jsMinifier }: IOpts) {
     logger.error(
       `${chalk.red(
         `jsMinifier: esbuild`,
-      )} does not support ie as targets, You can use ${chalk.green(
+      )} is not supported when there is ie in the targets, you can use ${chalk.green(
         `jsMinifier: 'terser'`,
       )}`,
     );

--- a/packages/bundler-webpack/src/utils/getEsBuildTarget.ts
+++ b/packages/bundler-webpack/src/utils/getEsBuildTarget.ts
@@ -1,10 +1,24 @@
+import { chalk, logger } from '@umijs/utils';
 import { DEFAULT_ESBUILD_TARGET_KEYS } from '../constants';
+import { JSMinifier } from '../types';
 
 interface IOpts {
   targets: Record<string, any>;
+  jsMinifier: `${JSMinifier}`;
 }
 
-export function getEsBuildTarget({ targets }: IOpts) {
+export function getEsBuildTarget({ targets, jsMinifier }: IOpts) {
+  if (targets?.['ie'] && jsMinifier === JSMinifier.esbuild) {
+    logger.error(
+      `${chalk.red(
+        `jsMinifier: esbuild`,
+      )} does not support ie as targets, You can use ${chalk.green(
+        `jsMinifier: 'terser'`,
+      )}`,
+    );
+    throw new Error('IE is not supported');
+  }
+
   return Object.keys(targets)
     .filter((key) => DEFAULT_ESBUILD_TARGET_KEYS.includes(key))
     .map((key) => {

--- a/packages/bundler-webpack/src/utils/getEsBuildTarget.ts
+++ b/packages/bundler-webpack/src/utils/getEsBuildTarget.ts
@@ -8,7 +8,7 @@ interface IOpts {
 }
 
 export function getEsBuildTarget({ targets, jsMinifier }: IOpts) {
-  if (targets?.['ie'] && jsMinifier === JSMinifier.esbuild) {
+  if (targets['ie'] && jsMinifier === JSMinifier.esbuild) {
     logger.error(
       `${chalk.red(
         `jsMinifier: esbuild`,


### PR DESCRIPTION
resolve #8744

默认的 esbuild js minify 不支持 ie 作为 target ，提示用户应该使用 terser 。