### PR TITLE
fix(umi): utils resolve wrong babel preset when dev

### DIFF
--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -28,6 +28,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@umijs/babel-preset-umi": "3.5.31",
     "@umijs/bundler-webpack": "3.5.31",
     "@umijs/core": "3.5.31",
     "@umijs/deps": "3.5.31",


### PR DESCRIPTION

![图片](https://user-images.githubusercontent.com/5035925/182313401-00f80d77-1e43-4a45-96a3-829e16f764b6.png)

修复 Umi 3 项目在 `umi dev` 时 `@umijs/utils` 可能拿到错误的 `@umijs/babel-preset-umi` 版本导致启动失败的问题，比如项目中存在 father 4 时

> 为什么不直接给 `@umijs/utils` 声明 `@umijs/babel-preset-umi`？

因为 `@umijs/babel-preset-umi` 也依赖 `@umijs/utils`，避免出现循环依赖；`umi` 是 `@umijs/utils` 的父级包、也是引发错误的命令起点，所以在父级包声明