### PR TITLE
Fix preset umi polyfill targets

### DIFF
--- a/docs/docs/api/config.md
+++ b/docs/docs/api/config.md
@@ -1062,7 +1062,7 @@ import SmileUrl, { ReactComponent as SvgSmile } from './smile.svg';
 ## targets
 
 - 类型：`object`
-- 默认值：`{ chrome: 87 }`
+- 默认值：`{ chrome: 80 }`
 
 配置需要兼容的浏览器最低版本。Umi 会根据这个自定引入 polyfill、配置 autoprefixer 和做语法转换等。
 

--- a/packages/preset-umi/src/constants.ts
+++ b/packages/preset-umi/src/constants.ts
@@ -4,8 +4,4 @@ export const DEFAULT_PORT = '8000';
 export const DEFAULT_HOST = '0.0.0.0';
 export const CACHE_DIR_NAME = '.cache';
 export const TEMPLATES_DIR = join(__dirname, '../templates');
-
-// see ../../bundler-webpack/src/constant.ts
-export const DEFAULT_BROWSER_TARGETS = {
-  chrome: 80,
-};
+export { DEFAULT_BROWSER_TARGETS } from '@umijs/bundler-webpack/dist/constants';

--- a/packages/preset-umi/src/constants.ts
+++ b/packages/preset-umi/src/constants.ts
@@ -4,3 +4,8 @@ export const DEFAULT_PORT = '8000';
 export const DEFAULT_HOST = '0.0.0.0';
 export const CACHE_DIR_NAME = '.cache';
 export const TEMPLATES_DIR = join(__dirname, '../templates');
+
+// see ../../bundler-webpack/src/constant.ts
+export const DEFAULT_BROWSER_TARGETS = {
+  chrome: 80,
+};

--- a/packages/preset-umi/src/constants.ts
+++ b/packages/preset-umi/src/constants.ts
@@ -4,4 +4,3 @@ export const DEFAULT_PORT = '8000';
 export const DEFAULT_HOST = '0.0.0.0';
 export const CACHE_DIR_NAME = '.cache';
 export const TEMPLATES_DIR = join(__dirname, '../templates');
-export { DEFAULT_BROWSER_TARGETS } from '@umijs/bundler-webpack/dist/constants';

--- a/packages/preset-umi/src/features/polyfill/polyfill.ts
+++ b/packages/preset-umi/src/features/polyfill/polyfill.ts
@@ -1,7 +1,7 @@
 import { transform } from '@umijs/bundler-utils/compiled/babel/core';
 import { getCorejsVersion, winPath } from '@umijs/utils';
 import { dirname, join } from 'path';
-import { DEFAULT_BROWSER_TARGETS } from '../../constants';
+import { DEFAULT_BROWSER_TARGETS } from '@umijs/bundler-webpack/dist/constants';
 import { IApi } from '../../types';
 
 export default (api: IApi) => {

--- a/packages/preset-umi/src/features/polyfill/polyfill.ts
+++ b/packages/preset-umi/src/features/polyfill/polyfill.ts
@@ -1,6 +1,7 @@
 import { transform } from '@umijs/bundler-utils/compiled/babel/core';
 import { getCorejsVersion, winPath } from '@umijs/utils';
 import { dirname, join } from 'path';
+import { DEFAULT_BROWSER_TARGETS } from '../../constants';
 import { IApi } from '../../types';
 
 export default (api: IApi) => {
@@ -60,6 +61,8 @@ export {};
   api.addPolyfillImports(() => [{ source: `./core/polyfill` }]);
 
   api.modifyConfig((memo) => {
+    memo.targets ||= DEFAULT_BROWSER_TARGETS;
+
     memo.alias['regenerator-runtime'] = dirname(
       require.resolve('regenerator-runtime/package'),
     );


### PR DESCRIPTION
1. 修复`umi build`时polyfill的`targets`为`undefined`的问题
![image](https://user-images.githubusercontent.com/34960995/189535266-cd22c457-20ee-4af7-b404-fc0594c63fcc.png)
这个问题也会导致`umi dev`时第二次编译的时候`mfsu` `buildDeps`
![image](https://user-images.githubusercontent.com/34960995/189535372-7c467961-aa6a-4799-a5f7-7fbd8d538598.png)
原因是第二次编译时`targets`已经被`bundler-webpack`修改为正确的`targets`
2. 修复文档，`targets` 默认是`{ chrome: 80 }`


-----
[View rendered docs/docs/api/config.md](https://github.com/2239559319/umi/blob/fix-preset-umi-polyfill-targets/docs/docs/api/config.md)