### PR TITLE
fix(renderer-react): client render failed when use builtin helmet

### DIFF
--- a/packages/renderer-react/src/browser.tsx
+++ b/packages/renderer-react/src/browser.tsx
@@ -1,6 +1,7 @@
 import { History } from 'history';
 import React, { useCallback, useEffect, useState } from 'react';
 // compatible with < react@18 in @umijs/preset-umi/src/features/react
+import { HelmetProvider } from 'react-helmet-async';
 import ReactDOM from 'react-dom/client';
 import { matchRoutes, Router, useRoutes } from 'react-router-dom';
 import { AppContext, useAppData } from './appContext';
@@ -209,22 +210,24 @@ export function renderClient(opts: {
     }, []);
 
     return (
-      <AppContext.Provider
-        value={{
-          routes: opts.routes,
-          routeComponents: opts.routeComponents,
-          clientRoutes,
-          pluginManager: opts.pluginManager,
-          rootElement: opts.rootElement!,
-          basename,
-          clientLoaderData,
-          serverLoaderData,
-          preloadRoute: handleRouteChange,
-          history: opts.history,
-        }}
-      >
-        {rootContainer}
-      </AppContext.Provider>
+      <HelmetProvider context={{}}>
+        <AppContext.Provider
+          value={{
+            routes: opts.routes,
+            routeComponents: opts.routeComponents,
+            clientRoutes,
+            pluginManager: opts.pluginManager,
+            rootElement: opts.rootElement!,
+            basename,
+            clientLoaderData,
+            serverLoaderData,
+            preloadRoute: handleRouteChange,
+            history: opts.history,
+          }}
+        >
+          {rootContainer}
+        </AppContext.Provider>
+      </HelmetProvider>
     );
   };
 


### PR DESCRIPTION
修复使用了内置的 `Helmet`、导致 client 渲染失败的问题