### PR TITLE
fix(bundler-webpack): `extraBabelIncludes` not working with tnpm

### DIFF
--- a/packages/bundler-webpack/src/config/javaScriptRules.ts
+++ b/packages/bundler-webpack/src/config/javaScriptRules.ts
@@ -65,7 +65,14 @@ export async function addJavaScriptRules(opts: IOpts) {
             }
             // use resolve instead of require.resolve
             // since require.resolve may meet the ERR_PACKAGE_PATH_NOT_EXPORTED error
-            return dirname(resolve.sync(`${p}/package.json`, { basedir: cwd }));
+            return dirname(
+              resolve.sync(`${p}/package.json`, {
+                basedir: cwd,
+                // same behavior as webpack, to ensure `include` paths matched
+                // ref: https://webpack.js.org/configuration/resolve/#resolvesymlinks
+                preserveSymlinks: false,
+              }),
+            );
           } catch (e: any) {
             if (e.code === 'MODULE_NOT_FOUND') {
               throw new Error('Cannot resolve extraBabelIncludes: ' + p);


### PR DESCRIPTION
Webpack 默认使用软链接解析后的地址、但 `extraBabelIncludes` 自动生成的 include 使用了软链接之前的地址（`resolve` 这个包的 `preserveSymlink` [默认值为 `true`](https://github.com/browserify/resolve#resolveid-opts-cb)），导致`extraBabelIncludes` 配置项不生效