### PR TITLE
feat(analytics): support ga4

### DIFF
--- a/docs/docs/max/analytics.md
+++ b/docs/docs/max/analytics.md
@@ -10,13 +10,13 @@
 
 ```ts
 {
-	analytics: {
-		ga_v2: 'G-abcdefg', // google analytics 的 key (GA 4)
-		baidu: 'baidu_tongji_key',
+  analytics: {
+    ga_v2: 'G-abcdefg', // google analytics 的 key (GA 4)
+    baidu: 'baidu_tongji_key',
 
     // 若你在使用 GA v1 旧版本，请使用 `ga` 来配置
     ga: 'ga_old_key'
-	}
+  }
 }
 ```
 

--- a/docs/docs/max/analytics.md
+++ b/docs/docs/max/analytics.md
@@ -10,11 +10,16 @@
 
 ```ts
 {
-	analytics:{
-		ga: 'ga_key', // google analytics 的 key
-		baidu: 'baidu_tongji_key'
+	analytics: {
+		ga_v2: 'G-abcdefg', // google analytics 的 key (GA 4)
+		baidu: 'baidu_tongji_key',
+
+    // 若你在使用 GA v1 旧版本，请使用 `ga` 来配置
+    ga: 'ga_old_key'
 	}
 }
 ```
 
-Google Analytics 的 key 也可以通过环境变量 `GA_KEY` 来配置。
+### 环境变量
+
+[Google Analytics 4](https://support.google.com/analytics/answer/10089681) 的 key 也可以通过环境变量 `GA_V2_KEY` 来配置，旧版本为 `GA_KEY` 。

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -45,8 +45,19 @@ export async function getMarkup(
     filters?: string[];
   }) {
     return Object.keys(opts.props)
-      .filter((key) => !(opts.filters || []).includes(key))
-      .map((key) => `${key}=${JSON.stringify(opts.props[key])}`)
+      .filter((key) => {
+        const isValidBoolean = opts.props[key] !== false;
+        return !(opts.filters || []).includes(key) && isValidBoolean;
+      })
+      .map((key) => {
+        const value = opts.props[key];
+        // Although not has value, it will still output `key=""` after cheerio parsed
+        // https://github.com/cheeriojs/cheerio/issues/1032
+        if (value === true) {
+          return `${key}`;
+        }
+        return `${key}=${JSON.stringify(value)}`;
+      })
       .join(' ');
   }
 


### PR DESCRIPTION
 - 支持 GA 4 最新版本谷歌统计。（ resolve #9654 ）

 - 修复输出 html 标签时，值为 `false` 的属性还被输出 （ 如：`async="false"` 本质上还是 `async` ）。  （ fix #9626 ）

-----
[View rendered docs/docs/max/analytics.md](https://github.com/MoeYc/umi/blob/chore/221031/docs/docs/max/analytics.md)