### PR TITLE
fix: example README

### DIFF
--- a/examples/with-request/readme.md
+++ b/examples/with-request/readme.md
@@ -1,3 +1,3 @@
-# with-sass
+# with-request
 
-An example of using [UmiJS](https://umijs.org/zh-CN) with [Sass](https://sass-lang.com/).
+An example of using [UmiJS](https://umijs.org/zh-CN) v4 with request(base on [axios](https://axios-http.com/) and [ahooks v2](https://ahooks-v2.surge.sh/))

--- a/examples/with-request/readme.md
+++ b/examples/with-request/readme.md
@@ -1,3 +1,3 @@
 # with-request
 
-An example of using [UmiJS](https://umijs.org/zh-CN) v4 with request(base on [axios](https://axios-http.com/) and [ahooks v2](https://ahooks-v2.surge.sh/))
+An example of using [UmiJS](https://umijs.org/zh-CN) v4 with request(base on [axios](https://axios-http.com/) and [ahooks v2](https://ahooks-v2.surge.sh/)).


### PR DESCRIPTION
I'm lost when migrate v3 to v4, especially **useRequest**. Helpfully I found the example here.
And I found a small mistake in readme that might mislead newbies

-----
[View rendered examples/with-request/readme.md](https://github.com/wujunyi792/umi/blob/fix-example/examples/with-request/readme.md)