### PR TITLE
chore: fix bootstrap script

### DIFF
--- a/scripts/bootstrap.ts
+++ b/scripts/bootstrap.ts
@@ -108,6 +108,17 @@ import { setExcludeFolder } from './.internal/utils';
         'utf-8',
       );
 
+      // .fatherrc.ts
+      await fs.writeFile(
+        path.join(pkgDir, '.fatherrc.ts'),
+        `import { defineConfig } from 'father';
+
+export default defineConfig({
+  extends: '../../.fatherrc.base.ts',
+});\n`,
+        'utf-8',
+      );
+
       // src/index.ts
       const srcDir = path.join(pkgDir, 'src');
       if (!fs.existsSync(srcDir)) {


### PR DESCRIPTION
## 背景
使用bootstrap创建子包后运行`npm run build`没有反映
## 原因和解法
package里用了father命令，单目录缺少father配置文件
在bootstrap阶段生成father配置文件