### PR TITLE
feat:preset-umi-assets-path去除build的目标assets的umi开头的命名限制

### DIFF
--- a/packages/preset-umi/src/commands/dev/getAssetsMap.ts
+++ b/packages/preset-umi/src/commands/dev/getAssetsMap.ts
@@ -1,6 +1,6 @@
 const UMI_ASSETS_REG = {
-  js: /^umi(\..+)?\.js$/,
-  css: /^umi(\..+)?\.css$/,
+  js: /^(.+)?\.js$/,
+  css: /^(.+)?\.css$/,
 };
 const HOT_UPDATE = '.hot-update.';
 


### PR DESCRIPTION
去除build的目标assets的umi开头的命名限制

项目中需要打包到指定static目录，因此需要重定义build的目标assets路径，因此提交了此pr