### PR TITLE
fix: fix doc page layout shift

### DIFF
--- a/packages/plugin-docs/client/theme-doc/tailwind.css
+++ b/packages/plugin-docs/client/theme-doc/tailwind.css
@@ -219,6 +219,10 @@ article hr {
   );
 }
 
+body {
+  overflow-y: scroll;
+}
+
 html {
   scroll-behavior: smooth;
 }


### PR DESCRIPTION
修复文档页面的`layout shift`问题
![image](https://user-images.githubusercontent.com/34960995/189589316-8ca3d3ee-1761-4461-a09d-6b830c29c4d0.png)
原因是异步chunk执行之前滚动条消失