### PR TITLE
perf: change webpack hash function to improve speed of hash calculation

### DIFF
--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -121,7 +121,8 @@ export async function getConfig(opts: IOpts): Promise<Configuration> {
     .set(
       'assetModuleFilename',
       `${applyOpts.staticPathPrefix}[name].[hash:8][ext]`,
-    );
+    )
+    .set('hashFunction', 'xxhash64'); // https://github.com/webpack/webpack/issues/14532#issuecomment-947525539
 
   // resolve
   // prettier-ignore

--- a/packages/preset-vue/src/features/config/config.ts
+++ b/packages/preset-vue/src/features/config/config.ts
@@ -6,9 +6,6 @@ import { addAssetRules } from './assetRules';
 export function getConfig(config: Config, api: IApi) {
   config.module.noParse(/^(vue|vue-router|vuex|vuex-router-sync)$/);
 
-  // https://github.com/webpack/webpack/issues/14532#issuecomment-947525539
-  config.output.set('hashFunction', 'xxhash64');
-
   // https://github.com/webpack/webpack/issues/11467#issuecomment-691873586
   config.module
     .rule('esm')


### PR DESCRIPTION
preset-vue中配置了但是umi本身没有配置