### PR TITLE
fix(preset-umi): pre-render failed for 404 page

### DIFF
--- a/packages/preset-umi/src/features/exportStatic/exportStatic.ts
+++ b/packages/preset-umi/src/features/exportStatic/exportStatic.ts
@@ -23,6 +23,8 @@ function getExportHtmlData(routes: Record<string, IRoute>): IExportHtmlItem[] {
   const map = new Map<string, IExportHtmlItem>();
 
   Object.values(routes).forEach((route) => {
+    const is404 = route.absPath === '/*';
+
     if (
       // skip layout
       !route.isLayout &&
@@ -31,16 +33,13 @@ function getExportHtmlData(routes: Record<string, IRoute>): IExportHtmlItem[] {
       // skip `*` route, because `*` is not working for most site serve services
       (!route.path.includes('*') ||
         // except `404.html`
-        route.absPath === '/*')
+        is404)
     ) {
-      const file =
-        route.absPath === '/*'
-          ? '404.html'
-          : join('.', route.absPath, 'index.html');
+      const file = is404 ? '404.html' : join('.', route.absPath, 'index.html');
 
       map.set(file, {
         route: {
-          path: route.absPath,
+          path: is404 ? '/404' : route.absPath,
           redirect: route.redirect,
         },
         file,


### PR DESCRIPTION
修复 404 页面预渲染的时候传入 `/*` 路由，导致路由匹配失败、预渲染结果为空的问题