### PR TITLE
fix: export getRequestInstance

### DIFF
--- a/packages/plugins/src/request.ts
+++ b/packages/plugins/src/request.ts
@@ -325,6 +325,7 @@ export {
   useRequest,
   UseRequestProvider,
   request,
+  getRequestInstance
 } from './request';
 `,
     });

--- a/packages/plugins/src/request.ts
+++ b/packages/plugins/src/request.ts
@@ -325,7 +325,7 @@ export {
   useRequest,
   UseRequestProvider,
   request,
-  getRequestInstance
+  getRequestInstance,
 } from './request';
 `,
     });


### PR DESCRIPTION
需要能够获取axios request 的instance，方便动态加载一些拦截器