### PR TITLE
fix(mfsu.eager): 🐛  mfsu.eager  缓存增加 cache dep 字段。

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
 coverage:
   status:
+    patch: off
     project:
       default:
         threshold: 5%


### PR DESCRIPTION
原先以为 alias 和 external 会影响 代码依赖而的扫描结果，就没加。

在查内部 marked external 方式的时候发现，调整 external 不使用 script 的方式后，期望重新构建依赖，但是没有。

参考 mfsu normal 增加 cachedepencies 来修复此缺陷