### PR TITLE
fix: replacer get wrong result when the value is undefined

### DIFF
--- a/packages/core/src/Route/routesToJSON.test.ts
+++ b/packages/core/src/Route/routesToJSON.test.ts
@@ -197,3 +197,28 @@ test('wrappers with dynamicImport', () => {
   `.trim(),
   );
 });
+
+test('wrappers is undefined', () => {
+  const ret = routesToJSON({
+    routes: [
+      {
+        path: '/',
+        component: '@/pages/index.ts',
+        wrappers: undefined,
+      },
+    ],
+    config: {
+      dynamicImport: true,
+    },
+  });
+  expect(ret).toEqual(
+    `
+[
+  {
+    "path": "/",
+    "component": dynamic({ loader: () => import(/* webpackChunkName: 'p__index' */'@/pages/index.ts')})
+  }
+]
+  `.trim(),
+  );
+});

--- a/packages/core/src/Route/routesToJSON.ts
+++ b/packages/core/src/Route/routesToJSON.ts
@@ -55,6 +55,9 @@ export default function ({ routes, config, cwd, isServer }: IOpts) {
   }
 
   function replacer(key: string, value: any) {
+    // JSON.stringify with take the value of undefined
+    if (value === undefined) return undefined;
+
     switch (key) {
       case 'component':
         if (isFunctionComponent(value)) return value;


### PR DESCRIPTION
3.x 版本中 Route 处理采用了 JSON.stringify 的方法这会导致无法过滤掉一些手动传入的 undefined 的相关数据，这会导致后面解析整个路由的时候出错 cannot read map of undefined，所以给 replacer 函数加了一个过滤