### PR TITLE
fix(mfsu): use ipv4 as mfsu server base

### DIFF
--- a/packages/preset-umi/src/commands/dev/dev.ts
+++ b/packages/preset-umi/src/commands/dev/dev.ts
@@ -335,11 +335,9 @@ PORT=8888 umi dev
           ...(api.config.mfsu?.include || []),
         ]),
       };
-      if (api.config.mf) {
-        opts.mfsuServerBase = `${api.config.https ? 'https' : 'http'}://${
-          api.appData.ip
-        }:${api.appData.port}`;
-      }
+      opts.mfsuServerBase = `${api.config.https ? 'https' : 'http'}://${
+        api.appData.ip
+      }:${api.appData.port}`;
       if (enableVite) {
         await bundlerVite.dev(opts);
       } else {

--- a/packages/preset-umi/src/commands/dev/dev.ts
+++ b/packages/preset-umi/src/commands/dev/dev.ts
@@ -336,7 +336,11 @@ PORT=8888 umi dev
         ]),
       };
       opts.mfsuServerBase = `${api.config.https ? 'https' : 'http'}://${
-        api.appData.ip
+        api.appData.ip ||
+        // When the proxy is not set `0.0.0.0` bypass, `0.0.0.0` is invalid
+        // We fallback to `localhost`
+        // https://github.com/umijs/umi/pull/8872/files
+        (api.appData.host === '0.0.0.0' ? 'localhost' : api.appData.host)
       }:${api.appData.port}`;
       if (enableVite) {
         await bundlerVite.dev(opts);


### PR DESCRIPTION
目前 mfsu 的 server base 是：

 - mf 插件 **开启** 时：用局域网 ip。

 - mf 插件 **关闭** 时：

     - **问题**：没有传值，所以在局域网机子上（比如手机），访问局域网 ipv4 会获取不到 mfsu 的文件，See #9072

     - **解法**：要解局域网访问的情况，`localhost` 不可以，`0.0.0.0` 也被否决了（多数人有代理冲突问题：https://github.com/umijs/umi/pull/8872 ），所以也用局域网 ip 提供应该是合理的。

FYI ：

 - https://github.com/umijs/umi/commit/fdc075319ff1eee313765560e78be5e333929d4e#diff-c16b3a20a2bbbffdd57e0e853b15ace128ae5b2d89009d19a5fabc6da05281eaR334-R338