### PR TITLE
feat: allow extraRoutePaths for exportStatic

### DIFF
--- a/docs/docs/api/config.md
+++ b/docs/docs/api/config.md
@@ -473,7 +473,7 @@ export default {
 
 ## exportStatic
 
-- 类型：`{}`
+- 类型：`{ extraRoutePaths: string[] | (() => string[] | Promise<string[]>) }`
 - 默认值：`undefined`
 
 开启该配置后会针对每个路由单独输出 HTML 文件，通常用于静态站点托管。例如项目有如下路由：
@@ -496,6 +496,38 @@ dist/index.html
 dist/index.html
 dist/docs/index.html
 dist/docs/a/index.html
+```
+
+通过 `extraRoutePaths` 子配置项可以产出额外的页面，通常用于动态路由静态化。例如有如下路由：
+
+```bash
+/news/:id
+```
+
+默认情况下只会输出 `dist/news/:id/index.html`，但可以通过配置 `extraRoutePaths` 将其静态化：
+
+```ts
+// .umirc.ts
+export default {
+  exportStatic: {
+    // 配置固定值
+    extraRoutePaths: ['/news/1', '/news/2'],
+    // 也可以配置函数动态获取
+    extraRoutePaths: async () => {
+      const res = await fetch('https://api.example.com/news');
+      const data = await res.json();
+      return data.map((item) => `/news/${item.id}`);
+    },
+  },
+}
+```
+
+此时输出文件会变成：
+
+```bash
+dist/news/:id/index.html
+dist/news/1/index.html
+dist/news/2/index.html
 ```
 
 ## favicons

--- a/packages/preset-umi/src/features/404/404.ts
+++ b/packages/preset-umi/src/features/404/404.ts
@@ -6,6 +6,7 @@ export function patchRoutes(routes: Routes): Routes {
   Object.keys(routes).forEach((key) => {
     if (routes[key].path === '404') {
       routes[key].path = '*';
+      routes[key].absPath = '/*';
     }
   });
   return routes;

--- a/packages/preset-umi/src/features/exportStatic/exportStatic.ts
+++ b/packages/preset-umi/src/features/exportStatic/exportStatic.ts
@@ -27,9 +27,14 @@ function getExportHtmlData(routes: Record<string, IRoute>): IExportHtmlItem[] {
       // skip dynamic route for win, because `:` is not allowed in file name
       (!IS_WIN || !route.path.includes('/:')) &&
       // skip `*` route, because `*` is not working for most site serve services
-      !route.path.includes('*')
+      (!route.path.includes('*') ||
+        // except `404.html`
+        route.absPath === '/*')
     ) {
-      const file = join('.', route.absPath, 'index.html');
+      const file =
+        route.absPath === '/*'
+          ? '404.html'
+          : join('.', route.absPath, 'index.html');
 
       map.set(file, {
         route: {


### PR DESCRIPTION
1. `exportStatic` 支持 `extraRoutePaths` 配置项，值可以是 `string[]` 或返回 `string[]` 的函数
2. 修复约定式 404 的 route 对象里 `absPath` 不正确的问题
3. `exportStatic` 支持将 `/*` 生成 `404.html`，多数静态站点托管服务会约定这个文件作为 404 页面