### PR TITLE
fix(server): keep origin by default in proxy

### DIFF
--- a/packages/server/src/Server/Server.ts
+++ b/packages/server/src/Server/Server.ts
@@ -278,10 +278,6 @@ class Server {
         return createProxyMiddleware(context!, {
           ...proxyConfig,
           onProxyReq(proxyReq, req: any, res) {
-            // 修改 host 模拟域名，避免 cors 只允许固定域名时报错
-            if (proxyReq.getHeader('origin')) {
-              proxyReq.setHeader('origin', target);
-            }
             proxyConfig.onProxyReq?.(proxyReq, req, res);
           },
           onProxyRes(proxyRes, req: any, res) {


### PR DESCRIPTION
回退 #8828 ，这个变更会导致部分走 origin 白名单、但不包含自己的服务端接口跨域请求失败

cc @citrusjunoss 下个版本会去掉这个逻辑，可以通过你后面 PR 的 onProxyReq 针对项目自定义