### PR TITLE
fix(bundler-webpack): compile cjs module as a wrong asset

### DIFF
--- a/packages/bundler-webpack/src/config/assetRules.ts
+++ b/packages/bundler-webpack/src/config/assetRules.ts
@@ -39,7 +39,7 @@ export async function addAssetRules(opts: IOpts) {
   const fallback = rule
     .oneOf('fallback')
     .exclude.add(/^$/) /* handle data: resources */
-    .add(/\.(js|mjs|jsx|ts|tsx)$/)
+    .add(/\.(js|mjs|cjs|jsx|ts|tsx)$/)
     .add(/\.(css|less|sass|scss|stylus)$/)
     .add(/\.html$/)
     .add(/\.json$/);

--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -137,6 +137,7 @@ export async function getConfig(opts: IOpts): Promise<Configuration> {
       .merge([
         '.wasm',
         '.mjs',
+        '.cjs',
         '.js',
         '.jsx',
         '.ts',

--- a/packages/bundler-webpack/src/config/javaScriptRules.ts
+++ b/packages/bundler-webpack/src/config/javaScriptRules.ts
@@ -31,7 +31,7 @@ export async function addJavaScriptRules(opts: IOpts) {
   const srcRules = [
     config.module
       .rule('src')
-      .test(/\.(js|mjs)$/)
+      .test(/\.(js|mjs|cjs)$/)
       .include.add([
         cwd,
         // import module out of cwd using APP_ROOT
@@ -44,7 +44,7 @@ export async function addJavaScriptRules(opts: IOpts) {
     config.module.rule('jsx-ts-tsx').test(/\.(jsx|ts|tsx)$/),
     config.module
       .rule('extra-src')
-      .test(/\.(js|mjs)$/)
+      .test(/\.(js|mjs|cjs)$/)
       .include.add([
         // support extraBabelIncludes
         ...opts.extraBabelIncludes.map((p) => {
@@ -93,7 +93,7 @@ export async function addJavaScriptRules(opts: IOpts) {
   const depRules = [
     config.module
       .rule('dep')
-      .test(/\.(js|mjs)$/)
+      .test(/\.(js|mjs|cjs)$/)
       .include.add(/node_modules/)
       .end()
       .exclude.add((path: string) => {


### PR DESCRIPTION
修复编译 `.cjs` 后缀的模块时、将其处理为静态资源的 bug；比如 [@opensumi/ide-extensions](https://unpkg.com/browse/@opensumi/ide-extension@2.19.9/lib/common/vscode/converter.js) 只有 cjs 产物，产物里 require 了 [marked](https://unpkg.com/browse/marked@4.0.19/package.json)、使用了它 `.cjs` 后缀的产物，Umi 在编译后者时就会将其处理为静态资源而不是一个模块