### PR TITLE
fix(create-umi/template): add missing id in mock data.

### DIFF
--- a/packages/create-umi/templates/max/mock/userAPI.ts
+++ b/packages/create-umi/templates/max/mock/userAPI.ts
@@ -1,6 +1,6 @@
 const users = [
-  { name: 'Umi', nickName: 'U', gender: 'MALE' },
-  { name: 'Fish', nickName: 'B', gender: 'FEMALE' },
+  { id: 0, name: 'Umi', nickName: 'U', gender: 'MALE' },
+  { id: 1, name: 'Fish', nickName: 'B', gender: 'FEMALE' },
 ];
 
 export default {


### PR DESCRIPTION
Bug Description：create-umi创建的ant design pro模板项目中，用户选择 CRUD示例 - 查询表格的某一个复选框，会同时选择全部的行，而selectedRowsState只有一条数据。
Reason：查询表格table以id为key，但mock数据中没有id，因此导致混乱。
Solution: 给mock数据加上id。