### PR TITLE
fix: lockCoreJS plugin support dynamic import

### DIFF
--- a/packages/babel-preset-umi/src/plugins/lockCoreJS.test.ts
+++ b/packages/babel-preset-umi/src/plugins/lockCoreJS.test.ts
@@ -23,3 +23,14 @@ test('only replace core-js/', () => {
   expect(code).toContain(`import 'a';\nimport 'core-js';`);
   expect(code).toContain('node_modules/core-js/foo');
 });
+
+test('dynamic import', () => {
+  const code = doTransform({
+    code: `import('a');import('core-js');import('core-js/foo');`,
+    opts: {
+      absoluteCoreJS: '/tmp/core-js/',
+    },
+  });
+  expect(code).toContain(`import('a');\nimport('core-js');`);
+  expect(code).toContain('node_modules/core-js/foo');
+});

--- a/packages/babel-preset-umi/src/plugins/lockCoreJS.ts
+++ b/packages/babel-preset-umi/src/plugins/lockCoreJS.ts
@@ -1,4 +1,5 @@
 import * as t from '@umijs/bundler-utils/compiled/babel/types';
+import * as Babel from '@umijs/bundler-utils/compiled/babel/core';
 import { winPath } from '@umijs/utils';
 import { dirname } from 'path';
 
@@ -8,8 +9,24 @@ function addLastSlash(path: string) {
 
 export default function () {
   return {
-    post({ path }: any) {
-      path.node.body.forEach((node: any) => {
+    visitor: {
+      CallExpression(path: Babel.NodePath<t.CallExpression>) {
+        if (
+          t.isImport(path.node.callee) &&
+          t.isStringLiteral(path.node.arguments?.[0]) &&
+          path.node.arguments[0].value.startsWith('core-js/')
+        ) {
+          path.node.arguments[0].value = path.node.arguments[0].value.replace(
+            /^core-js\//,
+            addLastSlash(
+              winPath(dirname(require.resolve('core-js/package.json'))),
+            ),
+          );
+        }
+      },
+    },
+    post({ path }: { path: Babel.NodePath<t.Program> }) {
+      path.node.body.forEach((node) => {
         if (t.isImportDeclaration(node)) {
           if (node.source.value.startsWith('core-js/')) {
             node.source.value = node.source.value.replace(


### PR DESCRIPTION
`core-js` may be imported manually and dynamically.

```
if (needPolyfill) {
  import('core-js/es').then();
}
```