### PR TITLE
fix(MFSU): 🐛 修复 cache 解析错误

### DIFF
--- a/packages/mfsu/src/depInfo.ts
+++ b/packages/mfsu/src/depInfo.ts
@@ -63,11 +63,19 @@ export class DepInfo implements IDepInfo {
   loadCache() {
     if (existsSync(this.cacheFilePath)) {
       logger.info('[MFSU] restore cache');
-      const { cacheDependency, moduleGraph } = JSON.parse(
-        readFileSync(this.cacheFilePath, 'utf-8'),
-      );
-      this.cacheDependency = cacheDependency;
-      this.moduleGraph.restore(moduleGraph);
+      try {
+        const { cacheDependency, moduleGraph } = JSON.parse(
+          readFileSync(this.cacheFilePath, 'utf-8'),
+        );
+        this.cacheDependency = cacheDependency;
+        this.moduleGraph.restore(moduleGraph);
+      } catch (e) {
+        logger.error('[MFSU] restore cache failed', e);
+        logger.error('please `rm -rf  node_modules/.cache`, and try again');
+        // 如果 cache 恢复失败, 依赖信息是不完整, 项目代码编译使用了缓存, 那么分析出来的依赖是不完整的
+        // 错误透传出去, 让用户删除缓存重新启动才能彻底解决
+        throw e;
+      }
     }
   }
 

--- a/packages/mfsu/src/staticDepInfo/staticDepInfo.ts
+++ b/packages/mfsu/src/staticDepInfo/staticDepInfo.ts
@@ -141,8 +141,17 @@ export class StaticDepInfo {
 
   loadCache() {
     if (existsSync(this.cacheFilePath)) {
-      this.builtWithDep = JSON.parse(readFileSync(this.cacheFilePath, 'utf-8'));
-      logger.info('[MFSU][eager] restored cache');
+      try {
+        this.builtWithDep = JSON.parse(
+          readFileSync(this.cacheFilePath, 'utf-8'),
+        );
+        logger.info('[MFSU][eager] restored cache');
+      } catch (e) {
+        logger.warn(
+          '[MFSU][eager] restore cache failed, fallback to Empty dependency',
+          e,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
### eager 模式
如果 JSON 文件损坏，直接使用一个空对象作为依赖信息；根据扫描结果重新构建依赖

### normal 模式
**不能** 简单的用空对象替代解析结果；如果使用空对象，项目代码编译时有缓存，只能分析到部分项目代码，所以收集到的依赖是不完整的。因此构建出来的依赖MF 模块也是不完整的。
因此，日志打 ERROR 提示 删 .cache, 透传 error 。