### PR TITLE
fix(server): proxy throw error 403

### DIFF
--- a/packages/server/src/Server/Server.ts
+++ b/packages/server/src/Server/Server.ts
@@ -278,6 +278,7 @@ class Server {
         return createProxyMiddleware(context!, {
           ...proxyConfig,
           onProxyReq(proxyReq) {
+            // 修改 host 模拟域名，避免 cors 只允许固定域名时报错
             if (proxyReq.getHeader('origin')) {
               proxyReq.setHeader('origin', target);
             }

--- a/packages/server/src/Server/Server.ts
+++ b/packages/server/src/Server/Server.ts
@@ -271,13 +271,18 @@ class Server {
       // It is possible to use the `bypass` method without a `target`.
       // However, the proxy middleware has no use in this case, and will fail to instantiate.
       if (proxyConfig.target) {
+        const target =
+          typeof proxyConfig.target === 'object'
+            ? url.format(proxyConfig.target)
+            : proxyConfig.target;
         return createProxyMiddleware(context!, {
           ...proxyConfig,
+          onProxyReq(proxyReq) {
+            if (proxyReq.getHeader('origin')) {
+              proxyReq.setHeader('origin', target);
+            }
+          },
           onProxyRes(proxyRes, req: any, res) {
-            const target =
-              typeof proxyConfig.target === 'object'
-                ? url.format(proxyConfig.target)
-                : proxyConfig.target;
             const realUrl = new URL(req.url || '', target)?.href || '';
             proxyRes.headers['x-real-url'] = realUrl;
             proxyConfig.onProxyRes?.(proxyRes, req, res);


### PR DESCRIPTION
一种场景是服务端设置了cors允许固定域名跨域后，本地没有通过修改host模拟域名，而是使用proxy解决跨域，配置成功后后仍然报403错误。


解决方案参考CRA项目下issue
[#5441](https://github.com/facebook/create-react-app/issues/5441#issue-370191452)



