### PR TITLE
refactor: 🎨 mfsu.eager 情况下项目代码构建使用不同的 cache 路径

### DIFF
--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -82,6 +82,9 @@ export async function getConfig(opts: IOpts): Promise<Configuration> {
       opts.staticPathPrefix !== undefined ? opts.staticPathPrefix : 'static/',
   };
 
+  // name
+  config.name(opts.name);
+
   // mode
   config.mode(opts.env);
   config.stats('none');

--- a/packages/bundler-webpack/src/dev.ts
+++ b/packages/bundler-webpack/src/dev.ts
@@ -93,6 +93,7 @@ export async function dev(opts: IOpts) {
   }
 
   const webpackConfig = await getConfig({
+    name: opts.mfsuStrategy === 'eager' ? 'eager' : undefined,
     cwd: opts.cwd,
     rootDir: opts.rootDir,
     env: Env.development,


### PR DESCRIPTION
why：解决切换配置时仍然需要删除 cache 目录的问题

mfsu.normal cache 路径  node_modules/.cache/bundler-webpack/default-development/
mfsu.eager   cache 路径  node_modules/.cache/bundler-webpack/eager-development/

cache name 规则 ref：https://webpack.js.org/configuration/cache/#cachename

为什么依赖构建不改
* 两种模式下，mf 的 exposes 的配置会有不同
* 两种模式下，重新构建的策略不同，不会相互影响