### PR TITLE
feat(plugin-tailwindcss): Add support for using APP_ROOT with tailwind plugin

### DIFF
--- a/packages/plugins/src/tailwindcss.ts
+++ b/packages/plugins/src/tailwindcss.ts
@@ -23,7 +23,10 @@ export default (api: IApi) => {
     const inputPath = join(api.cwd, 'tailwind.css');
     const generatedPath = join(api.paths.absTmpPath, outputPath);
     const binPath = join(api.cwd, 'node_modules/.bin/tailwind');
-    const configPath = join(api.cwd, 'tailwind.config.js');
+    const configPath = join(
+      process.env.APP_ROOT || api.cwd,
+      'tailwind.config.js',
+    );
 
     return new Promise<void>((resolve) => {
       /** 透过子进程建立 tailwindcss 服务，将生成的 css 写入 generatedPath */

--- a/packages/plugins/src/tailwindcss.ts
+++ b/packages/plugins/src/tailwindcss.ts
@@ -23,12 +23,15 @@ export default (api: IApi) => {
     const inputPath = join(api.cwd, 'tailwind.css');
     const generatedPath = join(api.paths.absTmpPath, outputPath);
     const binPath = join(api.cwd, 'node_modules/.bin/tailwind');
+    const configPath = join(api.cwd, 'tailwind.config.js');
 
     return new Promise<void>((resolve) => {
       /** 透过子进程建立 tailwindcss 服务，将生成的 css 写入 generatedPath */
       tailwind = crossSpawn(
         `${binPath}`,
         [
+          '-c',
+          configPath,
           '-i',
           inputPath,
           '-o',
@@ -37,6 +40,7 @@ export default (api: IApi) => {
         ],
         {
           stdio: 'inherit',
+          cwd: process.env.APP_ROOT || api.cwd,
         },
       );
       tailwind.on('error', (m: any) => {


### PR DESCRIPTION
Close #8771 

当使用 `plugin-tailwindcss` 时，如果指定 `APP_ROOT` 到子目录，设置中的 `content` 无法正确解析使用的 classnames

### Before

<img width="1265" alt="Screen Shot 2022-07-29 at 11 46 28 AM" src="https://user-images.githubusercontent.com/21105863/181680028-8d640323-1efd-4ae6-8ca9-60a8087395b8.png">

解决方法：在 tailwindcss 插件启动子进程时，指定 `cwd` 到 `process.env.APP_ROOT || api.cwd`

### After

<img width="1265" alt="Screen Shot 2022-07-29 at 11 47 05 AM" src="https://user-images.githubusercontent.com/21105863/181680053-af3c0a40-06c5-403e-a406-81beb3bdf8ce.png">

