### PR TITLE
doc(request): 修改 message.error 不能自动关闭的问题。

### DIFF
--- a/docs/docs/max/request.md
+++ b/docs/docs/max/request.md
@@ -354,7 +354,7 @@ export const request: RequestConfig = {
       } else if (error.response) {
         // Axios 的错误
         // 请求成功发出且服务器也响应了状态码，但状态代码超出了 2xx 的范围
-        message.error('Response status:', error.response.status);
+        message.error(`Response status:${error.response.status}`);
       } else if (error.request) {
         // 请求已经成功发起，但没有收到响应
         // \`error.request\` 在浏览器中是 XMLHttpRequest 的实例，


### PR DESCRIPTION
`message.error('Response status:', error.response.status);` 这样会导致提示只显示：`Response status：`，而且还不能正常自动关闭。

-----
[View rendered docs/docs/max/request.md](https://github.com/hqwlkj/umi/blob/patch-4/docs/docs/max/request.md)