### PR TITLE
feat(plugins): support antd v5 theme token for antd plugin

### DIFF
--- a/docs/docs/max/antd.md
+++ b/docs/docs/max/antd.md
@@ -19,6 +19,9 @@ export default {
     import: true,
     // less or css, default less
     style: 'less',
+    // shortcut of `configProvider.theme`
+    // use to configure theme token, antd v5 only
+    theme: {},
   },
 };
 ```
@@ -80,6 +83,14 @@ export default {
 - Type: `object`
 
 配置 `antd` 的 `configProvider`。
+
+### theme
+
+- Type: `object`
+
+配置 `antd@5` 的 theme token，等同于配置 `configProvider.theme`，且该配置项拥有更高的优先级。
+
+**注意：该配置项仅 antd v5 可用**
 
 ## FAQ
 

--- a/packages/plugins/src/antd.ts
+++ b/packages/plugins/src/antd.ts
@@ -103,7 +103,8 @@ export default (api: IApi) => {
     };
 
     // allow use `antd.theme` as the shortcut of `antd.configProvider.theme`
-    if (antdVersion.startsWith('5') && antd.theme) {
+    if (antd.theme) {
+      assert(antdVersion.startsWith('5'), `antd.theme is only valid when antd is 5`);
       antd.configProvider ??= {};
       // priority: antd.theme > antd.configProvider.theme
       antd.configProvider.theme = deepmerge(

--- a/packages/plugins/src/antd.ts
+++ b/packages/plugins/src/antd.ts
@@ -103,7 +103,7 @@ export default (api: IApi) => {
     };
 
     // allow use `antd.theme` as the shortcut of `antd.configProvider.theme`
-    if (antd.theme) {
+    if (antdVersion.startsWith('5') && antd.theme) {
       antd.configProvider ??= {};
       // priority: antd.theme > antd.configProvider.theme
       antd.configProvider.theme = Object.assign(

--- a/packages/plugins/src/antd.ts
+++ b/packages/plugins/src/antd.ts
@@ -1,6 +1,6 @@
 import { dirname } from 'path';
 import { IApi } from 'umi';
-import { Mustache } from 'umi/plugin-utils';
+import { Mustache, deepmerge } from 'umi/plugin-utils';
 import { resolveProjectDep } from './utils/resolveProjectDep';
 import { withTmpPath } from './utils/withTmpPath';
 
@@ -106,9 +106,8 @@ export default (api: IApi) => {
     if (antdVersion.startsWith('5') && antd.theme) {
       antd.configProvider ??= {};
       // priority: antd.theme > antd.configProvider.theme
-      antd.configProvider.theme = Object.assign(
-        {},
-        antd.configProvider.theme,
+      antd.configProvider.theme = deepmerge(
+        antd.configProvider.theme || {},
         antd.theme,
       );
     }

--- a/packages/plugins/src/antd.ts
+++ b/packages/plugins/src/antd.ts
@@ -30,6 +30,7 @@ export default (api: IApi) => {
             import: Joi.boolean(),
             // less or css, default less
             style: Joi.string().allow('less', 'css'),
+            theme: Joi.object(),
           }),
           Joi.boolean().invalid(true),
         );
@@ -100,6 +101,17 @@ export default (api: IApi) => {
       'root-entry-name': 'default',
       ...memo.theme,
     };
+
+    // allow use `antd.theme` as the shortcut of `antd.configProvider.theme`
+    if (antd.theme) {
+      antd.configProvider ??= {};
+      // priority: antd.theme > antd.configProvider.theme
+      antd.configProvider.theme = Object.assign(
+        {},
+        antd.configProvider.theme,
+        antd.theme,
+      );
+    }
 
     return memo;
   });


### PR DESCRIPTION
antd 插件支持配置 v5 版本的 theme token

-----
[View rendered docs/docs/max/antd.md](https://github.com/umijs/umi/blob/feature/antd-v5-theme/docs/docs/max/antd.md)