### PR TITLE
feat: add defineApp

### DIFF
--- a/docs/docs/api/runtime-config.md
+++ b/docs/docs/api/runtime-config.md
@@ -20,7 +20,7 @@ export default defineApp({
 })
 
 // or 
-import {  RuntimeConfig } from 'umi'
+import { RuntimeConfig } from 'umi'
 export const layout: RuntimeConfig['layout'] = () => {
   return {
     title: 'umi'

--- a/docs/docs/api/runtime-config.md
+++ b/docs/docs/api/runtime-config.md
@@ -6,6 +6,28 @@
 
 约定 `src/app.tsx` 为运行时配置。
 
+
+## TypeScript 提示
+如果你想在写配置时也有提示，可以通过 umi 的 defineApp 方法定义配置，
+```js
+import { defineApp } from 'umi'
+export default defineApp({
+  layout: () => {
+    return {
+      title: "umi",
+    }
+  }
+})
+
+// or 
+import {  RuntimeConfig } from 'umi'
+export const layout: RuntimeConfig['layout'] = () => {
+  return {
+    title: 'umi'
+  }
+}
+```
+
 ## 配置项
 
 > 以下配置项按字母排序。

--- a/packages/plugins/libs/qiankun/master/types.ts
+++ b/packages/plugins/libs/qiankun/master/types.ts
@@ -13,7 +13,7 @@ export type App = {
   // 取 entry 时是否需要开启跨域 credentials
   credentials?: boolean;
   props?: any;
-} & Pick<BaseIConfig, 'mountElementId'>;
+} & Partial<Pick<BaseIConfig, 'mountElementId'>>;
 
 export type MicroAppRoute = {
   path: string;

--- a/packages/plugins/src/dva.ts
+++ b/packages/plugins/src/dva.ts
@@ -1,7 +1,7 @@
 import * as t from '@umijs/bundler-utils/compiled/babel/types';
 import { winPath } from '@umijs/utils';
 import { join, relative } from 'path';
-import { IApi } from 'umi';
+import { IApi, RUNTIME_TYPE_FILE_NAME } from 'umi';
 import { chalk } from 'umi/plugin-utils';
 import { Model, ModelUtils } from './utils/modelUtils';
 import { withTmpPath } from './utils/withTmpPath';
@@ -50,6 +50,28 @@ export default (api: IApi) => {
       content: ModelUtils.getModelsContent(models),
     });
 
+    api.writeTmpFile({
+      path: RUNTIME_TYPE_FILE_NAME,
+      content: `
+export interface IRuntimeConfig {
+  dva?: {
+    config?: {
+        initialState?: Record<string, any>;
+        onError?: any;
+        onStateChange?: any;
+        onAction?: any;
+        onHmr?: any;
+        onReducer?: any;
+        onEffect?: any;
+        extraReducers?: any;
+        extraEnhancers?: any;
+        [key: string]: any;
+    },
+    plugins?: string[];
+  }
+}
+      `,
+    });
     // dva.tsx
     api.writeTmpFile({
       path: 'dva.tsx',

--- a/packages/plugins/src/initial-state.ts
+++ b/packages/plugins/src/initial-state.ts
@@ -1,4 +1,4 @@
-import { IApi } from 'umi';
+import { IApi, RUNTIME_TYPE_FILE_NAME } from 'umi';
 import { withTmpPath } from './utils/withTmpPath';
 
 export default (api: IApi) => {
@@ -127,6 +127,15 @@ import React from 'react';
 import Provider from './Provider';
 export function dataflowProvider(container) {
   return <Provider>{ container }</Provider>;
+}
+      `,
+    });
+
+    api.writeTmpFile({
+      path: RUNTIME_TYPE_FILE_NAME,
+      content: `
+export interface IRuntimeConfig {
+  getInitialState?: () => Promise<Record<string, any>>
 }
       `,
     });

--- a/packages/plugins/src/layout.ts
+++ b/packages/plugins/src/layout.ts
@@ -1,7 +1,7 @@
 import * as allIcons from '@ant-design/icons';
 import { existsSync } from 'fs';
 import { dirname, join } from 'path';
-import { IApi } from 'umi';
+import { IApi, RUNTIME_TYPE_FILE_NAME } from 'umi';
 import { lodash, Mustache, winPath } from 'umi/plugin-utils';
 import { withTmpPath } from './utils/withTmpPath';
 
@@ -276,7 +276,7 @@ const { formatMessage } = useIntl();
         : 'type InitDataType = any;'
     }
     import { IConfigFromPlugins } from '@@/core/pluginConfig';
-    
+
     export type RunTimeLayoutConfig = (initData: InitDataType) => Omit<
       ProLayoutProps,
       'rightContentRender'
@@ -304,7 +304,15 @@ const { formatMessage } = useIntl();
     };
     `,
     });
-
+    api.writeTmpFile({
+      path: RUNTIME_TYPE_FILE_NAME,
+      content: `
+import type { RunTimeLayoutConfig } from './types.d';
+export interface IRuntimeConfig {
+  layout?: RunTimeLayoutConfig
+}
+      `,
+    });
     const iconsMap = Object.keys(api.appData.routes).reduce<
       Record<string, boolean>
     >((memo, id) => {

--- a/packages/plugins/src/qiankun/master.ts
+++ b/packages/plugins/src/qiankun/master.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
-import { IApi } from 'umi';
+import { IApi, RUNTIME_TYPE_FILE_NAME } from 'umi';
 import { winPath } from 'umi/plugin-utils';
 import { withTmpPath } from '../utils/withTmpPath';
 import {
@@ -83,6 +83,21 @@ export default (api: IApi) => {
   }
 
   api.onGenerateFiles(() => {
+    api.writeTmpFile({
+      path: RUNTIME_TYPE_FILE_NAME,
+      content: `
+import { MasterOptions } from './types'
+type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
+type XOR<T, U> = (Without<T, U> & U) | (Without<U, T> & T);
+interface Config {
+  master?: MasterOptions;
+}
+export interface IRuntimeConfig {
+  qiankun?: XOR<MasterOptions, Config>;
+  ${MODEL_EXPORT_NAME}?: () => Record<string, any>;
+}
+      `,
+    });
     api.writeTmpFile({
       path: 'masterOptions.ts',
       content: `

--- a/packages/plugins/src/qiankun/slave.ts
+++ b/packages/plugins/src/qiankun/slave.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
-import { IApi } from 'umi';
+import { IApi, RUNTIME_TYPE_FILE_NAME } from 'umi';
 import { winPath } from 'umi/plugin-utils';
 import { withTmpPath } from '../utils/withTmpPath';
 import { qiankunStateFromMasterModelNamespace } from './constants';
@@ -38,7 +38,30 @@ export default (api: IApi) => {
       ];
     },
   });
-
+  api.onGenerateFiles(() => {
+    api.writeTmpFile({
+      path: RUNTIME_TYPE_FILE_NAME,
+      content: `
+interface LifeCycles {
+    bootstrap?: (props?: any) => Promise<any>;
+    mount?: (props?: any) => Promise<any>;
+    unmount?: (props?: any) => Promise<any>;
+    update?: (props?: any) => Promise<any>;
+}
+type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
+type XOR<T, U> = (Without<T, U> & U) | (Without<U, T> & T);
+interface SlaveOption extends LifeCycles {
+    enable?: boolean;
+}
+interface Config {
+    slave?: SlaveOption;
+}
+export interface IRuntimeConfig {
+    qiankun?: XOR<Config, LifeCycles>
+}
+      `,
+    });
+  });
   api.modifyDefaultConfig((memo) => {
     const initialSlaveOptions: SlaveOptions = {
       devSourceMap: true,

--- a/packages/plugins/src/request.ts
+++ b/packages/plugins/src/request.ts
@@ -1,5 +1,5 @@
 import { dirname } from 'path';
-import { IApi } from 'umi';
+import { IApi, RUNTIME_TYPE_FILE_NAME } from 'umi';
 import { Mustache, winPath } from 'umi/plugin-utils';
 
 export default (api: IApi) => {
@@ -327,6 +327,16 @@ export {
   request,
 } from './request';
 `,
+    });
+
+    api.writeTmpFile({
+      path: RUNTIME_TYPE_FILE_NAME,
+      content: `
+import type { RequestConfig } from './types.d'
+export type IRuntimeConfig = {
+  request?: RequestConfig
+};
+      `,
     });
   });
 };

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -389,6 +389,7 @@ export default function EmptyRoute() {
       context: {
         plugins: plugins.map((plugin, index) => ({
           index,
+          // 在 app.ts 中，如果使用了 defineApp 方法，会存在 export default 的情况
           hasDefaultExport: appPluginRegExp.test(plugin),
           path: winPath(plugin),
         })),
@@ -589,7 +590,7 @@ export default function EmptyRoute() {
             `import type { IRuntimeConfig as Plugin${pluginIndex} } from '${noSuffixRuntimeConfigFile}'`,
           );
           runtimeConfigType += ` & Plugin${pluginIndex}`;
-          pluginIndex++;
+          pluginIndex += 1;
         }
       }
       api.writeTmpFile({
@@ -601,8 +602,9 @@ export default function EmptyRoute() {
           runtimeConfigType,
         },
       });
-      exports.push(`export * from './core/defineApp'`);
-
+      exports.push(`export { defineApp } from './core/defineApp'`);
+      // https://javascript.plainenglish.io/leveraging-type-only-imports-and-exports-with-typescript-3-8-5c1be8bd17fb
+      exports.push(`export type {  RuntimeConfig } from './core/defineApp'`);
       api.writeTmpFile({
         noPluginDir: true,
         path: 'exports.ts',

--- a/packages/preset-umi/templates/defineApp.tpl
+++ b/packages/preset-umi/templates/defineApp.tpl
@@ -1,0 +1,16 @@
+
+
+{{{ beforeImport }}}
+interface IDefaultRuntimeConfig {
+  onRouteChange?: (props: { routes: any, clientRoutes: any, location: any, action:any }) => void;
+  patchRoutes?: (props: { routes: any }) => void;
+  patchClientRoutes?: (props: { routes: any }) => void;
+  render?: (oldRender: () => void) => void;
+  rootContainer?: (lastRootContainer:JSX.Element, args?: any) => void;
+  [key: string]: any;
+}
+{{{ runtimeConfigType }}}
+
+export function defineApp(config: RuntimeConfig): RuntimeConfig {
+  return config;
+}

--- a/packages/preset-umi/templates/defineApp.tpl
+++ b/packages/preset-umi/templates/defineApp.tpl
@@ -1,12 +1,10 @@
-
-
 {{{ beforeImport }}}
 interface IDefaultRuntimeConfig {
   onRouteChange?: (props: { routes: any, clientRoutes: any, location: any, action:any }) => void;
   patchRoutes?: (props: { routes: any }) => void;
   patchClientRoutes?: (props: { routes: any }) => void;
   render?: (oldRender: () => void) => void;
-  rootContainer?: (lastRootContainer:JSX.Element, args?: any) => void;
+  rootContainer?: (lastRootContainer: JSX.Element, args?: any) => void;
   [key: string]: any;
 }
 {{{ runtimeConfigType }}}

--- a/packages/preset-umi/templates/plugin.tpl
+++ b/packages/preset-umi/templates/plugin.tpl
@@ -3,11 +3,17 @@ import * as Plugin_{{{ index }}} from '{{{ path }}}';
 {{/plugins}}
 import { PluginManager } from 'umi';
 
+function __defaultExport (obj) {
+  if (obj.default) {
+    return typeof obj.default === 'function' ? obj.default() :  obj.default
+  }
+  return obj;
+}
 export function getPlugins() {
   return [
 {{#plugins}}
     {
-      apply: Plugin_{{{ index }}},
+      apply: {{#hasDefaultExport}}__defaultExport(Plugin_{{{ index }}}),{{/hasDefaultExport}}{{^hasDefaultExport}}Plugin_{{{ index }}},{{/hasDefaultExport}}
       path: process.env.NODE_ENV === 'production' ? void 0 : '{{{ path }}}',
     },
 {{/plugins}}

--- a/packages/umi/src/constants.ts
+++ b/packages/umi/src/constants.ts
@@ -7,3 +7,5 @@ export const DEFAULT_CONFIG_FILES = [
   'config/config.js',
 ];
 export const FRAMEWORK_NAME = 'umi';
+
+export const RUNTIME_TYPE_FILE_NAME = 'runtimeConfig.d.ts';

--- a/packages/umi/src/index.ts
+++ b/packages/umi/src/index.ts
@@ -1,7 +1,7 @@
 import { IServicePluginAPI, PluginAPI } from '@umijs/core';
 
 export { run } from './cli/cli';
-export * from './constants';
+export { RUNTIME_TYPE_FILE_NAME } from './constants';
 export { defineConfig } from './defineConfig';
 export { defineMock } from './defineMock';
 export * from './service/service';

--- a/packages/umi/src/index.ts
+++ b/packages/umi/src/index.ts
@@ -1,6 +1,7 @@
 import { IServicePluginAPI, PluginAPI } from '@umijs/core';
 
 export { run } from './cli/cli';
+export * from './constants';
 export { defineConfig } from './defineConfig';
 export { defineMock } from './defineMock';
 export * from './service/service';


### PR DESCRIPTION
实现思路：

插件约定输出一个 `runtimeConfig.d.ts` 作为插件的运行时配置
通过动态生成 `defineApp` ，使用交叉类型合并所有插件导出的运行时配置


修改点：
1，为自带的 layout、dva、qiankun 添加` runtimeConfig.d.ts `生成逻辑
2，在 tmpFile 中生成 `defineApp`，添加了一个 `defineApp.tpl `用于生成代码
3，修改了 `plugin.tpl`，添加了一个 __defaultExport 用于处理 `export default `的场景
4，【文档】添加 defineApp 使用指引

-----
[View rendered docs/docs/api/runtime-config.md](https://github.com/umijs/umi/blob/mr/master/define_app/docs/docs/api/runtime-config.md)