### PR TITLE
docs:中文文档的Umi Max模块的request引用缺少单引号

### DIFF
--- a/docs/docs/max/request.md
+++ b/docs/docs/max/request.md
@@ -152,7 +152,7 @@ export default () => {
 
 
 ### request
-通过 `import { request } from '@@/plugin-request` 你可以使用内置的请求方法。
+通过 `import { request } from '@@/plugin-request'` 你可以使用内置的请求方法。
 
 `request` 接收的 `options`除了透传 [axios](https://axios-http.com/docs/req_config) 的所有 config 之外，我们还额外添加了几个属性 `skipErrorHandler`，`getResponse`，`requestInterceptors` 和 `responseInterceptors` 。
 


### PR DESCRIPTION
https://umijs.org/docs/max/request
中文文档的Umi Max模块的request引用缺少单引号，原文如下
**_通过 import { request } from '@@/plugin-request 你可以使用内置的请求方法_**
 '@@/plugin-request 缺少反单引号

-----
[View rendered docs/docs/max/request.md](https://github.com/YqxLzx/umi/blob/fix_documentText/docs/docs/max/request.md)