### PR TITLE
fix: 修复prompts无法cancel

### DIFF
--- a/packages/utils/src/Generator/Generator.ts
+++ b/packages/utils/src/Generator/Generator.ts
@@ -25,7 +25,11 @@ class Generator {
 
   async run() {
     const questions = this.prompting();
-    this.prompts = await prompts(questions);
+    this.prompts = await prompts(questions, {
+      onCancel() {
+        process.exit(1);
+      },
+    });
     await this.writing();
   }
 


### PR DESCRIPTION
修复 @umijs/utils 中 Generator 的 prompts 无法取消, 现在cmd+c中断还会copy模版文件