### PR TITLE
fix(preset-umi): crossorigin config schema field error

### DIFF
--- a/packages/preset-umi/src/features/crossorigin/crossorigin.ts
+++ b/packages/preset-umi/src/features/crossorigin/crossorigin.ts
@@ -12,7 +12,7 @@ export default (api: IApi) => {
         return Joi.alternatives(
           Joi.boolean(),
           Joi.object({
-            include: Joi.array().items(Joi.object().instance(RegExp)),
+            includes: Joi.array().items(Joi.object().instance(RegExp)),
           }),
         );
       },


### PR DESCRIPTION
修复取值跟校验值不一致