### PR TITLE
refactor(preset-umi): allow modify appjs path

### DIFF
--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -371,14 +371,7 @@ export default function EmptyRoute() {
     // plugin.ts
     const plugins: string[] = await api.applyPlugins({
       key: 'addRuntimePlugin',
-      initialValue: [
-        tryPaths([
-          join(api.paths.absSrcPath, 'app.ts'),
-          join(api.paths.absSrcPath, 'app.tsx'),
-          join(api.paths.absSrcPath, 'app.jsx'),
-          join(api.paths.absSrcPath, 'app.js'),
-        ]),
-      ].filter(Boolean),
+      initialValue: [api.appData.appJS?.path].filter(Boolean),
     });
     const validKeys = await api.applyPlugins({
       key: 'addRuntimePluginKey',

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -1,4 +1,4 @@
-import { lodash, tryPaths, winPath } from '@umijs/utils';
+import { lodash, winPath } from '@umijs/utils';
 import { existsSync, readdirSync } from 'fs';
 import { basename, dirname, join } from 'path';
 import { RUNTIME_TYPE_FILE_NAME } from 'umi';


### PR DESCRIPTION
使用 appData 上的 appJS 路径而不是单独获取，这样可以允许插件修改 appJS 的路径