### PR TITLE
chore: improve @umijs/plugin-run

### DIFF
--- a/packages/plugin-run/package.json
+++ b/packages/plugin-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/plugin-run",
-  "version": "4.0.12",
+  "version": "4.0.0-canary.20220819.1",
   "description": "@umijs/plugin-run",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/plugin-run#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/preset-umi/package.json
+++ b/packages/preset-umi/package.json
@@ -32,6 +32,7 @@
     "@umijs/bundler-vite": "4.0.0-canary.20220819.1",
     "@umijs/bundler-webpack": "4.0.0-canary.20220819.1",
     "@umijs/core": "4.0.0-canary.20220819.1",
+    "@umijs/plugin-run": "4.0.0-canary.20220819.1",
     "@umijs/renderer-react": "4.0.0-canary.20220819.1",
     "@umijs/server": "4.0.0-canary.20220819.1",
     "@umijs/utils": "4.0.0-canary.20220819.1",

--- a/packages/preset-umi/src/index.ts
+++ b/packages/preset-umi/src/index.ts
@@ -53,6 +53,7 @@ export default () => {
       require.resolve('./commands/plugin'),
       require.resolve('./commands/verify-commit'),
       require.resolve('./commands/preview'),
+      require.resolve('@umijs/plugin-run'),
     ],
   };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,7 +146,7 @@ importers:
       '@ant-design/icons': 4.7.0
       '@ant-design/pro-descriptions': 1.11.14
       '@ant-design/pro-form': 1.71.2
-      '@ant-design/pro-layout': 6.38.18
+      '@ant-design/pro-layout': 6.38.19
       '@ant-design/pro-table': 2.78.2
       '@antv/l7-react': 2.3.9
       '@umijs/max': link:../../packages/max
@@ -1319,6 +1319,7 @@ importers:
       '@umijs/bundler-vite': 4.0.0-canary.20220819.1
       '@umijs/bundler-webpack': 4.0.0-canary.20220819.1
       '@umijs/core': 4.0.0-canary.20220819.1
+      '@umijs/plugin-run': 4.0.0-canary.20220819.1
       '@umijs/renderer-react': 4.0.0-canary.20220819.1
       '@umijs/server': 4.0.0-canary.20220819.1
       '@umijs/utils': 4.0.0-canary.20220819.1
@@ -1349,6 +1350,7 @@ importers:
       '@umijs/bundler-vite': link:../bundler-vite
       '@umijs/bundler-webpack': link:../bundler-webpack
       '@umijs/core': link:../core
+      '@umijs/plugin-run': link:../plugin-run
       '@umijs/renderer-react': link:../renderer-react
       '@umijs/server': link:../server
       '@umijs/utils': link:../utils
@@ -1846,8 +1848,8 @@ packages:
       use-media-antd-query: 1.1.0
     dev: false
 
-  /@ant-design/pro-layout/6.38.18:
-    resolution: {integrity: sha512-ItZBM4T5wp8VoR1xXodyH4EBYiaZFJeJhyfrE7MNJnqL00Yd8AsF+gIgh42aOB2XQZMRAz5P3AOk2HdYjOPVFA==}
+  /@ant-design/pro-layout/6.38.19:
+    resolution: {integrity: sha512-GH88dJWvR2yuZL5K4fbIKm0PW3Y/LUsjC3xHZuazbaQJvHlFjm2L7xvSP3hd5FLkSABcbMVe6Ol6WC1/Br73FA==}
     peerDependencies:
       react: '>=16.9.0'
     peerDependenciesMeta:
@@ -1856,7 +1858,7 @@ packages:
     dependencies:
       '@ant-design/icons': 4.7.0
       '@ant-design/pro-provider': 1.10.0
-      '@ant-design/pro-utils': 1.44.0
+      '@ant-design/pro-utils': 1.45.0
       '@babel/runtime': 7.18.9
       '@umijs/route-utils': 2.1.1
       '@umijs/ssr-darkreader': 4.9.45
@@ -2053,8 +2055,8 @@ packages:
       swr: 1.3.0
     dev: false
 
-  /@ant-design/pro-utils/1.44.0:
-    resolution: {integrity: sha512-+r5KwzuCkp34p5Apudbe1wNGuSVNu2yrPX3TVAnFT8p7ZTg5iHLhNXOOcAKmON/Qktil7GUTW+v0t29/0fBy8Q==}
+  /@ant-design/pro-utils/1.45.0:
+    resolution: {integrity: sha512-Tk9uYj1Ep7ISeC4pk701jeQ91fUOG5zQmyNrKqeBo1i402ErcK7Nw9uCCvCUU3KxWmgywhWLy1VaVFl0KDQTgQ==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
@@ -11664,8 +11666,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2


### PR DESCRIPTION
一些改动，

* 内置到 preset-umi
* 支持 js
* 用 import 的方式引入原 script，避免 script 相对依赖的路径问题
* 临时文件的路径改到 node_modules/.cache 下

cc @txp1035 