### PR TITLE
fix: IBabelPlugin type

### DIFF
--- a/packages/bundler-esbuild/src/types.ts
+++ b/packages/bundler-esbuild/src/types.ts
@@ -15,7 +15,11 @@ export interface ICopy {
   to: string;
 }
 
-export type IBabelPlugin = string | [string, { [key: string]: any }];
+export type IBabelPlugin =
+  | Function
+  | string
+  | [string, { [key: string]: any }]
+  | [string, { [key: string]: any }, string];
 
 export interface IConfig {
   alias?: Record<string, string>;

--- a/packages/bundler-vite/src/types.ts
+++ b/packages/bundler-vite/src/types.ts
@@ -19,7 +19,11 @@ export interface ICopy {
   to: string;
 }
 
-export type IBabelPlugin = string | [string, { [key: string]: any }];
+export type IBabelPlugin =
+  | Function
+  | string
+  | [string, { [key: string]: any }]
+  | [string, { [key: string]: any }, string];
 
 export interface IConfig {
   alias?: Record<string, string>;

--- a/packages/bundler-webpack/src/types.ts
+++ b/packages/bundler-webpack/src/types.ts
@@ -37,7 +37,11 @@ export interface ICopy {
 }
 
 type WebpackConfig = Required<Configuration>;
-type IBabelPlugin = Function | string | [string, { [key: string]: any }];
+type IBabelPlugin =
+  | Function
+  | string
+  | [string, { [key: string]: any }]
+  | [string, { [key: string]: any }, string];
 
 export interface DeadCodeParams {
   patterns?: string[];


### PR DESCRIPTION
支持相同 babel plugin 第三个参数（实例 id） 的配置，babel-plugin-import 中经常会用到

<img width="463" alt="image" src="https://user-images.githubusercontent.com/471003/187120852-23184b66-6992-4258-8db2-2c414cd07c32.png">


```ts
{
  plugins: [
    ['babel-plugin-import', { libraryName: 'components-a' }, 'components-a'],
    ['babel-plugin-import', { libraryName: 'components-b' }, 'components-b']
  ]
}
```

https://babeljs.io/docs/en/configuration#pluginpreset-merging
https://www.npmjs.com/package/babel-plugin-import