### PR TITLE
feat(renderer-react): export generatePath from react-router-dom

### DIFF
--- a/docs/docs/api/api.md
+++ b/docs/docs/api/api.md
@@ -78,6 +78,20 @@ TODO: SUPPORT
 */
 }
 
+### generatePath
+
+使用给定的带参数的 path 和对应的 params 生成实际要访问的路由。
+
+```ts
+import { generatePath } from 'umi';
+
+generatePath("/users/:id", { id: "42" }); // "/users/42"
+generatePath("/files/:type/*", {
+  type: "img",
+  "*": "cat.jpg",
+}); // "/files/img/cat.jpg"
+```
+
 ### history
 
 和 history 相关的操作，用于获取当前路由信息、执行路由跳转、监听路由变更。

--- a/packages/renderer-react/src/index.ts
+++ b/packages/renderer-react/src/index.ts
@@ -6,6 +6,7 @@ export {
 } from 'history';
 export {
   createSearchParams,
+  generatePath,
   matchPath,
   matchRoutes,
   Navigate,


### PR DESCRIPTION
部分情况下需要在程序中手动渲染带参数的路由，在 react router v6 中，需要通过 generatePath 方法来实现。

当前版本的 umi 并未导出该函数，这里补充上。

-----
[View rendered docs/docs/api/api.md](https://github.com/ye-will/umi/blob/master/docs/docs/api/api.md)