### PR TITLE
fix(preset-umi): overrides.less not working for antd dynamic dom

### DIFF
--- a/packages/preset-umi/src/features/overrides/overrides.ts
+++ b/packages/preset-umi/src/features/overrides/overrides.ts
@@ -15,31 +15,28 @@ export default (api: IApi) => {
       memo.extraPostCSSPlugins.push([
         // prefix #root for overrides.{ext} style file, to make sure selector priority is higher than async chunk style
         require('postcss-prefix-selector')({
-          // put a fake prefix because api.config.mountElementId is not available in config stage
-          prefix: '#fake',
+          // why not #root?
+          // antd will insert dom into body, prefix #root will not works for that
+          prefix: 'body',
           transform(
             _p: string,
             selector: string,
-            _ps: string,
+            prefixedSelector: string,
             filePath: string,
           ) {
             const isOverridesFile =
               winPath(api.appData.overridesCSS[0]) === winPath(filePath);
 
-            if (
-              isOverridesFile &&
-              !new RegExp(`^#${api.config.mountElementId}([:[\\s]|$)`).test(
-                selector,
-              )
-            ) {
-              // special case for html and body, because they are not in #root
+            if (isOverridesFile) {
               if (selector === 'html') {
+                // special :first-child to promote html selector priority
                 return `html:first-child`;
-              } else if (selector === 'body') {
-                return `* + body`;
+              } else if (/^body([\s+~>[:]|$)/.test(selector)) {
+                // use + to promote body selector priority
+                return `* + ${selector}`;
               }
 
-              return `#${api.config.mountElementId} ${selector}`;
+              return prefixedSelector;
             }
 
             return selector;


### PR DESCRIPTION
改用 body 提升 overrides.less 里的样式优先级，解决 antd 动态插入到 body 下的 DOM 不受覆盖影响的问题