### PR TITLE
fix(preset-umi): helmet head lost after ssr

### DIFF
--- a/packages/preset-umi/src/features/exportStatic/exportStatic.ts
+++ b/packages/preset-umi/src/features/exportStatic/exportStatic.ts
@@ -58,10 +58,16 @@ async function getPreRenderedHTML(api: IApi, htmlTpl: string, path: string) {
 
   try {
     const markup = await markupRender(path);
-    const [mainTpl, extraTpl] = markup.split('</html>');
+    const [mainTpl, extraTpl = ''] = markup.split('</html>');
+    // TODO: improve return type for markup generator
+    const helmetContent = mainTpl.match(
+      /<head>[^]*?(<[^>]+data-rh[^]+)<\/head>/,
+    )?.[1];
     const bodyContent = mainTpl.match(/<body[^>]*>([^]+?)<\/body>/)?.[1];
 
     htmlTpl = htmlTpl
+      // append helmet content
+      .replace('</head>', `${helmetContent}</head>`)
       // replace #root with pre-rendered body content
       .replace(
         new RegExp(`<div id="${api.config.mountElementId}"[^>]*>.*?</div>`),


### PR DESCRIPTION
修复 Helmet head 标签在 SSR 下丢失的问题

后续优化：把 markupGenerator 的返回值做拓展，正则匹配不稳定