### PR TITLE
feat(preset-umi): ignoreMomentLocale enabled by default

### DIFF
--- a/packages/preset-umi/src/features/configPlugins/configPlugins.ts
+++ b/packages/preset-umi/src/features/configPlugins/configPlugins.ts
@@ -70,6 +70,7 @@ export default (api: IApi) => {
     base: '/',
     history: { type: 'browser' },
     svgr: {},
+    ignoreMomentLocale: true,
   };
 
   const bundleSchemas = api.config.vite


### PR DESCRIPTION
与文档描述一致