### PR TITLE
feat(preset-umi): react ssr support helmet tags

### DIFF
--- a/docs/docs/api/api.md
+++ b/docs/docs/api/api.md
@@ -92,6 +92,24 @@ generatePath("/files/:type/*", {
 }); // "/files/img/cat.jpg"
 ```
 
+### Helmet
+
+即 [react-helmet-async](https://github.com/staylor/react-helmet-async) 提供的 Helmet 组件，用于在页面中动态配置 `head` 中的标签，例如 `title`。
+
+> 注意：为了确保 SSR 时 Helmet 仍能正常工作，请务必使用 Umi 提供的 Helmet 而不是单独安装 react-helmet
+
+```tsx
+import { Helmet } from 'umi';
+
+export default function Page() {
+  return (
+    <Helmet>
+      <title>Hello World</title>
+    </Helmet>
+  );
+}
+```
+
 ### history
 
 和 history 相关的操作，用于获取当前路由信息、执行路由跳转、监听路由变更。

--- a/packages/preset-umi/templates/server.tpl
+++ b/packages/preset-umi/templates/server.tpl
@@ -1,4 +1,4 @@
-import { getClientRootComponent } from '{{{ serverRendererPath }}}';
+import { getClientRootComponent, getHelmetContext } from '{{{ serverRendererPath }}}';
 import { getRoutes } from './core/route';
 import { createHistory as createClientHistory } from './core/history';
 import { getPlugins as getClientPlugins } from './core/plugin';
@@ -42,6 +42,7 @@ const createOpts = {
   getRoutes,
   manifest,
   getClientRootComponent,
+  helmetContext: getHelmetContext(),
   createHistory,
 };
 const requestHandler = createRequestHandler(createOpts);

--- a/packages/renderer-react/package.json
+++ b/packages/renderer-react/package.json
@@ -25,6 +25,7 @@
     "@babel/runtime": "7.18.9",
     "@loadable/component": "5.15.2",
     "history": "5.3.0",
+    "react-helmet-async": "1.3.0",
     "react-router-dom": "6.3.0"
   },
   "devDependencies": {

--- a/packages/renderer-react/src/index.ts
+++ b/packages/renderer-react/src/index.ts
@@ -23,6 +23,7 @@ export {
   useRoutes,
   useSearchParams,
 } from 'react-router-dom';
+export { Helmet } from 'react-helmet-async';
 export {
   useAppData,
   useClientLoaderData,

--- a/packages/renderer-react/src/server.tsx
+++ b/packages/renderer-react/src/server.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
+import { HelmetProvider } from 'react-helmet-async';
 import { StaticRouter } from 'react-router-dom/server';
 import { AppContext } from './appContext';
 import { Routes } from './browser';
 import { createClientRoutes } from './routes';
 import { IRouteComponents, IRoutesById } from './types';
+
+// store helmet data
+const helmetContext = {};
+
+// get helmet context
+export function getHelmetContext() {
+  return helmetContext;
+}
 
 // Get the root React component for ReactDOMServer.renderToString
 export async function getClientRootComponent(opts: {
@@ -43,19 +52,21 @@ export async function getClientRootComponent(opts: {
   }
   return (
     <Html loaderData={opts.loaderData} manifest={opts.manifest}>
-      <AppContext.Provider
-        value={{
-          routes: opts.routes,
-          routeComponents: opts.routeComponents,
-          clientRoutes,
-          pluginManager: opts.pluginManager,
-          basename,
-          clientLoaderData: {},
-          serverLoaderData: opts.loaderData,
-        }}
-      >
-        {rootContainer}
-      </AppContext.Provider>
+      <HelmetProvider context={helmetContext}>
+        <AppContext.Provider
+          value={{
+            routes: opts.routes,
+            routeComponents: opts.routeComponents,
+            clientRoutes,
+            pluginManager: opts.pluginManager,
+            basename,
+            clientLoaderData: {},
+            serverLoaderData: opts.loaderData,
+          }}
+        >
+          {rootContainer}
+        </AppContext.Provider>
+      </HelmetProvider>
     </Html>
   );
 }

--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -18,6 +18,7 @@ interface CreateRequestHandlerOptions {
   getValidKeys: () => any;
   getRoutes: (PluginManager: any) => any;
   getClientRootComponent: (PluginManager: any) => any;
+  helmetContext: any;
   createHistory: (opts: any) => any;
 }
 
@@ -103,7 +104,24 @@ export function createMarkupGenerator(opts: CreateRequestHandlerOptions) {
           next();
         };
         writable.on('finish', () => {
-          resolve(Buffer.concat(chunks).toString('utf8'));
+          let html = Buffer.concat(chunks).toString('utf8');
+
+          // append helmet tags to head
+          html = html.replace(
+            /(<\/head>)/,
+            [
+              opts.helmetContext.helmet.title.toString(),
+              opts.helmetContext.helmet.priority.toString(),
+              opts.helmetContext.helmet.meta.toString(),
+              opts.helmetContext.helmet.link.toString(),
+              opts.helmetContext.helmet.script.toString(),
+              '$1',
+            ]
+              .filter(Boolean)
+              .join('/n'),
+          );
+
+          resolve(html);
         });
 
         // why not use `renderToStaticMarkup` or `renderToString`?

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1295,7 +1295,7 @@ importers:
       mini-css-extract-plugin: 2.6.0_webpack@5.72.1
       postcss-flexbugs-fixes: 5.0.2_postcss@8.4.14
       postcss-loader: 6.2.1_xvg4ntyrrwt57qzvggqcbeozu4
-      purgecss-webpack-plugin: 4.1.3_webpack@5.72.1
+      purgecss-webpack-plugin: 4.1.3_@swc+core@1.2.165
       sass-loader: 12.6.0_webpack@5.72.1
       schema-utils: 4.0.0
       speed-measure-webpack-plugin: 1.5.0_webpack@5.72.1
@@ -1614,11 +1614,13 @@ importers:
       history: 5.3.0
       react: 18.1.0
       react-dom: 18.1.0
+      react-helmet-async: 1.3.0
       react-router-dom: 6.3.0
     dependencies:
       '@babel/runtime': 7.18.9
       '@loadable/component': 5.15.2_react@18.1.0
       history: 5.3.0
+      react-helmet-async: 1.3.0_ef5jwxihqo6n7gxfmzogljlgcm
       react-router-dom: 6.3.0_ef5jwxihqo6n7gxfmzogljlgcm
     devDependencies:
       react: 18.1.0
@@ -4270,7 +4272,6 @@ packages:
   /@babel/compat-data/7.18.8:
     resolution: {integrity: sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/compat-data/7.19.0:
     resolution: {integrity: sha512-y5rqgTTPTmaF5e2nVhOxw+Ur9HDJLsWb6U/KpgUzRZEdPfE6VOubXBKLdbcUTijzRptednSBDQbYZBOSqJxpJw==}
@@ -4471,6 +4472,18 @@ packages:
       '@babel/types': 7.19.0
     dev: true
 
+  /@babel/helper-compilation-targets/7.18.9:
+    resolution: {integrity: sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/compat-data': 7.18.8
+      '@babel/helper-validator-option': 7.18.6
+      browserslist: 4.21.2
+      semver: 6.3.0
+    dev: false
+
   /@babel/helper-compilation-targets/7.18.9_@babel+core@7.18.9:
     resolution: {integrity: sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==}
     engines: {node: '>=6.9.0'}
@@ -4509,18 +4522,6 @@ packages:
       browserslist: 4.21.2
       semver: 6.3.0
     dev: true
-
-  /@babel/helper-compilation-targets/7.19.0:
-    resolution: {integrity: sha512-Ai5bNWXIvwDvWM7njqsG3feMlL9hCVQsPYXodsZyLwshYkZVJt59Gftau4VrE8S9IT9asd2uSP1hG6wCNw+sXA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/compat-data': 7.19.0
-      '@babel/helper-validator-option': 7.18.6
-      browserslist: 4.21.3
-      semver: 6.3.0
-    dev: false
 
   /@babel/helper-compilation-targets/7.19.0_@babel+core@7.17.9:
     resolution: {integrity: sha512-Ai5bNWXIvwDvWM7njqsG3feMlL9hCVQsPYXodsZyLwshYkZVJt59Gftau4VrE8S9IT9asd2uSP1hG6wCNw+sXA==}
@@ -4668,7 +4669,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0-0
     dependencies:
-      '@babel/helper-compilation-targets': 7.19.0
+      '@babel/helper-compilation-targets': 7.18.9
       '@babel/helper-plugin-utils': 7.18.9
       debug: 4.3.4
       lodash.debounce: 4.0.8
@@ -6825,7 +6826,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/helper-module-transforms': 7.19.0
+      '@babel/helper-module-transforms': 7.18.9
       '@babel/helper-plugin-utils': 7.18.9
       '@babel/helper-simple-access': 7.18.6
       babel-plugin-dynamic-import-node: 2.3.3
@@ -16055,7 +16056,7 @@ packages:
   /axios/0.27.2_debug@4.3.4:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
-      follow-redirects: 1.15.1_debug@4.3.4
+      follow-redirects: 1.15.1
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
@@ -16252,7 +16253,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.19.0
+      '@babel/compat-data': 7.18.8
       '@babel/helper-define-polyfill-provider': 0.3.2
       semver: 6.3.0
     transitivePeerDependencies:
@@ -21980,18 +21981,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-
-  /follow-redirects/1.15.1_debug@4.3.4:
-    resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dependencies:
-      debug: 4.3.4
-    dev: true
 
   /for-each/0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -31070,17 +31059,20 @@ packages:
       - utf-8-validate
     dev: true
 
-  /purgecss-webpack-plugin/4.1.3_webpack@5.72.1:
+  /purgecss-webpack-plugin/4.1.3_@swc+core@1.2.165:
     resolution: {integrity: sha512-1OHS0WE935w66FjaFSlV06ycmn3/A8a6Q+iVUmmCYAujQ1HPdX+psMXUhASEW0uF1PYEpOlhMc5ApigVqYK08g==}
-    peerDependencies:
-      webpack: '*'
     peerDependenciesMeta:
       webpack:
         optional: true
     dependencies:
       purgecss: 4.1.3
-      webpack: 5.72.1_@swc+core@1.2.165
+      webpack: 5.74.0_@swc+core@1.2.165
       webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+      - webpack-cli
     dev: true
 
   /purgecss/4.1.3:
@@ -34272,14 +34264,6 @@ packages:
   /react-dev-utils/12.0.1_3rubbgt5ekhqrcgx4uwls3neim:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
-    peerDependencies:
-      typescript: '>=2.7'
-      webpack: '>=4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      webpack:
-        optional: true
     dependencies:
       '@babel/code-frame': 7.18.6
       address: 1.1.2
@@ -34309,7 +34293,9 @@ packages:
     transitivePeerDependencies:
       - eslint
       - supports-color
+      - typescript
       - vue-template-compiler
+      - webpack
     dev: false
 
   /react-devtools-inline/4.4.0:
@@ -34378,6 +34364,26 @@ packages:
     dependencies:
       create-react-class: 15.7.0
       prop-types: 15.8.1
+    dev: false
+
+  /react-helmet-async/1.3.0_ef5jwxihqo6n7gxfmzogljlgcm:
+    resolution: {integrity: sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==}
+    peerDependencies:
+      react: ^16.6.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.6.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.18.9
+      invariant: 2.2.4
+      prop-types: 15.8.1
+      react: 18.1.0
+      react-dom: 18.1.0_react@18.1.0
+      react-fast-compare: 3.2.0
+      shallowequal: 1.1.0
     dev: false
 
   /react-helmet-async/1.3.0_sfoxds7t5ydpegc3knd667wn6m:
@@ -37646,6 +37652,33 @@ packages:
       webpack: 5.74.0_xdjijeb6bgyaxqcwazk6btvxwi
     dev: true
 
+  /terser-webpack-plugin/5.3.6_ti3dfendm45sbfjxbpdoqc2qwy:
+    resolution: {integrity: sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+      webpack:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.15
+      '@swc/core': 1.2.165
+      jest-worker: 27.5.1
+      schema-utils: 3.1.1
+      serialize-javascript: 6.0.0
+      terser: 5.14.2
+      webpack: 5.74.0_@swc+core@1.2.165
+    dev: true
+
   /terser-webpack-plugin/5.3.6_webpack@5.72.1:
     resolution: {integrity: sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==}
     engines: {node: '>= 10.13.0'}
@@ -39765,6 +39798,46 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  /webpack/5.74.0_@swc+core@1.2.165:
+    resolution: {integrity: sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/eslint-scope': 3.7.4
+      '@types/estree': 0.0.51
+      '@webassemblyjs/ast': 1.11.1
+      '@webassemblyjs/wasm-edit': 1.11.1
+      '@webassemblyjs/wasm-parser': 1.11.1
+      acorn: 8.7.1
+      acorn-import-assertions: 1.8.0_acorn@8.7.1
+      browserslist: 4.21.2
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.10.0
+      es-module-lexer: 0.9.3
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.10
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.1.1
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.6_ti3dfendm45sbfjxbpdoqc2qwy
+      watchpack: 2.4.0
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    dev: true
 
   /webpack/5.74.0_xdjijeb6bgyaxqcwazk6btvxwi:
     resolution: {integrity: sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==}


### PR DESCRIPTION
react ssr 支持渲染 helmet 添加的标签，比如用于 tdk 生成，关键变更：
1. renderer-react 内置 `react-helmet-async`、以兼容 react@18 流式渲染，导出 `Helmet` 给页面使用
2. ssr 阶段自动收集 helmetContext 里的数据、转换成 `head` 下的标签内容（比如 title、meta 等），实现 helmet 的 ssr 支持