### PR TITLE
docs: props should be wrapped with {} instead of () in umi max i18n example

### DIFF
--- a/docs/docs/max/i18n.md
+++ b/docs/docs/max/i18n.md
@@ -140,7 +140,7 @@ import { FormattedMessage } from 'umi';
 export default () => {
   return (
     <p>
-      <FormattedMessage id="user.welcome" values=({ name: '张三' }) />
+      <FormattedMessage id="user.welcome" values={{ name: '张三' }} />
     </p>
   );
 };


### PR DESCRIPTION
null

-----
[View rendered docs/docs/max/i18n.md](https://github.com/juetan/umi/blob/patch-1/docs/docs/max/i18n.md)