### PR TITLE
fix(legacy): not transform polyfill for ie11

### DIFF
--- a/docs/docs/api/config.md
+++ b/docs/docs/api/config.md
@@ -618,7 +618,7 @@ https: {
 
 ## legacy
 
-- 类型：`{ buildOnly?: boolean }`
+- 类型：`{ buildOnly?: boolean; nodeModulesTransform?: boolean; }`
 - 默认值：`false`
 
 当你需要兼容低版本浏览器时，可能需要该选项，开启后将默认使用 **非现代** 的打包工具做构建，这会显著增加你的构建时间。
@@ -632,7 +632,7 @@ legacy: {}
 开启此选项后：
 
  - 不支持自定义 `srcTranspiler` 、`jsMinifier` 、 `cssMinifier` 选项。
- - 将转译全部 `node_modules` 内的源码，`targets` 兼容至 ie 11 。
+ - 将转译全部 `node_modules` 内的源码，`targets` 兼容至 ie 11 ，通过指定 `nodeModulesTransform: false` 来取消对 `node_modules` 的转换，此时你可以通过配置 `extraBabelIncludes` 更精准的转换那些有兼容性问题的包。
  - 因低版本浏览器不支持 Top level await ，当你在使用 `externals` 时，确保你没有在使用异步性质的 [`externalsType`](https://webpack.js.org/configuration/externals/#externalstype) 时又使用了同步导入依赖。
 
 ## links

--- a/packages/preset-umi/src/features/legacy/legacy.ts
+++ b/packages/preset-umi/src/features/legacy/legacy.ts
@@ -98,26 +98,6 @@ export default (api: IApi) => {
         ie: 11,
       };
 
-      // transform all node_modules pkgs to es5
-      if (nodeModulesTransform) {
-        memo.module
-          .rule('extra-src')
-          .include.add(/node_modules/)
-          .end();
-      }
-
-      // prevent transform node_modules some problems
-      memo.module
-        .rule('extra-src')
-        // prevent transform `core-js` polyfill
-        // https://github.com/umijs/umi/issues/9124
-        // https://github.com/zloirock/core-js/issues/514
-        .exclude.add(/core-js/)
-        // prevent transform util functions
-        // https://github.com/webpack-contrib/mini-css-extract-plugin/issues/471
-        .add(/node_modules\/(css-loader)/)
-        .end();
-
       logger.ready(
         `${chalk.cyan(
           'legacy',
@@ -135,6 +115,26 @@ export default (api: IApi) => {
         if (originChainWebpack) {
           originChainWebpack(memo, ...args);
         }
+
+        // transform all node_modules pkgs to es5
+        if (nodeModulesTransform) {
+          memo.module
+            .rule('extra-src')
+            .include.add(/node_modules/)
+            .end();
+        }
+
+        // prevent transform node_modules some problems
+        memo.module
+          .rule('extra-src')
+          // prevent transform `core-js` polyfill
+          // https://github.com/umijs/umi/issues/9124
+          // https://github.com/zloirock/core-js/issues/514
+          .exclude.add(/core-js/)
+          // prevent transform util functions
+          // https://github.com/webpack-contrib/mini-css-extract-plugin/issues/471
+          .add(/node_modules\/(css-loader)/)
+          .end();
 
         // ensure svgr transform outputs is es5
         useBabelTransformSvgr(memo, api);

--- a/packages/preset-umi/src/features/legacy/legacy.ts
+++ b/packages/preset-umi/src/features/legacy/legacy.ts
@@ -109,10 +109,10 @@ export default (api: IApi) => {
       // prevent transform node_modules some problems
       memo.module
         .rule('extra-src')
-        .exclude// prevent transform `core-js` polyfill
+        // prevent transform `core-js` polyfill
         // https://github.com/umijs/umi/issues/9124
         // https://github.com/zloirock/core-js/issues/514
-        .add(/core-js/)
+        .exclude.add(/core-js/)
         // prevent transform util functions
         // https://github.com/webpack-contrib/mini-css-extract-plugin/issues/471
         .add(/node_modules\/(css-loader)/)


### PR DESCRIPTION
1. fix #9124

2. `nodeModulesTransform` : 支持关闭 `node_modules` 转换，反向自己添加需要 `extraBabelIncludes` 的包。 from @xiaohuoni 



-----
[View rendered docs/docs/api/config.md](https://github.com/MoeYc/umi/blob/fix/ie-11-core-js/docs/docs/api/config.md)