### PR TITLE
feat: enable loose mode for class-properties

### DIFF
--- a/examples/with-mobx/pages/hello.tsx
+++ b/examples/with-mobx/pages/hello.tsx
@@ -1,0 +1,18 @@
+import { inject, observer } from 'mobx-react';
+import React from 'react';
+import '../style.less';
+
+export default inject('hello')(
+  observer(function HomePage(props) {
+    console.log(props.hello.msg);
+    return (
+      <div className="container">
+        <p className="title">UmiJS x Mobx x Decorators</p>
+        <p className="display-count">{props.hello.msg}</p>
+        <div>
+          <button onClick={() => props.hello.sayHello()}>say</button>
+        </div>
+      </div>
+    );
+  }),
+);

--- a/examples/with-mobx/stores/index.ts
+++ b/examples/with-mobx/stores/index.ts
@@ -1,5 +1,7 @@
 import Counter from './modules/counter';
+import Hello from './modules/hello';
 
 export default {
   counter: new Counter(),
+  hello: new Hello(),
 };

--- a/examples/with-mobx/stores/modules/hello.ts
+++ b/examples/with-mobx/stores/modules/hello.ts
@@ -1,0 +1,21 @@
+import { makeObservable, observable, override, action } from 'mobx';
+
+class BaseHello {
+  @observable
+  msg = 'base hello';
+
+  constructor() {
+    makeObservable(this);
+  }
+
+  @action sayHello() {
+    this.msg = 'say base hello world';
+  }
+}
+
+export default class Hello extends BaseHello {
+  msg = 'hello mobx';
+  @override sayHello(): void {
+    this.msg = 'say hello world';
+  }
+}

--- a/examples/with-mobx/tsconfig.json
+++ b/examples/with-mobx/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./.umi/tsconfig.json",
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
+}

--- a/packages/babel-preset-umi/src/index.test.ts
+++ b/packages/babel-preset-umi/src/index.test.ts
@@ -25,12 +25,12 @@ test('async generator function', () => {
   expect(code).toContain(`return _awaitAsyncGenerator(111);`);
 });
 
-// no loose
+// loose
 test('class properties', () => {
   const code = doTransform({
     code: `class Foo { a = 'b'; foo = () => this.a; static c = 'd';}`,
   });
-  expect(code).toContain(`_defineProperty(this, "a", 'b');`);
+  expect(code).toContain(`this.a = 'b';`);
 });
 
 test('optional chaining', () => {
@@ -133,7 +133,7 @@ test('typescript with allowDeclareFields', () => {
       code: `class A { declare foo: string; bar: string }`,
       filename: 'foo.ts',
     }),
-  ).toContain(`_defineProperty(this, "bar", void 0);`);
+  ).toContain(`this.bar = void 0;`);
 });
 
 xtest('typescript with onlyRemoveTypeImports', () => {

--- a/packages/babel-preset-umi/src/index.ts
+++ b/packages/babel-preset-umi/src/index.ts
@@ -73,6 +73,39 @@ export default (_context: any, opts: IOpts) => {
         ),
         { legacy: true },
       ],
+      // Enable loose mode to use assignment instead of defineProperty
+      // Note:
+      // 'loose' mode configuration must be the same for
+      // * @babel/plugin-proposal-class-properties
+      // * @babel/plugin-proposal-private-methods
+      // * @babel/plugin-proposal-private-property-in-object
+      // (when they are enabled)
+      // ref: https://github.com/facebook/create-react-app/issues/4263
+      // ref: https://github.com/mobxjs/mobx/issues/1471
+      // ref: https://github.com/umijs/umi/issues/9396
+      [
+        require.resolve(
+          '@umijs/bundler-utils/compiled/babel/plugin-proposal-class-properties',
+        ),
+        { loose: true },
+      ],
+      [
+        require.resolve(
+          '@umijs/bundler-utils/compiled/babel/plugin-proposal-private-methods',
+        ),
+        {
+          loose: true,
+        },
+      ],
+      [
+        require.resolve(
+          '@umijs/bundler-utils/compiled/babel/plugin-proposal-private-property-in-object',
+        ),
+        {
+          loose: true,
+        },
+      ],
+
       // do-expressions
       [
         require.resolve(

--- a/packages/bundler-utils/bundles/babel/bundle.js
+++ b/packages/bundler-utils/bundles/babel/bundle.js
@@ -33,4 +33,9 @@ module.exports = {
   template: () => require('@babel/template'),
   traverse: () => require('@babel/traverse'),
   types: () => require('@babel/types'),
+
+  // class 使用 loose 模式需要
+  pluginProposalClassProperties: () => require('@babel/plugin-proposal-class-properties'),
+  pluginProposalPrivateMethods: () => require('@babel/plugin-proposal-private-methods'),
+  pluginProposalPrivatePropertyInObject: () => require('@babel/plugin-proposal-private-property-in-object')
 };

--- a/packages/bundler-utils/bundles/babel/packages/plugin-proposal-class-properties.js
+++ b/packages/bundler-utils/bundles/babel/packages/plugin-proposal-class-properties.js
@@ -1,0 +1,1 @@
+module.exports = require('./').pluginProposalClassProperties();

--- a/packages/bundler-utils/bundles/babel/packages/plugin-proposal-private-methods.js
+++ b/packages/bundler-utils/bundles/babel/packages/plugin-proposal-private-methods.js
@@ -1,0 +1,1 @@
+module.exports = require('./').pluginProposalPrivateMethods();

--- a/packages/bundler-utils/bundles/babel/packages/plugin-proposal-private-property-in-object.js
+++ b/packages/bundler-utils/bundles/babel/packages/plugin-proposal-private-property-in-object.js
@@ -1,0 +1,1 @@
+module.exports = require('./').pluginProposalPrivatePropertyInObject();

--- a/packages/bundler-utils/compiled/babel/plugin-proposal-class-properties.js
+++ b/packages/bundler-utils/compiled/babel/plugin-proposal-class-properties.js
@@ -1,0 +1,1 @@
+module.exports = require('./').pluginProposalClassProperties();

--- a/packages/bundler-utils/compiled/babel/plugin-proposal-private-methods.js
+++ b/packages/bundler-utils/compiled/babel/plugin-proposal-private-methods.js
@@ -1,0 +1,1 @@
+module.exports = require('./').pluginProposalPrivateMethods();

--- a/packages/bundler-utils/compiled/babel/plugin-proposal-private-property-in-object.js
+++ b/packages/bundler-utils/compiled/babel/plugin-proposal-private-property-in-object.js
@@ -1,0 +1,1 @@
+module.exports = require('./').pluginProposalPrivatePropertyInObject();


### PR DESCRIPTION
Close #9396 
解决因为  babel 编译导致的 mobx 使用 decorator 无法工作
