### PR TITLE
docs: :memo: 给 request 文档中 errorThrower 添加备注

### DIFF
--- a/docs/docs/max/request.md
+++ b/docs/docs/max/request.md
@@ -69,7 +69,9 @@ export const request: RequestConfig = {
 
 如果你觉得这种方式进行错误处理过于繁琐，可以直接在拦截器中实现自己的错误处理。
 
-> 注：`errorThrower` 是利用 `responseInterceptors` 实现的，它的触发条件是: 当 `data.success` 为 `false` 时，具体代码逻辑可以在路径 `src/.umi/plugin-request` 中找到。
+<Message emoji="🚨" >
+`errorThrower` 是利用 `responseInterceptors` 实现的，它的触发条件是: 当 `data.success` 为 `false` 时。
+</Message>
 
 #### requestInterceptors
 为 request 方法添加请求阶段的拦截器。

--- a/docs/docs/max/request.md
+++ b/docs/docs/max/request.md
@@ -1,3 +1,5 @@
+import { Message } from 'umi';
+
 # 请求
 
 `@umijs/max` 内置了插件方案。它基于 [axios](https://axios-http.com/) 和 [ahooks](https://ahooks-v2.surge.sh) 的 `useRequest` 提供了一套统一的网络请求和错误处理方案。

--- a/docs/docs/max/request.md
+++ b/docs/docs/max/request.md
@@ -69,6 +69,8 @@ export const request: RequestConfig = {
 
 如果你觉得这种方式进行错误处理过于繁琐，可以直接在拦截器中实现自己的错误处理。
 
+> 注：`errorThrower` 是利用 `responseInterceptors` 实现的，它的触发条件是: 当 `data.success` 为 `false` 时，具体代码逻辑可以在路径 `src/.umi/plugin-request` 中找到。
+
 #### requestInterceptors
 为 request 方法添加请求阶段的拦截器。
 


### PR DESCRIPTION
在我的项目中后端返回给前端的字段不是 `success`，因此在 `errorThrower` 使用过程中，无法 catch `Error`。

查看源码以后才发现默认是对 `data.success` 进行判断，所以我的项目中只能使用拦截器进行判断。

这块的文档需要做一下补充。

-----
[View rendered docs/docs/max/request.md](https://github.com/october-rain/umi/blob/docs/request/docs/docs/max/request.md)