### PR TITLE
fix(mfsu-eager): 🐛 默认开启 mfsu eager 模式

### DIFF
--- a/packages/mfsu/src/babelPlugins/awaitImport/MFImport.ts
+++ b/packages/mfsu/src/babelPlugins/awaitImport/MFImport.ts
@@ -51,10 +51,10 @@ export default function () {
           if (
             t.isImport(node.callee) &&
             node.arguments.length === 1 &&
-            node.arguments[0].type === 'StringLiteral'
+            t.isStringLiteral(node.arguments[0])
           ) {
             const newValue = opts.resolveImportSource(node.arguments[0].value);
-            node.arguments[0] = t.stringLiteral(newValue);
+            node.arguments[0].value = newValue;
           }
         },
       },

--- a/packages/mfsu/src/mfsu/strategyStaticAnalyze.ts
+++ b/packages/mfsu/src/mfsu/strategyStaticAnalyze.ts
@@ -133,13 +133,14 @@ export class StaticAnalyzeStrategy implements IMFSUStrategy {
         const start = Date.now();
         let event = this.staticDepInfo.getProducedEvent();
         while (event.length === 0) {
-          await sleep(200);
+          await sleep(100);
           event = this.staticDepInfo.getProducedEvent();
           if (Date.now() - start > 5000) {
             logger.warn('webpack wait mfsu deps too long');
             break;
           }
         }
+        logger.debug(`webpack waited ${Date.now() - start} ms`);
       },
       onCompileDone: () => {
         // fixme if mf module finished earlier than src compile

--- a/packages/mfsu/src/staticDepInfo/simulations/babel-plugin-import.test.ts
+++ b/packages/mfsu/src/staticDepInfo/simulations/babel-plugin-import.test.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import createImports from './babel-plugin-import';
 
 function pathToVersion(): string {
@@ -42,6 +43,32 @@ test('babel-plugin-import: with alias', () => {
 
         { replaceValue: `mf//project/node_modules/antd/es/row`,         value: '/project/node_modules/antd/es/row',         version: '1.2.3', isMatch: true,},
         { replaceValue: `mf//project/node_modules/antd/es/row/style`,   value: '/project/node_modules/antd/es/row/style',   version: '1.2.3', isMatch: true,},
+    ],
+  );
+});
+
+test('WINDOWS: babel-plugin-import: with alias', () => {
+  expect(
+    handleImports({
+      imports: [
+        // prettier-ignore
+        {n: "antd", s: 26, e: 30, ss: 0, se: 31, d: -1, a: -1},
+      ],
+      mfName: 'mf',
+      alias: {
+        antd: 'D:\\user\\umi\\node_modules\\antd',
+      },
+      rawCode: 'import {Model, Row} from "antd";',
+      pathToVersion,
+    }),
+  ).toEqual(
+    // prettier-ignore
+    [
+      { replaceValue: `mf/D:/user/umi/node_modules/antd/es/model`,       value: 'D:\\user\\umi\\node_modules\\antd/es/model',       version: '1.2.3', isMatch: true,},
+      { replaceValue: `mf/D:/user/umi/node_modules/antd/es/model/style`, value: 'D:\\user\\umi\\node_modules\\antd/es/model/style', version: '1.2.3', isMatch: true,},
+
+      { replaceValue: `mf/D:/user/umi/node_modules/antd/es/row`,         value: 'D:\\user\\umi\\node_modules\\antd/es/row',         version: '1.2.3', isMatch: true,},
+      { replaceValue: `mf/D:/user/umi/node_modules/antd/es/row/style`,   value: 'D:\\user\\umi\\node_modules\\antd/es/row/style',   version: '1.2.3', isMatch: true,},
     ],
   );
 });

--- a/packages/mfsu/src/staticDepInfo/simulations/babel-plugin-import.ts
+++ b/packages/mfsu/src/staticDepInfo/simulations/babel-plugin-import.ts
@@ -54,7 +54,7 @@ export default function createHandle(importOptions: {
         retMatched.push({
           isMatch: true,
           value: unAliasedModulePath,
-          replaceValue: `${mfName}/${unAliasedModulePath}`,
+          replaceValue: `${mfName}/${winPath(unAliasedModulePath)}`,
           version,
         });
 
@@ -65,7 +65,7 @@ export default function createHandle(importOptions: {
         retMatched.push({
           isMatch: true,
           value: unAliasedStylePath,
-          replaceValue: `${mfName}/${unAliasedStylePath}`,
+          replaceValue: `${mfName}/${winPath(unAliasedStylePath)}`,
           version,
         });
       }

--- a/packages/preset-umi/src/features/configPlugins/configPlugins.ts
+++ b/packages/preset-umi/src/features/configPlugins/configPlugins.ts
@@ -71,6 +71,7 @@ export default (api: IApi) => {
     history: { type: 'browser' },
     svgr: {},
     ignoreMomentLocale: true,
+    mfsu: { strategy: 'eager' },
   };
 
   const bundleSchemas = api.config.vite

--- a/packages/preset-umi/src/libs/folderCache/AutoUpdateSourceCodeCache.ts
+++ b/packages/preset-umi/src/libs/folderCache/AutoUpdateSourceCodeCache.ts
@@ -4,7 +4,7 @@ import {
   parse,
 } from '@umijs/bundler-utils/compiled/es-module-lexer';
 import { build as esBuild } from '@umijs/bundler-utils/compiled/esbuild';
-import { logger } from '@umijs/utils';
+import { logger, winPath } from '@umijs/utils';
 // @ts-ignore
 import fg from 'fast-glob';
 import { readFileSync } from 'fs';
@@ -76,17 +76,20 @@ export class AutoUpdateSrcCodeCache {
 
   private async initFileList(): Promise<string[]> {
     const start = Date.now();
-    const files = await fg(join(this.srcPath, '**', '*.{ts,js,jsx,tsx}'), {
-      dot: true,
-      ignore: [
-        '**/*.d.ts',
-        '**/*.test.{js,ts,jsx,tsx}',
-        // fixme respect to environment
-        '**/.umi-production/**',
-        '**/node_modules/**',
-        '**/.git/**',
-      ],
-    });
+    const files = await fg(
+      winPath(join(this.srcPath, '**', '*.{ts,js,jsx,tsx}')),
+      {
+        dot: true,
+        ignore: [
+          '**/*.d.ts',
+          '**/*.test.{js,ts,jsx,tsx}',
+          // fixme respect to environment
+          '**/.umi-production/**',
+          '**/node_modules/**',
+          '**/.git/**',
+        ],
+      },
+    );
     logger.debug('[MFSU][eager] fast-glob costs', Date.now() - start);
 
     return files;

--- a/packages/preset-umi/src/libs/folderCache/AutoUpdateSourceCodeCache.ts
+++ b/packages/preset-umi/src/libs/folderCache/AutoUpdateSourceCodeCache.ts
@@ -44,7 +44,7 @@ export class AutoUpdateSrcCodeCache {
         '**/node_modules/**',
         '**/.git/**',
       ],
-      debouncedTimeout: 500,
+      debouncedTimeout: 200,
       filesLoader: async (files: string[]) => {
         const loaded: Record<string, string> = {};
         await this.batchProcess(files);


### PR DESCRIPTION
1. 修复 eager 模式下 chunkName 不生效的问题（使用 stringLiteral 替换参数，参数的注释就被无意的删除了; 这个场景下直接修改 value 更加合理
2. 默认开启 eager 模式，修复 windows 路径问题
3. 调优文件等待参数
