### PR TITLE
refactor(preset-umi): discard file field for client routes

### DIFF
--- a/packages/preset-umi/src/features/tmpFiles/routes.test.ts
+++ b/packages/preset-umi/src/features/tmpFiles/routes.test.ts
@@ -57,7 +57,7 @@ test('getRoutes', async () => {
   expect(routes[1].parentId).toBe(undefined);
 
   // @@/global-layout
-  expect(routes['@@/global-layout'].file).toBe('@/layouts/index.tsx');
+  expect(routes['@@/global-layout'].file).toContain('layouts/index.tsx');
   expect(routes['@@/global-layout'].parentId).toBe(undefined);
   expect(routes['@@/global-layout'].isLayout).toBe(true);
 

--- a/packages/preset-umi/src/features/tmpFiles/routes.test.ts
+++ b/packages/preset-umi/src/features/tmpFiles/routes.test.ts
@@ -78,6 +78,9 @@ test('getRoutes', async () => {
     delete routes[id].__absFile;
   });
 
+  // 覆写 layout 的绝对路径地址，用于保持快照稳定
+  routes['@@/global-layout'].file = '@/layouts/index.tsx';
+
   expect(routes).toMatchSnapshot();
 });
 

--- a/packages/preset-umi/src/features/tmpFiles/routes.ts
+++ b/packages/preset-umi/src/features/tmpFiles/routes.ts
@@ -128,8 +128,6 @@ export async function getRoutes(opts: {
   }
 
   // layout routes
-  const absSrcPath = opts.api.paths.absSrcPath;
-
   const absLayoutPath = tryPaths([
     join(opts.api.paths.absSrcPath, 'layouts/index.tsx'),
     join(opts.api.paths.absSrcPath, 'layouts/index.vue'),

--- a/packages/preset-umi/src/features/tmpFiles/routes.ts
+++ b/packages/preset-umi/src/features/tmpFiles/routes.ts
@@ -137,26 +137,17 @@ export async function getRoutes(opts: {
     join(opts.api.paths.absSrcPath, 'layouts/index.js'),
   ]);
 
-  const layouts = (
-    await opts.api.applyPlugins({
-      key: 'addLayouts',
-      initialValue: [
-        absLayoutPath && {
-          id: '@@/global-layout',
-          file: winPath(absLayoutPath),
-          test(route: any) {
-            return route.layout !== false;
-          },
+  const layouts = await opts.api.applyPlugins({
+    key: 'addLayouts',
+    initialValue: [
+      absLayoutPath && {
+        id: '@@/global-layout',
+        file: winPath(absLayoutPath),
+        test(route: any) {
+          return route.layout !== false;
         },
-      ].filter(Boolean),
-    })
-  ).map((layout: { file: string }) => {
-    // prune local path prefix, avoid mix in outputs
-    layout.file = layout.file.replace(
-      new RegExp(`^${winPath(absSrcPath)}`),
-      '@',
-    );
-    return layout;
+      },
+    ].filter(Boolean),
   });
   for (const layout of layouts) {
     addParentRoute({

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -348,8 +348,8 @@ export default function EmptyRoute() {
     for (const id of Object.keys(clonedRoutes)) {
       for (const key of Object.keys(clonedRoutes[id])) {
         const route = clonedRoutes[id];
-        // Remove __ prefix props and absPath props
-        if (key.startsWith('__') || key.startsWith('absPath')) {
+        // Remove __ prefix props, absPath props and file props
+        if (key.startsWith('__') || ['absPath', 'file'].includes(key)) {
           delete route[key];
         }
       }


### PR DESCRIPTION
1. 移除 `code/route.ts` 中 `routes` 对象里的 `file` 字段，避免磁盘路径被打进产物
2. 移除原来处理 `api.addLayouts` 里 `file` 字段的逻辑