### PR TITLE
fix(history): push and replace patch with getter

### DIFF
--- a/packages/preset-umi/templates/history.tpl
+++ b/packages/preset-umi/templates/history.tpl
@@ -24,10 +24,10 @@ export function createHistory(opts: any) {
       h.replace(patchTo(to), state);
     },
     get location() {
-      return h.location
+      return h.location;
     },
     get action() {
-      return h.action
+      return h.action;
     }
   }
 

--- a/packages/preset-umi/templates/history.tpl
+++ b/packages/preset-umi/templates/history.tpl
@@ -14,15 +14,23 @@ export function createHistory(opts: any) {
   if (opts.basename) {
     basename = opts.basename;
   }
-  history = h;
-  const oldPush = h.push;
-  history.push = (to, state) => {
-    oldPush(patchTo(to), state);
-  };
-  const oldReplace = h.replace;
-  history.replace = (to, state) => {
-    oldReplace(patchTo(to), state);
-  };
+
+  history = {
+    ...h,
+    push(to, state) {
+      h.push(patchTo(to), state);
+    },
+    replace(to, state) {
+      h.replace(patchTo(to), state);
+    },
+    get location() {
+      return h.location
+    },
+    get action() {
+      return h.action
+    }
+  }
+
   return h;
 }
 


### PR DESCRIPTION
#### 内容

回退到原来的代码，并加上丢失的 getter 。

#### 问题

这个地方改 `history.push` 其实是改了引用，`h` 也被影响了，这样是不对的。会导致内部 `navigate` / `Link` 等多一层 basename 。

根本原因是解构拷贝的时候把 [getter](https://github.com/remix-run/history/blob/3e9dab413f4eda8d6bce565388c5ddb7aeff9f7e/packages/history/index.ts#L530-L535) 弄丢了。。。

花了三个小时才发现 🤯

#### Resolve

fix #9209 
fix #9287
