### PR TITLE
fix(route): path ends with `*` children should inherit `*`

### DIFF
--- a/packages/core/src/route/routesConfig.test.ts
+++ b/packages/core/src/route/routesConfig.test.ts
@@ -131,6 +131,75 @@ test('wrappers', () => {
   });
 });
 
+test('wrappers path ends with `*`, children should inherit `*` as path', () => {
+  // multi wrappers
+  expect(
+    getConfigRoutes({
+      routes: [
+        {
+          path: '/home/*',
+          component: 'index',
+          wrappers: ['wrapperA', 'wrapperB'],
+        },
+      ],
+    }),
+  ).toEqual({
+    '2': {
+      id: '2',
+      path: '/home/*',
+      absPath: '/home/*',
+      file: 'wrapperA',
+      parentId: undefined,
+      isWrapper: true,
+    },
+    '3': {
+      id: '3',
+      path: '*',
+      file: 'wrapperB',
+      absPath: '/home/*',
+      parentId: '2',
+      isWrapper: true,
+    },
+    '1': {
+      id: '1',
+      file: 'index',
+      path: '*',
+      absPath: '/home/*',
+      parentId: '3',
+      originPath: '/home/*',
+    },
+  });
+  // single wrapper
+  expect(
+    getConfigRoutes({
+      routes: [
+        {
+          path: '/*',
+          component: 'index',
+          wrappers: ['wrapper'],
+        },
+      ],
+    }),
+  ).toEqual({
+    '2': {
+      id: '2',
+      path: '/*',
+      absPath: '/*',
+      file: 'wrapper',
+      parentId: undefined,
+      isWrapper: true,
+    },
+    '1': {
+      id: '1',
+      path: '*',
+      absPath: '/*',
+      originPath: '/*',
+      file: 'index',
+      parentId: '2',
+    },
+  });
+});
+
 test('opts.onResolveComponent', () => {
   expect(
     getConfigRoutes({

--- a/packages/core/src/route/routesConfig.ts
+++ b/packages/core/src/route/routesConfig.ts
@@ -54,7 +54,7 @@ function transformRoute(opts: {
     const parentAbsPath = opts.parentId
       ? opts.memo.ret[opts.parentId].absPath.replace(/\/+$/, '/') // to remove '/'s on the tail
       : '/';
-    absPath = parentAbsPath + absPath;
+    absPath = `${parentAbsPath}${endsWithStar(parentAbsPath) ? '' : absPath}`;
   }
   opts.memo.ret[id] = {
     ...routeProps,
@@ -83,7 +83,7 @@ function transformRoute(opts: {
         onResolveComponent: opts.onResolveComponent,
       });
       parentId = id;
-      path = '';
+      path = endsWithStar(path) ? '*' : '';
     });
     opts.memo.ret[id].parentId = parentId;
     opts.memo.ret[id].path = path;
@@ -99,4 +99,8 @@ function transformRoute(opts: {
     });
   }
   return { id };
+}
+
+function endsWithStar(str: string) {
+  return str.endsWith('*');
 }


### PR DESCRIPTION
fix #8787

父路由结尾是通配符 `*` 时，子路由的路径应该是 `path: '*'` ，而 `path: ''` 无法匹配上。


