### PR TITLE
fix(bundler-webpack): globalThis check logic

### DIFF
--- a/packages/bundler-webpack/src/plugins/RuntimePublicPathPlugin.ts
+++ b/packages/bundler-webpack/src/plugins/RuntimePublicPathPlugin.ts
@@ -18,7 +18,7 @@ export class RuntimePublicPathPlugin {
           )
             return;
           // @ts-ignore
-          module._cachedGeneratedCode = `__webpack_require__.p = (typeof globalThis !== undefined ? globalThis : window).publicPath || '/';`;
+          module._cachedGeneratedCode = `__webpack_require__.p = (typeof globalThis !== 'undefined' ? globalThis : window).publicPath || '/';`;
         }
       });
     });


### PR DESCRIPTION
修复 runtimePublicPath 里对 `globalThis` 的判断

ref: #8650 