### PR TITLE
fix(plugins/locale): 修复国际化插件导出的 api ts类型失效的bug

### DIFF
--- a/packages/plugins/src/locale.ts
+++ b/packages/plugins/src/locale.ts
@@ -240,8 +240,8 @@ export default (api: IApi) => {
     api.writeTmpFile({
       path: 'index.ts',
       content: `
-export { addLocale, setLocale, getLocale, getIntl, useIntl, injectIntl, formatMessage, FormattedMessage, getAllLocales } from './localeExports.ts';
-export { SelectLang } from './SelectLang.tsx';
+export { addLocale, setLocale, getLocale, getIntl, useIntl, injectIntl, formatMessage, FormattedMessage, getAllLocales } from './localeExports';
+export { SelectLang } from './SelectLang';
 `,
     });
   });


### PR DESCRIPTION
Close #8751

该问题是因为reexport的时候用了文件名，这导致了 ts 类型的丢失。修改方法是将文件名改成模块名。并不是纯类型的导出，故不需要 .d.ts