### PR TITLE
docs(preset-umi,docs): modify metas type httpEquiv to http-equiv

### DIFF
--- a/docs/docs/api/plugin-api.md
+++ b/docs/docs/api/plugin-api.md
@@ -337,7 +337,7 @@ api.addHTMLHeadScripts(() => `console.log('I am in HTML-head')`)
 ```ts
 {
   content?: string,
-  httpEquiv?: string,
+  'http-equiv'?: string,
   name?: string,
   scheme?: string  
 }

--- a/packages/preset-umi/src/types.ts
+++ b/packages/preset-umi/src/types.ts
@@ -56,7 +56,7 @@ export type ILink = Partial<{
 }>;
 export type IMeta = Partial<{
   content: string;
-  httpEquiv: string;
+  'http-equiv': string;
   name: string;
   scheme: string;
 }>;


### PR DESCRIPTION
文档和类型定义都写了 `httpEquiv`。但实际在后面拼接 meta 的时候并没有处理 `httpEquiv` -> `http-equiv`。
如下：

```ts
  api.addHTMLMetas(() => [
    {
      httpEquiv: 'cache-control',
      content: 'no-cache',
    },
    {
      'http-equiv': 'refresh',
      content: '10000',
    },
  ])
```

<img width="429" alt="2022-11-08_19-59-41" src="https://user-images.githubusercontent.com/15888881/200561185-49778dc0-4ffe-452f-82d1-1fe673dce780.png">


-----
[View rendered docs/docs/api/plugin-api.md](https://github.com/simonwong/umi/blob/feature/meta-http-equiv/docs/docs/api/plugin-api.md)