### PR TITLE
docs: Modify the spelling of useAcces

### DIFF
--- a/docs/docs/max/access.md
+++ b/docs/docs/max/access.md
@@ -104,7 +104,7 @@ export default PageA;
 
 - Type: `boolean`
 
-是否有权限，通常通过 `useAcces` 获取后传入进来。
+是否有权限，通常通过 `useAccess` 获取后传入进来。
 
 #### fallback
 


### PR DESCRIPTION
modify `useAcces` to `useAccess`

-----
[View rendered docs/docs/max/access.md](https://github.com/learnsomesome/umi/blob/patch-1/docs/docs/max/access.md)