### PR TITLE
fix: mf apply hmr

### DIFF
--- a/packages/bundler-webpack/src/config/additionalEntryPlugin.ts
+++ b/packages/bundler-webpack/src/config/additionalEntryPlugin.ts
@@ -1,20 +1,15 @@
 import { Compiler, EntryPlugin } from '@umijs/bundler-webpack/compiled/webpack';
 import Config from '@umijs/bundler-webpack/compiled/webpack-5-chain';
-import { Env, IConfig } from '../types';
 
 interface IOpts {
-  userConfig: IConfig;
   config: Config;
-  env: Env;
 }
 
 class AdditionEntryPlugin {
   apply(compiler: Compiler) {
     compiler.hooks.environment.tap('AdditionEntryPlugin', () => {
       const additionalEntries = [];
-      additionalEntries.push(
-       require.resolve('../../client/client/client'),
-      );
+      additionalEntries.push(require.resolve('../../client/client/client'));
       if (typeof EntryPlugin !== 'undefined') {
         for (const additionalEntry of additionalEntries) {
           new EntryPlugin(compiler.context, additionalEntry, {
@@ -29,9 +24,5 @@ class AdditionEntryPlugin {
 
 export async function addAdditionEntryPlugin(opts: IOpts) {
   const { config } = opts;
-  const isDev = opts.env === Env.development;
-
-  if (isDev) {
-    config.plugin('add-addtion-entry-plugin').use(AdditionEntryPlugin);
-  }
+  config.plugin('add-addtion-entry-plugin').use(AdditionEntryPlugin);
 }

--- a/packages/bundler-webpack/src/config/additionalEntryPlugin.ts
+++ b/packages/bundler-webpack/src/config/additionalEntryPlugin.ts
@@ -8,31 +8,12 @@ interface IOpts {
   env: Env;
 }
 
-interface AdditionEntryPluginOptions {
-  context?: string;
-}
-
 class AdditionEntryPlugin {
-  options: AdditionEntryPluginOptions = {};
-
-  constructor(options: {}) {
-    if (!options) {
-      return;
-    }
-  }
-
   apply(compiler: Compiler) {
-    if (!this.options.context) {
-      this.options = {
-        ...this.options,
-        context: compiler.context,
-      };
-    }
-
     compiler.hooks.environment.tap('AdditionEntryPlugin', () => {
       const additionalEntries = [];
       additionalEntries.push(
-        `${require.resolve('../../client/client/client')}`,
+       require.resolve('../../client/client/client'),
       );
       if (typeof EntryPlugin !== 'undefined') {
         for (const additionalEntry of additionalEntries) {

--- a/packages/bundler-webpack/src/config/additionalEntryPlugin.ts
+++ b/packages/bundler-webpack/src/config/additionalEntryPlugin.ts
@@ -1,0 +1,56 @@
+import { Compiler, EntryPlugin } from '@umijs/bundler-webpack/compiled/webpack';
+import Config from '@umijs/bundler-webpack/compiled/webpack-5-chain';
+import { Env, IConfig } from '../types';
+
+interface IOpts {
+  userConfig: IConfig;
+  config: Config;
+  env: Env;
+}
+
+interface AdditionEntryPluginOptions {
+  context?: string;
+}
+
+class AdditionEntryPlugin {
+  options: AdditionEntryPluginOptions = {};
+
+  constructor(options: {}) {
+    if (!options) {
+      return;
+    }
+  }
+
+  apply(compiler: Compiler) {
+    if (!this.options.context) {
+      this.options = {
+        ...this.options,
+        context: compiler.context,
+      };
+    }
+
+    compiler.hooks.environment.tap('AdditionEntryPlugin', () => {
+      const additionalEntries = [];
+      additionalEntries.push(
+        `${require.resolve('../../client/client/client')}`,
+      );
+      if (typeof EntryPlugin !== 'undefined') {
+        for (const additionalEntry of additionalEntries) {
+          new EntryPlugin(compiler.context, additionalEntry, {
+            // eslint-disable-next-line no-undefined
+            name: undefined,
+          }).apply(compiler);
+        }
+      }
+    });
+  }
+}
+
+export async function addAdditionEntryPlugin(opts: IOpts) {
+  const { config } = opts;
+  const isDev = opts.env === Env.development;
+
+  if (isDev) {
+    config.plugin('add-addtion-entry-plugin').use(AdditionEntryPlugin);
+  }
+}

--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -11,6 +11,7 @@ import {
 import { RuntimePublicPathPlugin } from '../plugins/RuntimePublicPathPlugin';
 import { Env, IConfig } from '../types';
 import { getBrowsersList } from '../utils/browsersList';
+import { addAdditionEntryPlugin } from './additionalEntryPlugin';
 import { addAssetRules } from './assetRules';
 import { addBundleAnalyzerPlugin } from './bundleAnalyzerPlugin';
 import { addCompressPlugin } from './compressPlugin';
@@ -167,6 +168,8 @@ export async function getConfig(opts: IOpts): Promise<Configuration> {
   await addSVGRules(applyOpts);
 
   // plugins
+  // additional entry plugin
+  await addAdditionEntryPlugin(applyOpts);
   // mini-css-extract-plugin
   await addMiniCSSExtractPlugin(applyOpts);
   // ignoreMomentLocale

--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -169,7 +169,9 @@ export async function getConfig(opts: IOpts): Promise<Configuration> {
 
   // plugins
   // additional entry plugin
-  await addAdditionEntryPlugin(applyOpts);
+  if (isDev && opts.hmr) {
+    await addAdditionEntryPlugin(applyOpts);
+  }
   // mini-css-extract-plugin
   await addMiniCSSExtractPlugin(applyOpts);
   // ignoreMomentLocale


### PR DESCRIPTION
umi bundler webpack的hmr在module federation暴露的模块中失效
以下改动针对所有出口文件，新增hmr