### PR TITLE
fix: mime模块拒绝服务漏洞 - mime@1.3.6 - 间接引入

### DIFF
--- a/packages/preset-built-in/package.json
+++ b/packages/preset-built-in/package.json
@@ -44,7 +44,7 @@
     "es5-imcompatible-versions": "^0.1.62",
     "history-with-query": "4.10.4",
     "html-entities": "^2.1.0",
-    "mime": "1.3.6",
+    "mime": "1.4.1",
     "react-refresh": "0.10.0",
     "react-router": "5.2.0",
     "react-router-config": "5.1.1",


### PR DESCRIPTION
fix: bump mime to 1.4.1 to fix CVE-2017-16138
Close https://github.com/umijs/umi/issues/8528