### PR TITLE
fix(bundler-webpack): type definition of proxy config

### DIFF
--- a/packages/bundler-webpack/src/server/server.ts
+++ b/packages/bundler-webpack/src/server/server.ts
@@ -11,7 +11,7 @@ import { createReadStream, existsSync } from 'fs';
 import http from 'http';
 import { extname, join } from 'path';
 import { MESSAGE_TYPE } from '../constants';
-import { IConfig } from '../types';
+import { IConfig, ProxyOptions } from '../types';
 import { createWebSocketServer } from './ws';
 
 interface IOpts {
@@ -173,7 +173,7 @@ export async function createServer(opts: IOpts) {
     // proxy: { target, context }
     // proxy: { '/api': { target, context } }
     // proxy: [{ target, context }]
-    const proxyArr = Array.isArray(proxy)
+    const proxyArr: ProxyOptions[] = Array.isArray(proxy)
       ? proxy
       : proxy.target
       ? [proxy]
@@ -194,9 +194,9 @@ export async function createServer(opts: IOpts) {
           onProxyReq(proxyReq, req: any, res) {
             // add origin in request header
             if (proxyReq.getHeader('origin')) {
-              proxyReq.setHeader('origin', new URL(proxy.target)?.href || '');
+              proxyReq.setHeader('origin', new URL(proxy.target!)?.href || '');
             }
-            proxy.onProxyReq?.(proxyReq, req, res);
+            proxy.onProxyReq?.(proxyReq, req, res, proxy);
           },
           // Add x-real-url in response header
           onProxyRes(proxyRes, req: any, res) {

--- a/packages/bundler-webpack/src/types.ts
+++ b/packages/bundler-webpack/src/types.ts
@@ -1,6 +1,6 @@
 import type { Config as SwcConfig } from '@swc/core';
 import type { HttpsServerOptions } from '@umijs/bundler-utils';
-import type { Options as ProxyOptions } from '../compiled/http-proxy-middleware';
+import type { Options as HPMOptions } from '../compiled/http-proxy-middleware';
 import { Configuration } from '../compiled/webpack';
 import Config from '../compiled/webpack-5-chain';
 
@@ -52,6 +52,15 @@ export interface DeadCodeParams {
   context?: string;
 }
 
+type HPMFnArgs = Parameters<NonNullable<HPMOptions['onProxyReq']>>;
+export interface ProxyOptions extends HPMOptions {
+  target?: string;
+  context?: string | string[];
+  bypass?: (
+    ...args: [HPMFnArgs[1], HPMFnArgs[2], HPMFnArgs[3]]
+  ) => string | boolean | null | void;
+}
+
 export interface IConfig {
   alias?: Record<string, string>;
   autoCSSModules?: boolean;
@@ -80,7 +89,7 @@ export interface IConfig {
   lessLoader?: { [key: string]: any };
   outputPath?: string;
   postcssLoader?: { [key: string]: any };
-  proxy?: { [key: string]: ProxyOptions };
+  proxy?: { [key: string]: ProxyOptions } | ProxyOptions[];
   publicPath?: string;
   purgeCSS?: { [key: string]: any };
   sassLoader?: { [key: string]: any };


### PR DESCRIPTION
1. 修复 #8639 支持数组形式 proxy 的类型定义，避免 `defineConfig` 报错
2. **[注意]** 修正 `proxy.onProxyReq` 的调用参数，把 proxy 传入以符合它需要的参数类型