### PR TITLE
fix(preset-umi): unexpected hidden route chunk from hidden dir

### DIFF
--- a/packages/preset-umi/src/features/tmpFiles/routes.ts
+++ b/packages/preset-umi/src/features/tmpFiles/routes.ts
@@ -276,6 +276,8 @@ export function componentToChunkName(component: string, cwd?: string): string {
         .replace(/[\[\]]/g, '')
         // 插件层的文件也可能是路由组件，比如 plugin-layout 插件
         .replace(/^.umi-production__/, 't__')
+        // 避免产出隐藏文件（比如 .dumi/theme）下的路由组件
+        .replace(/^\./, '')
         .replace(/^pages__/, 'p__')
     : '';
 }


### PR DESCRIPTION
修复从隐藏目录下引入路由组件会产出隐藏 chunk 产物的问题，比如 dumi 的 `.dumi/theme/layouts` 下可能会有路由组件