### PR TITLE
feat: 支持配置 publicPath 为 auto

### DIFF
--- a/packages/preset-umi/src/commands/dev/createRouteMiddleware.ts
+++ b/packages/preset-umi/src/commands/dev/createRouteMiddleware.ts
@@ -35,7 +35,7 @@ function createRouteMiddleware(opts: { api: IApi }) {
       const requestHandler = await createRequestHandler({
         ...markupArgs,
         styles: markupArgs.styles.concat(assetsMap['umi.css'] || []),
-        scripts: (assetsMap['umi.js'] || []).concat(markupArgs.scripts!),
+        scripts: markupArgs.scripts.concat(assetsMap['umi.js'] || []),
         esmScript: false,
         historyType: opts.api.config.history?.type || 'browser',
       });

--- a/packages/preset-umi/src/commands/dev/createRouteMiddleware.ts
+++ b/packages/preset-umi/src/commands/dev/createRouteMiddleware.ts
@@ -35,7 +35,7 @@ function createRouteMiddleware(opts: { api: IApi }) {
       const requestHandler = await createRequestHandler({
         ...markupArgs,
         styles: markupArgs.styles.concat(assetsMap['umi.css'] || []),
-        scripts: markupArgs.scripts.concat(assetsMap['umi.js'] || []),
+        scripts: (assetsMap['umi.js'] || []).concat(markupArgs.scripts!),
         esmScript: false,
         historyType: opts.api.config.history?.type || 'browser',
       });

--- a/packages/preset-umi/src/commands/dev/getAssetsMap.ts
+++ b/packages/preset-umi/src/commands/dev/getAssetsMap.ts
@@ -6,6 +6,7 @@ const HOT_UPDATE = '.hot-update.';
 
 export function getAssetsMap(opts: { stats: any; publicPath: string }) {
   const { stats, publicPath } = opts;
+  const displayPublicPath = publicPath === 'auto' ? '/' : publicPath;
 
   let ret: Record<string, string[]> = {};
   let json = stats.toJson();
@@ -15,10 +16,10 @@ export function getAssetsMap(opts: { stats: any; publicPath: string }) {
       !asset.name.includes(HOT_UPDATE) &&
       UMI_ASSETS_REG.js.test(asset.name)
     ) {
-      ret['umi.js'] = [`${publicPath}${asset.name}`];
+      ret['umi.js'] = [`${displayPublicPath}${asset.name}`];
     }
     if (UMI_ASSETS_REG.css.test(asset.name)) {
-      ret['umi.css'] = [`${publicPath}${asset.name}`];
+      ret['umi.css'] = [`${displayPublicPath}${asset.name}`];
     }
   }
   return ret;

--- a/packages/preset-umi/src/features/configPlugins/schema.ts
+++ b/packages/preset-umi/src/features/configPlugins/schema.ts
@@ -29,7 +29,9 @@ export function getSchemas(): Record<string, (Joi: Root) => any> {
     plugins: (Joi) => Joi.array().items(Joi.string()),
     presets: (Joi) => Joi.array().items(Joi.string()),
     publicPath: (Joi) =>
-      Joi.string().regex(/\/$/).error(new Error('publicPath must end with /')),
+      Joi.string()
+        .regex(/(\/|auto)$/)
+        .error(new Error('publicPath must be "auto" or end with /')),
     routes: (Joi) => Joi.array().items(Joi.object()),
     scripts: (Joi) => Joi.array(),
     styles: (Joi) => Joi.array(),

--- a/packages/preset-umi/src/features/configPlugins/schema.ts
+++ b/packages/preset-umi/src/features/configPlugins/schema.ts
@@ -30,7 +30,7 @@ export function getSchemas(): Record<string, (Joi: Root) => any> {
     presets: (Joi) => Joi.array().items(Joi.string()),
     publicPath: (Joi) =>
       Joi.string()
-        .regex(/(\/|auto)$/)
+        .regex(/(\/|^auto)$/)
         .error(new Error('publicPath must be "auto" or end with /')),
     routes: (Joi) => Joi.array().items(Joi.object()),
     scripts: (Joi) => Joi.array(),


### PR DESCRIPTION
1. 4.0.9 的时候有一个 [PR](https://github.com/umijs/umi/pull/8647) 优化了 umi.css 的顺序，但是 js 的顺序仍然是放到前面，也会有问题，在 3.x  的时候主文件也是一直是注入到最后的
2. `publicPath` 设置为 'auto' 后，加载 chunk 文件会根据当前的主文件 host 去匹配，这一点在前后端分离并区分CDN环境的情况下非常有用，webpack 也很早就支持了 [Automatic publicPath](https://webpack.js.org/guides/public-path/#automatic-publicpath)