### PR TITLE
docs: fix runtimePublicPath default value

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1087,7 +1087,7 @@ setCreateHistoryOptions({
 ## runtimePublicPath
 
 - Type: `boolean`
-- Default: `false`
+- Default: `true`
 
 配置是否启用运行时 publicPath。
 

--- a/docs/config/README.zh-CN.md
+++ b/docs/config/README.zh-CN.md
@@ -1086,7 +1086,7 @@ setCreateHistoryOptions({
 ## runtimePublicPath
 
 - Type: `boolean`
-- Default: `false`
+- Default: `true`
 
 配置是否启用运行时 publicPath。
 


### PR DESCRIPTION
修改文档中 `runtimePublicPath` 默认值

-----
[View rendered docs/config/README.md](https://github.com/zhangminggeek/umi/blob/3.x/docs/config/README.md)
[View rendered docs/config/README.zh-CN.md](https://github.com/zhangminggeek/umi/blob/3.x/docs/config/README.zh-CN.md)