### PR TITLE
fix: 文档搜索结果不能滚动

### DIFF
--- a/packages/plugin-docs/client/theme-doc/Search.tsx
+++ b/packages/plugin-docs/client/theme-doc/Search.tsx
@@ -94,7 +94,7 @@ export default () => {
           id="search-results-wrapper"
           className={cx(
             'absolute transition-all duration-500 top-12 w-96 rounded-lg',
-            'cursor-pointer shadow overflow-hidden',
+            'cursor-pointer shadow overflow-y-scroll',
             keyword && isFocused ? 'max-h-80' : 'max-h-0',
           )}
         >


### PR DESCRIPTION
修复文档中搜索结果太多不能滚动问题