### PR TITLE
fix(renderer-vue): fix empty route parsing error if component is not set

### DIFF
--- a/examples/boilerplate-vue/.umirc.ts
+++ b/examples/boilerplate-vue/.umirc.ts
@@ -47,6 +47,19 @@ export default {
       ],
     },
     {
+      path: '/users',
+      routes: [
+        {
+          path: '',
+          redirect: '/users/login',
+        },
+        {
+          path: 'login',
+          component: 'users/login',
+        },
+      ],
+    },
+    {
       // 404
       path: '/:pathMatch(.*)*',
       component: '@/components/404',

--- a/examples/boilerplate-vue/app.tsx
+++ b/examples/boilerplate-vue/app.tsx
@@ -11,8 +11,10 @@ export function onAppCreated({ app }: any) {
 
 export function onMounted({ app, router }: any) {
   console.log('onMounted', app, router);
-  router.beforeEach((to, from) => {
+  // @ts-ignore
+  router.beforeEach((to, from, next) => {
     console.log('router beforeEach', to, from);
+    next();
   });
 }
 

--- a/examples/boilerplate-vue/layouts/index.vue
+++ b/examples/boilerplate-vue/layouts/index.vue
@@ -6,7 +6,8 @@
         <router-link to="/">Home</router-link>
         <router-link to="/docs">Docs</router-link>
         <router-link to="/about">About</router-link>
-        <router-link to="/List">List</router-link>
+        <router-link to="/list">List</router-link>
+        <router-link to="/users">Users</router-link>
       </nav>
     </header>
     <main>

--- a/examples/boilerplate-vue/pages/docs.vue
+++ b/examples/boilerplate-vue/pages/docs.vue
@@ -4,6 +4,7 @@
 </template>
 <script lang="ts" setup>
 import { ref, onMounted } from 'vue';
+// @ts-ignore
 import marked from 'marked';
 
 const content = ref();

--- a/examples/boilerplate-vue/pages/users/login.vue
+++ b/examples/boilerplate-vue/pages/users/login.vue
@@ -1,0 +1,3 @@
+<template>
+  <h2>Login Page</h2>
+</template>

--- a/packages/preset-vue/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-vue/src/features/tmpFiles/tmpFiles.ts
@@ -50,11 +50,13 @@ export default (api: IApi) => {
         noPluginDir: true,
         path: 'core/EmptyRoute.tsx',
         content: `
-import { defineComponent } from 'vue';
+import { defineComponent, h, resolveComponent } from 'vue';
 
 export default defineComponent({
+  name: 'EmptyRoute',
   setup() {
-    return () => <router-view></router-view>;
+    const RouterView = resolveComponent('RouterView')
+    return () => h(RouterView, null);
   },
 });
         `,


### PR DESCRIPTION
解决路由未设置 component 时编译错误 
现在的 空路由使用的是 jsx 语法 目前不支持, 修改成手动创建 vnode 