### PR TITLE
fix: 🐛 恢复项目编译webpack 日志 name 为 “Wepack”

### DIFF
--- a/packages/bundler-webpack/src/dev.ts
+++ b/packages/bundler-webpack/src/dev.ts
@@ -93,7 +93,6 @@ export async function dev(opts: IOpts) {
   }
 
   const webpackConfig = await getConfig({
-    name: opts.mfsuStrategy === 'eager' ? 'eager' : undefined,
     cwd: opts.cwd,
     rootDir: opts.rootDir,
     env: Env.development,
@@ -118,7 +117,12 @@ export async function dev(opts: IOpts) {
     cache: opts.cache
       ? {
           ...opts.cache,
-          cacheDirectory: join(cacheDirectoryPath, 'bundler-webpack'),
+          cacheDirectory: join(
+            cacheDirectoryPath,
+            opts.mfsuStrategy === 'eager'
+              ? 'bundler-webpack-eager'
+              : 'bundler-webpack',
+          ),
         }
       : undefined,
     pkg: opts.pkg,


### PR DESCRIPTION
change cache path  when mfsu.eager
dont overwrite config name

### after

```bash
$ls .cache/
.
..
bundler-webpack
bundler-webpack-eager
logger
mfsu
mfsu-deps
```

```text
event - [Webpack] Compiled in 19630 ms (7395 modules)
wait  - [Webpack] Compiling...
event - [MFSU][eager] start build deps
info  - [MFSU] skip buildDeps
event - [Webpack] Compiled in 1259 ms (7225 modules)
wait  - [Webpack] Compiling...
event - [MFSU][eager] start build deps
info  - [MFSU] skip buildDeps
event - [Webpack] Compiled in 920 ms (7225 modules)
```

