### PR TITLE
fix: history is undefined on render

### DIFF
--- a/packages/preset-umi/templates/umi.tpl
+++ b/packages/preset-umi/templates/umi.tpl
@@ -27,16 +27,25 @@ async function render() {
     },
   });
 
+  const contextOpts = pluginManager.applyPlugins({
+    key: 'modifyContextOpts',
+    type: ApplyPluginsType.modify,
+    initialValue: {},
+  });
+
+  const basename = contextOpts.basename || '{{{ basename }}}';
+
+  const history = createHistory({
+    type: contextOpts.historyType || '{{{ historyType }}}',
+    basename,
+    ...contextOpts.historyOpts,
+  });
+
   return (pluginManager.applyPlugins({
     key: 'render',
     type: ApplyPluginsType.compose,
     initialValue() {
-      const contextOpts = pluginManager.applyPlugins({
-        key: 'modifyContextOpts',
-        type: ApplyPluginsType.modify,
-        initialValue: {},
-      });
-      const basename = contextOpts.basename || '{{{ basename }}}';
+      
       const context = {
 {{#hydrate}}
         hydrate: true,
@@ -53,11 +62,7 @@ async function render() {
 {{/loadingComponent}}
         publicPath,
         runtimePublicPath,
-        history: createHistory({
-          type: contextOpts.historyType || '{{{ historyType }}}',
-          basename,
-          ...contextOpts.historyOpts,
-        }),
+        history,
         basename,
       };
       return renderClient(context);


### PR DESCRIPTION
Close #9761

app.ts

```
import { history } from 'umi'
export function render(oldRender: any) {
  console.log('history',history);
  oldRender();
}

```

## before

undefined

## after

{createHref: ƒ, push: ƒ, replace: ƒ, …}

![image](https://user-images.githubusercontent.com/11746742/201565460-2572be39-19e5-4a2d-8614-c2ad1b851340.png)
