### PR TITLE
fix: fix useMatch empty return

### DIFF
--- a/packages/plugins/libs/qiankun/master/getMicroAppRouteComponent.tsx.tpl
+++ b/packages/plugins/libs/qiankun/master/getMicroAppRouteComponent.tsx.tpl
@@ -12,7 +12,7 @@ export function getMicroAppRouteComponent(opts: {
   const { base, masterHistoryType, appName, routeProps, routePath } = opts;
   const RouteComponent = () => {
     const match = useMatch(routePath);
-    const url = match.pathnameBase;
+    const url = match ? match.pathnameBase : '';
     // 默认取静态配置的 base
     let umiConfigBase = base === '/' ? '' : base;
 


### PR DESCRIPTION
<img width="450" alt="image" src="https://user-images.githubusercontent.com/17680888/196900273-a4dfdffd-084e-4068-b086-b851506cd462.png">

`useMatch` might returns 'null' which will cause a crash