### PR TITLE
feat(mfsu): ✨ MFSU 因为依赖缺失 报错优化

### DIFF
--- a/packages/mfsu/src/dep/dep.ts
+++ b/packages/mfsu/src/dep/dep.ts
@@ -1,4 +1,4 @@
-import { pkgUp, winPath } from '@umijs/utils';
+import { pkgUp, winPath, logger, chalk } from '@umijs/utils';
 import assert from 'assert';
 import enhancedResolve from 'enhanced-resolve';
 import { readFileSync } from 'fs';
@@ -68,7 +68,15 @@ export * from '${this.file}';
 
     // none node natives
     const realFile = await this.getRealFile();
-    assert(realFile, `filePath not found of ${this.file}`);
+
+    if (!realFile) {
+      logger.error(
+        `Can not resolve dependence : '${chalk.red(
+          this.file,
+        )}', please install it`,
+      );
+    }
+    assert(realFile, `dependence not found: ${this.file}`);
     const content = readFileSync(realFile, 'utf-8');
     return await getExposeFromContent({
       content,


### PR DESCRIPTION
###  构建报错
```bash
error - Can not resolve dependence : 'lodash.sample', please install it
error - [MFSU][eager] build failed AssertionError [ERR_ASSERTION]: dependence not found: lodash.sample
    at Dep.buildExposeContent (/Users/umi/git/umi-next/packages/mfsu/dist/dep/dep.js:73:31)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async DepBuilderInWorker.writeMFFiles (/Users/umi/git/umi-next/packages/preset-umi/dist/commands/dev/depBuildWorker/depBuilder.js:131:23)
    at async DepBuilderInWorker.build (/Users/umi/git/umi-next/packages/preset-umi/dist/commands/dev/depBuildWorker/depBuilder.js:102:7)
```

###  请求 mfsu 构建产物 文件不存在报错

 ```bash
error - MFSU dist file: /Users/umi/git/umi-playground/node_modules/.cache/mfsu/mf-va_remoteEntry.js not found
error - MFSU latest build error  AssertionError [ERR_ASSERTION]: dependence not found: lodash.sample
    at Dep.buildExposeContent (/Users/umi/git/umi-next/packages/mfsu/dist/dep/dep.js:73:31)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async DepBuilderInWorker.writeMFFiles (/Users/umi/git/umi-next/packages/preset-umi/dist/commands/dev/depBuildWorker/depBuilder.js:131:23)
    at async DepBuilderInWorker.build (/Users/umi/git/umi-next/packages/preset-umi/dist/commands/dev/depBuildWorker/depBuilder.js:102:7)    
```