### PR TITLE
fix: mock bug

### DIFF
--- a/packages/preset-umi/src/features/mock/getMockData.ts
+++ b/packages/preset-umi/src/features/mock/getMockData.ts
@@ -73,6 +73,9 @@ export function getMockData(opts: {
       }
       return memo;
     }, {});
+  for (const file of register.getFiles()) {
+    delete require.cache[file];
+  }
   register.restore();
   return ret;
 }

--- a/packages/preset-umi/src/features/mock/mock.ts
+++ b/packages/preset-umi/src/features/mock/mock.ts
@@ -47,16 +47,11 @@ export default function (api: IApi) {
 
   api.onStart(() => {
     const mockConfig = api.config.mock || {};
-    const { include = [], exclude = [] } = mockConfig;
+    const { include = [] } = mockConfig;
     watch({
       path: ['mock', ...include].map((pattern) =>
         path.resolve(api.cwd, pattern),
       ),
-      watchOpts: {
-        ignored: exclude.map((pattern: string) =>
-          path.resolve(api.cwd, pattern),
-        ),
-      },
       addToUnWatches: true,
       onChange: () => {
         updateMockData(() => {


### PR DESCRIPTION
Close #8889 

- 解决 demo例子里： 更改name的值，需要改2次，才有第一次更改的数据，延迟了一次的问题。
- 解决 demo例子里：引用CustomData['/api.php']时，标识重复mock路由，改用exclude: ['mock/custom-data/**']后正常，并保证watch时，热更新正常，watch时，不要排除exclude，只在normalizeMockFile入口方法排除exclude，现在mock逻辑和umi3基本一致