### PR TITLE
feat: conventional overrides.less to override 3rd-party styles

### DIFF
--- a/packages/preset-umi/package.json
+++ b/packages/preset-umi/package.json
@@ -46,6 +46,7 @@
     "html-webpack-plugin": "5.5.0",
     "magic-string": "0.26.2",
     "path-to-regexp": "1.7.0",
+    "postcss-prefix-selector": "1.16.0",
     "react": "18.1.0",
     "react-dom": "18.1.0",
     "react-router": "6.3.0",

--- a/packages/preset-umi/src/features/appData/appData.ts
+++ b/packages/preset-umi/src/features/appData/appData.ts
@@ -7,6 +7,7 @@ import { osLocale } from '../../../compiled/os-locale';
 import { expandCSSPaths, expandJSPaths } from '../../commands/dev/watch';
 import { createResolver, scan } from '../../libs/scan';
 import { IApi } from '../../types';
+import { getOverridesCSS } from '../overrides/overrides';
 import { getApiRoutes, getRoutes } from '../tmpFiles/routes';
 
 export default (api: IApi) => {
@@ -45,9 +46,10 @@ export default (api: IApi) => {
     memo.appJS = await getAppJsInfo();
     memo.locale = await osLocale();
     memo.vite = api.config.vite ? {} : undefined;
-    const { globalCSS, globalJS } = getGlobalFiles();
+    const { globalCSS, globalJS, overridesCSS } = getGlobalFiles();
     memo.globalCSS = globalCSS;
     memo.globalJS = globalJS;
+    memo.overridesCSS = overridesCSS;
 
     const gitDir = findGitDir(api.paths.cwd);
     if (gitDir) {
@@ -88,9 +90,10 @@ export default (api: IApi) => {
     async fn(args: any) {
       if (!args.isFirstTime) {
         api.appData.appJS = await getAppJsInfo();
-        const { globalCSS, globalJS } = getGlobalFiles();
+        const { globalCSS, globalJS, overridesCSS } = getGlobalFiles();
         api.appData.globalCSS = globalCSS;
         api.appData.globalJS = globalJS;
+        api.appData.overridesCSS = overridesCSS;
       }
     },
     stage: Number.NEGATIVE_INFINITY,
@@ -156,9 +159,14 @@ export default (api: IApi) => {
       [],
     );
 
+    const overridesCSS = [getOverridesCSS(api.paths.absSrcPath)].filter(
+      Boolean,
+    ) as string[];
+
     return {
       globalCSS,
       globalJS,
+      overridesCSS,
     };
   }
 };

--- a/packages/preset-umi/src/features/overrides/overrides.ts
+++ b/packages/preset-umi/src/features/overrides/overrides.ts
@@ -1,0 +1,48 @@
+import { winPath } from '@umijs/utils';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { expandCSSPaths } from '../../commands/dev/watch';
+import type { IApi } from '../../types';
+
+export function getOverridesCSS(absSrcPath: string) {
+  return expandCSSPaths(join(absSrcPath, 'overrides')).find(existsSync);
+}
+
+export default (api: IApi) => {
+  api.modifyConfig((memo) => {
+    if (getOverridesCSS(api.paths.absSrcPath)) {
+      memo.extraPostCSSPlugins ??= [];
+      memo.extraPostCSSPlugins.push([
+        // prefix #root for overrides.{ext} style file, to make sure selector priority is higher than async chunk style
+        require('postcss-prefix-selector')({
+          // put a fake prefix because api.config.mountElementId is not available in config stage
+          prefix: '#fake',
+          transform(
+            _p: string,
+            selector: string,
+            _ps: string,
+            filePath: string,
+          ) {
+            const isOverridesFile =
+              winPath(api.appData.overridesCSS[0]) === winPath(filePath);
+
+            if (isOverridesFile && !['html', 'body'].includes(selector)) {
+              // special case for html and body, because they are not in #root
+              if (selector === 'html') {
+                return `html:first-child`;
+              } else if (selector === 'body') {
+                return `* + body`;
+              }
+
+              return `#${api.config.mountElementId} ${selector}`;
+            }
+
+            return selector;
+          },
+        }),
+      ]);
+    }
+
+    return memo;
+  });
+};

--- a/packages/preset-umi/src/features/overrides/overrides.ts
+++ b/packages/preset-umi/src/features/overrides/overrides.ts
@@ -26,7 +26,12 @@ export default (api: IApi) => {
             const isOverridesFile =
               winPath(api.appData.overridesCSS[0]) === winPath(filePath);
 
-            if (isOverridesFile && !['html', 'body'].includes(selector)) {
+            if (
+              isOverridesFile &&
+              !new RegExp(`^#${api.config.mountElementId}([:[\\s]|$)`).test(
+                selector,
+              )
+            ) {
               // special case for html and body, because they are not in #root
               if (selector === 'html') {
                 return `html:first-child`;

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -268,7 +268,12 @@ declare module '*.txt' {
         entryCodeAhead: (
           await api.applyPlugins({
             key: 'addEntryCodeAhead',
-            initialValue: [],
+            // keep same insert position with umi 3, to raise style priority
+            // ref: https://github.com/umijs/umi/blob/73925addfb33eb936aed7a8c3051bfde6adf741b/packages/preset-built-in/src/plugins/features/globalCSS.ts#L25
+            initialValue: [
+              api.appData.globalCSS.length &&
+                `import '${winPath(api.appData.globalCSS[0])}';`,
+            ].filter(Boolean),
           })
         ).join('\n'),
         polyfillImports: importsToStr(
@@ -281,9 +286,6 @@ declare module '*.txt' {
           await api.applyPlugins({
             key: 'addEntryImportsAhead',
             initialValue: [
-              api.appData.globalCSS.length && {
-                source: api.appData.globalCSS[0],
-              },
               api.appData.globalJS.length && {
                 source: api.appData.globalJS[0],
               },

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -295,7 +295,12 @@ declare module '*.txt' {
         imports: importsToStr(
           await api.applyPlugins({
             key: 'addEntryImports',
-            initialValue: [],
+            initialValue: [
+              // append overrides.{ext} style file
+              api.appData.overridesCSS.length && {
+                source: api.appData.overridesCSS[0],
+              },
+            ].filter(Boolean),
           }),
         ).join('\n'),
         basename: api.config.base,

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -268,12 +268,7 @@ declare module '*.txt' {
         entryCodeAhead: (
           await api.applyPlugins({
             key: 'addEntryCodeAhead',
-            // keep same insert position with umi 3, to raise style priority
-            // ref: https://github.com/umijs/umi/blob/73925addfb33eb936aed7a8c3051bfde6adf741b/packages/preset-built-in/src/plugins/features/globalCSS.ts#L25
-            initialValue: [
-              api.appData.globalCSS.length &&
-                `import '${winPath(api.appData.globalCSS[0])}';`,
-            ].filter(Boolean),
+            initialValue: [],
           })
         ).join('\n'),
         polyfillImports: importsToStr(
@@ -286,6 +281,9 @@ declare module '*.txt' {
           await api.applyPlugins({
             key: 'addEntryImportsAhead',
             initialValue: [
+              api.appData.globalCSS.length && {
+                source: api.appData.globalCSS[0],
+              },
               api.appData.globalJS.length && {
                 source: api.appData.globalJS[0],
               },

--- a/packages/preset-umi/src/index.ts
+++ b/packages/preset-umi/src/index.ts
@@ -21,6 +21,7 @@ export default () => {
       require.resolve('./features/favicons/favicons'),
       require.resolve('./features/mock/mock'),
       require.resolve('./features/mpa/mpa'),
+      require.resolve('./features/overrides/overrides'),
       require.resolve('./features/polyfill/polyfill'),
       require.resolve('./features/polyfill/publicPathPolyfill'),
       require.resolve('./features/routePrefetch/routePrefetch'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1378,6 +1378,7 @@ importers:
       multer: 1.4.4
       os-locale: ^6.0.2
       path-to-regexp: 1.7.0
+      postcss-prefix-selector: 1.16.0
       react: 18.1.0
       react-dom: 18.1.0
       react-router: 6.3.0
@@ -1407,6 +1408,7 @@ importers:
       html-webpack-plugin: 5.5.0
       magic-string: 0.26.2
       path-to-regexp: 1.7.0
+      postcss-prefix-selector: 1.16.0
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
       react-router: 6.3.0_react@18.1.0
@@ -12491,8 +12493,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      JSONStream: 1.3.5
       is-text-path: 1.0.1
+      JSONStream: 1.3.5
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -22835,6 +22837,15 @@ packages:
       postcss: 8.4.16
       postcss-value-parser: 4.2.0
     dev: true
+
+  /postcss-prefix-selector/1.16.0:
+    resolution: {integrity: sha512-rdVMIi7Q4B0XbXqNUEI+Z4E+pueiu/CS5E6vRCQommzdQ/sgsS4dK42U7GX8oJR+TJOtT+Qv3GkNo6iijUMp3Q==}
+    peerDependencies:
+      postcss: '>4 <9'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+    dev: false
 
   /postcss-preset-env/7.5.0:
     resolution: {integrity: sha512-0BJzWEfCdTtK2R3EiKKSdkE51/DI/BwnhlnicSW482Ym6/DGHud8K0wGLcdjip1epVX0HKo4c8zzTeV/SkiejQ==}


### PR DESCRIPTION
支持约定式的 `overrides.less`，不同于 `global.less`，它的所有选择器会被自动提升优先级，以确保即便在路由按需、存在异步 css chunk 的情况下，也能达到覆盖样式的效果

close #8326 