### PR TITLE
修复 tsconfig.json 的文件 include 问题

### DIFF
--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -89,7 +89,12 @@ export default (api: IApi) => {
                 : {}),
             },
           },
-          include: [`${baseUrl}.umirc.ts`],
+          include: [
+            `${baseUrl}.umirc.ts`,
+            `${baseUrl}**/*.d.ts`,
+            `${baseUrl}**/*.ts`,
+            `${baseUrl}**/*.tsx`
+          ],
         },
         null,
         2,


### PR DESCRIPTION
https://github.com/umijs/umi/pull/9246 只包含了`.umirc.ts`，导致 tsconfig.json 无法正确发现其他的 `.ts(x)` 文件。。。

现在使用 `create-umi@latest` 新建工程的话，源文件中全是报错。。。

![Screen Shot 2022-09-08 at 16 54 46](https://user-images.githubusercontent.com/9099214/189080001-4eec8a06-5521-4cab-8132-210148b77647.png)
