### PR TITLE
fix: 🐛 move mfsu.mfName  modify to defaultConfigModify hook

### DIFF
--- a/packages/plugins/src/qiankun/slave.ts
+++ b/packages/plugins/src/qiankun/slave.ts
@@ -137,7 +137,7 @@ export interface IRuntimeConfig {
         ...memo.qiankun,
         slave: initialSlaveOptions,
       },
-    };
+    } as any;
 
     const shouldNotModifyDefaultBase =
       api.userConfig.qiankun?.slave?.shouldNotModifyDefaultBase ??
@@ -148,16 +148,11 @@ export interface IRuntimeConfig {
       modifiedDefaultConfig.base = `/${api.pkg.name}`;
     }
 
-    return modifiedDefaultConfig;
-  });
-
-  api.modifyConfig((config) => {
-    // mfsu 场景默认给子应用增加 mfName 配置，从而避免冲突
-    if (config.mfsu !== false) {
-      config.mfsu = {
-        ...config.mfsu,
+    if (modifiedDefaultConfig.mfsu !== false) {
+      modifiedDefaultConfig.mfsu = {
+        ...modifiedDefaultConfig.mfsu,
         mfName:
-          config.mfsu?.mfName ||
+          modifiedDefaultConfig.mfsu?.mfName ||
           `mf_${api.pkg.name
             // 替换掉包名里的特殊字符
             // e.g. @umi/ui -> umi_ui
@@ -165,7 +160,8 @@ export interface IRuntimeConfig {
             .replace(/\W/g, '_')}`,
       };
     }
-    return config;
+
+    return modifiedDefaultConfig;
   });
 
   api.addHTMLHeadScripts(() => {


### PR DESCRIPTION
## why 
当 tern 应用启动 mfsu eager 的配置下，原先的主线程获取配置是 slave 的环境变量没有生效，所以未修改 mfName 值
当 编译构建 worker 线程启动时，环境变量已经生效，salve 插件又修改了 mfName 为 mf_{pkg.name}

那么主线程构建的应用 使用 mf 远端名称，远端应用使用的是 mf_{pkg.name} 导致加载失败。

## solution
最终配置  会使用 config 和 default config 合并，所以将 mfName 修改的行为放到 modifyDefaultConfig 中，这样主线程和 work 线程配置就一致了。

