### PR TITLE
fix: 🐛 mfsu 依赖构建不使用 CopyPlugin

### DIFF
--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -55,7 +55,7 @@ export interface IOpts {
     cacheDirectory?: string;
   };
   pkg?: Record<string, any>;
-  copy?: boolean;
+  disableCopy?: boolean;
 }
 
 export async function getConfig(opts: IOpts): Promise<Configuration> {
@@ -188,7 +188,7 @@ export async function getConfig(opts: IOpts): Promise<Configuration> {
   // fork-ts-checker
   await addForkTSCheckerPlugin(applyOpts);
   // copy
-  if (opts.copy !== false) {
+  if (!opts.disableCopy) {
     await addCopyPlugin(applyOpts);
   }
   // manifest

--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -55,6 +55,7 @@ export interface IOpts {
     cacheDirectory?: string;
   };
   pkg?: Record<string, any>;
+  copy?: boolean;
 }
 
 export async function getConfig(opts: IOpts): Promise<Configuration> {
@@ -187,7 +188,9 @@ export async function getConfig(opts: IOpts): Promise<Configuration> {
   // fork-ts-checker
   await addForkTSCheckerPlugin(applyOpts);
   // copy
-  await addCopyPlugin(applyOpts);
+  if (opts.copy !== false) {
+    await addCopyPlugin(applyOpts);
+  }
   // manifest
   await addManifestPlugin(applyOpts);
   // hmr

--- a/packages/bundler-webpack/src/dev.ts
+++ b/packages/bundler-webpack/src/dev.ts
@@ -135,6 +135,7 @@ export async function dev(opts: IOpts) {
     env: Env.development,
     entry: opts.entry,
     userConfig: opts.config,
+    copy: false,
     hash: true,
     staticPathPrefix: MF_DEP_PREFIX,
     name: MFSU_NAME,

--- a/packages/bundler-webpack/src/dev.ts
+++ b/packages/bundler-webpack/src/dev.ts
@@ -135,7 +135,7 @@ export async function dev(opts: IOpts) {
     env: Env.development,
     entry: opts.entry,
     userConfig: opts.config,
-    copy: false,
+    disableCopy: true,
     hash: true,
     staticPathPrefix: MF_DEP_PREFIX,
     name: MFSU_NAME,


### PR DESCRIPTION
why:

1. 源码依赖构建已经 serve 了public 下的静态资源，依赖构建就不需要重复 copy 了。
2. 避免新增 mfsu 的[中间件](https://github.com/umijs/umi/blob/bc95b76bac0b8b42e67f723509e25304d3541266/packages/mfsu/src/mfsu/mfsu.ts#L354-L356)兜底 serve  node_modules/.cache/mfsu/时， 拦截了 devServer 的 serve 和 其他 middleware。