### PR TITLE
fix: process.env.APP_ROOT should not be added in config path, it will be included when execuing as cwd

### DIFF
--- a/packages/plugins/src/tailwindcss.ts
+++ b/packages/plugins/src/tailwindcss.ts
@@ -24,7 +24,7 @@ export default (api: IApi) => {
     const generatedPath = join(api.paths.absTmpPath, outputPath);
     const binPath = getTailwindBinPath({ cwd: api.cwd });
     const configPath = join(
-      process.env.APP_ROOT || api.cwd,
+      api.cwd,
       'tailwind.config.js',
     );
 


### PR DESCRIPTION
## issue description

When `APP_ROOT` is used. it should not be added in talwindcss config path, since it will cause duplication of this part when executing, see below:

```
 tailwind = crossSpawn(
        `${binPath}`,
        [
          '-c',
          configPath,
          '-i',
          inputPath,
          '-o',
          generatedPath,
          api.env === 'development' ? '--watch' : '',
        ],
        {
          stdio: 'inherit',
          cwd: process.env.APP_ROOT || api.cwd,
        },
      );
```