### PR TITLE
refactor: 🎨 node version < v16.9.0 , show config error directly

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1,5 +1,5 @@
 import esbuild from '@umijs/bundler-utils/compiled/esbuild';
-import { chokidar, lodash, register } from '@umijs/utils';
+import { chokidar, lodash, register, semver } from '@umijs/utils';
 import joi from '@umijs/utils/compiled/@hapi/joi';
 import assert from 'assert';
 import { existsSync } from 'fs';
@@ -172,7 +172,7 @@ export class Config {
         } catch (e) {
           // Error.prototype.cause has been fully supported from  node v16.9.0
           // Ref https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause#browser_compatibility
-          if (process.version < 'v16.9.0') {
+          if (semver.lt(semver.clean(process.version)!, '16.9.0')) {
             throw e;
           }
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -170,6 +170,12 @@ export class Config {
         try {
           config = lodash.merge(config, require(configFile).default);
         } catch (e) {
+          // Error.prototype.cause has been fully supported from  node v16.9.0
+          // Ref https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause#browser_compatibility
+          if (process.version < 'v16.9.0') {
+            throw e;
+          }
+
           // @ts-ignore
           throw new Error(`Parse config file failed: [${configFile}]`, {
             cause: e,


### PR DESCRIPTION
16.9.0 之前的 node 版本，不支持 cause ，所以真实的 error 打印不出来。

如果16.9.0 之前的直接抛错到下游。


## after

```text
> max  dev

info  - @local
fatal - Error: code error
    at Object.<anonymous> (/Users/umi/git/umi-playground/.umirc.ts:34:7)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Module._compile (/Users/umi/git/umi-next/packages/utils/compiled/pirates/index.js:1:1668)
    at Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Object.newLoader [as .ts] (/Users/umi/git/umi-next/packages/utils/compiled/pirates/index.js:1:1684)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:93:18)
    at Function.getUserConfig (/Users/umi/git/umi-next/packages/core/dist/config/config.js:141:54)
```

## before

```text
> max  dev

info  - @local
fatal - Error: Parse config file failed: [/Users/pshu/git/umi-playground/.umirc.ts]
    at Function.getUserConfig (/Users/pshu/git/umi-next/packages/core/dist/config/config.js:143:17)
    at Config.getUserConfig (/Users/pshu/git/umi-next/packages/core/dist/config/config.js:51:19)
    at Service.run (/Users/pshu/git/umi-next/packages/core/dist/service/service.js:196:37)
    at Service.run2 (/Users/pshu/git/umi-next/packages/umi/dist/service/service.js:58:23)
    at /Users/pshu/git/umi-next/packages/umi/dist/cli/forkedDev.js:24:19
    at Object.<anonymous> (/Users/pshu/git/umi-next/packages/umi/dist/cli/forkedDev.js:37:3)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12
```

