### PR TITLE
fix(mfsu): babel should transform `extraBabelIncludes`

### DIFF
--- a/packages/bundler-webpack/src/dev.ts
+++ b/packages/bundler-webpack/src/dev.ts
@@ -137,6 +137,7 @@ export async function dev(opts: IOpts) {
     staticPathPrefix: MF_DEP_PREFIX,
     name: MFSU_NAME,
     chainWebpack: opts.config.mfsu?.chainWebpack,
+    extraBabelIncludes: opts.config.extraBabelIncludes,
     cache: {
       buildDependencies: opts.cache?.buildDependencies,
       cacheDirectory: join(cacheDirectoryPath, 'mfsu-deps'),


### PR DESCRIPTION
fix #8796

mfsu 应该处理配置的 `extraBabelIncludes` ，否则 mfsu 打包时无法对 `node_modules` 里的源码进行 auto css module。