### PR TITLE
fix: bump ansi-html to ^0.0.8

### DIFF
--- a/packages/preset-built-in/package.json
+++ b/packages/preset-built-in/package.json
@@ -36,7 +36,7 @@
     "@umijs/server": "3.5.34",
     "@umijs/types": "3.5.34",
     "@umijs/utils": "3.5.34",
-    "ansi-html": "^0.0.7",
+    "ansi-html": "^0.0.8",
     "core-js": "3.6.5",
     "core-js-pure": "^3.8.1",
     "error-stack-parser": "^2.0.6",

--- a/packages/preset-built-in/package.json
+++ b/packages/preset-built-in/package.json
@@ -36,7 +36,7 @@
     "@umijs/server": "3.5.34",
     "@umijs/types": "3.5.34",
     "@umijs/utils": "3.5.34",
-    "ansi-html": "^0.0.8",
+    "ansi-html": "^0.0.9",
     "core-js": "3.6.5",
     "core-js-pure": "^3.8.1",
     "error-stack-parser": "^2.0.6",


### PR DESCRIPTION
bump ansi-html to ^0.0.8
fix CVE-2021-23424