### PR TITLE
feat: add dva types

### DIFF
--- a/examples/with-dva/models/count.ts
+++ b/examples/with-dva/models/count.ts
@@ -1,4 +1,9 @@
+import type { DvaModel } from 'umi';
+
 const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
+export interface CountModelState {
+  num: number;
+}
 
 export default {
   namespace: 'count',
@@ -6,7 +11,7 @@ export default {
     num: 0,
   },
   reducers: {
-    add(state: any) {
+    add(state: any): any {
       state.num += 1;
     },
   },
@@ -19,4 +24,4 @@ export default {
       throw new Error('effect error');
     },
   },
-};
+} as DvaModel<CountModelState>;

--- a/packages/plugins/src/dva.ts
+++ b/packages/plugins/src/dva.ts
@@ -1,7 +1,6 @@
 import * as t from '@umijs/bundler-utils/compiled/babel/types';
 import { winPath } from '@umijs/utils';
-import { dirname, extname, join, relative } from 'path';
-
+import { join, relative } from 'path';
 import { IApi, RUNTIME_TYPE_FILE_NAME } from 'umi';
 import { chalk } from 'umi/plugin-utils';
 import { Model, ModelUtils } from './utils/modelUtils';
@@ -41,7 +40,7 @@ export default (api: IApi) => {
     return memo;
   });
 
-  api.onGenerateFiles(async (args) => {
+  api.onGenerateFiles((args) => {
     const models = args.isFirstTime
       ? api.appData.pluginDva.models
       : getAllModels(api);

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -512,6 +512,7 @@ export default function EmptyRoute() {
           })
         ).join(', ')} } from '${rendererPath}';`,
       );
+      exports.push(`export type {  History } from '${rendererPath}'`);
       // umi/client/client/plugin
       exports.push('// umi/client/client/plugin');
       const umiPluginPath = winPath(join(umiDir, 'client/client/plugin.js'));


### PR DESCRIPTION
增加导出类型 `ConnectProps`，`ConnectRC`，`Reducer`，`Effect`，`SubscriptionsMapObject`，`DvaModel`

用例：

```ts
import type { DvaModel } from 'umi';

export interface CountModelState {
  num: number;
}

const CountModel: DvaModel<CountModelState> = {
  namespace: 'count',
  state: {
    num: 0,
  },
  reducers: {
    add(state: any): any {
      state.num += 1;
    },
  },
  effects: {
    *addAsync(_action: any, { put }: any) {
      yield put({ type: 'add' });
    },
    *throwError(_action: any) {
      throw new Error('effect error');
    },
  },
};

export default CountModel;
```

Closes:  https://github.com/umijs/umi/issues/8638 https://github.com/umijs/umi/issues/9355