### PR TITLE
fix(plugin-layout): fixed kebab-case icon transform error

### DIFF
--- a/packages/plugins/src/layout.ts
+++ b/packages/plugins/src/layout.ts
@@ -376,7 +376,7 @@ import icons from './icons';
 function formatIcon(name: string) {
   return name
     .replace(name[0], name[0].toUpperCase())
-    .replace(/-(\w)/g, function(all, letter) {
+    .replace(/-(\\w)/g, function(all, letter) {
       return letter.toUpperCase();
     });
 }


### PR DESCRIPTION
kebab-case 图标转换有点问题，原因是字符串转义消耗掉了 "\\" 字符，因此需要将 "\\" => "\\\\"