### PR TITLE
fix: 🐛 mfsu resovle in monorepo

### DIFF
--- a/packages/mfsu/src/dep/dep.ts
+++ b/packages/mfsu/src/dep/dep.ts
@@ -2,7 +2,7 @@ import { pkgUp, winPath, logger, chalk } from '@umijs/utils';
 import assert from 'assert';
 import enhancedResolve from 'enhanced-resolve';
 import { readFileSync } from 'fs';
-import { isAbsolute, join } from 'path';
+import { isAbsolute, join, dirname } from 'path';
 import { MF_VA_PREFIX } from '../constants';
 import { MFSU } from '../mfsu/mfsu';
 import { trimFileContent } from '../utils/trimFileContent';
@@ -23,6 +23,20 @@ async function resolve(context: string, path: string): Promise<string> {
   });
 }
 
+async function resolveFromContexts(
+  contexts: string[],
+  path: string,
+): Promise<string> {
+  for (const context of contexts) {
+    try {
+      return await resolve(context, path);
+    } catch (e) {
+      // ignore
+    }
+  }
+  throw new Error(`Can't resolve ${path} from ${contexts.join(', ')}`);
+}
+
 export class Dep {
   public file: string;
   public version: string;
@@ -31,12 +45,14 @@ export class Dep {
   public normalizedFile: string;
   public filePath: string;
   public excludeNodeNatives: boolean;
+  public importer: string | undefined;
 
   constructor(opts: {
     file: string;
     version: string;
     cwd: string;
     excludeNodeNatives: boolean;
+    importer?: string;
   }) {
     this.file = winPath(opts.file);
     this.version = opts.version;
@@ -45,6 +61,7 @@ export class Dep {
     this.normalizedFile = this.shortFile.replace(/\//g, '_').replace(/:/g, '_');
     this.filePath = `${MF_VA_PREFIX}${this.normalizedFile}.js`;
     this.excludeNodeNatives = opts.excludeNodeNatives!;
+    this.importer = opts.importer;
   }
 
   async buildExposeContent() {
@@ -87,16 +104,21 @@ export * from '${this.file}';
 
   async getRealFile() {
     try {
+      const contexts = [this.cwd];
+      if (this.importer) {
+        contexts.push(dirname(this.importer));
+      }
+
       // don't need to handle alias here
       // it's already handled by babel plugin
-      return await resolve(this.cwd, this.file);
+      return await resolveFromContexts(contexts, this.file);
     } catch (e) {
       return null;
     }
   }
 
   static buildDeps(opts: {
-    deps: Record<string, { file: string; version: string }>;
+    deps: Record<string, { file: string; version: string; importer?: string }>;
     cwd: string;
     mfsu: MFSU;
   }) {

--- a/packages/mfsu/src/dep/dep.ts
+++ b/packages/mfsu/src/dep/dep.ts
@@ -13,6 +13,7 @@ const resolver = enhancedResolve.create({
   extensions: ['.wasm', '.mjs', '.js', '.jsx', '.ts', '.tsx', '.json'],
   exportsFields: ['exports'],
   conditionNames: ['import', 'module', 'require', 'node'],
+  symlinks: false,
 });
 
 async function resolve(context: string, path: string): Promise<string> {

--- a/packages/mfsu/src/dep/getExposeFromContent.ts
+++ b/packages/mfsu/src/dep/getExposeFromContent.ts
@@ -13,7 +13,7 @@ export async function getExposeFromContent(opts: {
     opts.filePath &&
     /\.(css|less|scss|sass|stylus|styl)$/.test(opts.filePath)
   ) {
-    return `import '${opts.dep.file}';`;
+    return `import '${opts.filePath}';`;
   }
 
   // Support Assets Files
@@ -24,7 +24,7 @@ export async function getExposeFromContent(opts: {
     )
   ) {
     return `
-import _ from '${opts.dep.file}';
+import _ from '${opts.filePath}';
 export default _;`.trim();
   }
 
@@ -39,9 +39,9 @@ export default _;`.trim();
   // cjs
   if (isCJS) {
     return [
-      `import _ from '${opts.dep.file}';`,
+      `import _ from '${opts.filePath}';`,
       `export default _;`,
-      `export * from '${opts.dep.file}';`,
+      `export * from '${opts.filePath}';`,
     ].join('\n');
   }
   // esm
@@ -49,7 +49,7 @@ export default _;`.trim();
     const ret = [];
     let hasExports = false;
     if (exports.includes('default')) {
-      ret.push(`import _ from '${opts.dep.file}';`);
+      ret.push(`import _ from '${opts.filePath}';`);
       ret.push(`export default _;`);
       hasExports = true;
     }
@@ -60,18 +60,18 @@ export default _;`.trim();
       //       export * from '.'
       /export\s*\*\s*from/.test(opts.content)
     ) {
-      ret.push(`export * from '${opts.dep.file}';`);
+      ret.push(`export * from '${opts.filePath}';`);
       hasExports = true;
     }
 
     if (!hasExports) {
       // 只有 __esModule 的全量导出
       if (exports.includes('__esModule')) {
-        ret.push(`import _ from '${opts.dep.file}';`);
+        ret.push(`import _ from '${opts.filePath}';`);
         ret.push(`export default _;`);
-        ret.push(`export * from '${opts.dep.file}';`);
+        ret.push(`export * from '${opts.filePath}';`);
       } else {
-        ret.push(`import '${opts.dep.file}';`);
+        ret.push(`import '${opts.filePath}';`);
       }
     }
 

--- a/packages/mfsu/src/dep/getExposeFromContent.ts
+++ b/packages/mfsu/src/dep/getExposeFromContent.ts
@@ -2,12 +2,15 @@ import assert from 'assert';
 import { basename } from 'path';
 import { Dep } from './dep';
 import { getModuleExports } from './getModuleExports';
+import { winPath } from '@umijs/utils';
 
 export async function getExposeFromContent(opts: {
   dep: Dep;
   filePath: string;
   content: string;
 }) {
+  const importPath = winPath(opts.filePath);
+
   // Support CSS
   if (
     opts.filePath &&
@@ -24,7 +27,7 @@ export async function getExposeFromContent(opts: {
     )
   ) {
     return `
-import _ from '${opts.filePath}';
+import _ from '${importPath}';
 export default _;`.trim();
   }
 
@@ -39,9 +42,9 @@ export default _;`.trim();
   // cjs
   if (isCJS) {
     return [
-      `import _ from '${opts.filePath}';`,
+      `import _ from '${importPath}';`,
       `export default _;`,
-      `export * from '${opts.filePath}';`,
+      `export * from '${importPath}';`,
     ].join('\n');
   }
   // esm
@@ -49,7 +52,7 @@ export default _;`.trim();
     const ret = [];
     let hasExports = false;
     if (exports.includes('default')) {
-      ret.push(`import _ from '${opts.filePath}';`);
+      ret.push(`import _ from '${importPath}';`);
       ret.push(`export default _;`);
       hasExports = true;
     }
@@ -60,18 +63,18 @@ export default _;`.trim();
       //       export * from '.'
       /export\s*\*\s*from/.test(opts.content)
     ) {
-      ret.push(`export * from '${opts.filePath}';`);
+      ret.push(`export * from '${importPath}';`);
       hasExports = true;
     }
 
     if (!hasExports) {
       // 只有 __esModule 的全量导出
       if (exports.includes('__esModule')) {
-        ret.push(`import _ from '${opts.filePath}';`);
+        ret.push(`import _ from '${importPath}';`);
         ret.push(`export default _;`);
-        ret.push(`export * from '${opts.filePath}';`);
+        ret.push(`export * from '${importPath}';`);
       } else {
-        ret.push(`import '${opts.filePath}';`);
+        ret.push(`import '${importPath}';`);
       }
     }
 

--- a/packages/mfsu/src/dep/getExposeFromContent.ts
+++ b/packages/mfsu/src/dep/getExposeFromContent.ts
@@ -16,7 +16,7 @@ export async function getExposeFromContent(opts: {
     opts.filePath &&
     /\.(css|less|scss|sass|stylus|styl)$/.test(opts.filePath)
   ) {
-    return `import '${opts.filePath}';`;
+    return `import '${importPath}';`;
   }
 
   // Support Assets Files

--- a/packages/mfsu/src/depInfo.ts
+++ b/packages/mfsu/src/depInfo.ts
@@ -11,6 +11,8 @@ interface IOpts {
 export type DepModule = {
   file: string;
   version: string;
+  // 如果 importer 不存在, 需要保证 file 可以从 cwd 解析到
+  importer?: string;
 };
 
 export interface IDepInfo {

--- a/packages/mfsu/src/moduleGraph.test.ts
+++ b/packages/mfsu/src/moduleGraph.test.ts
@@ -196,3 +196,52 @@ test('circular deps restore', () => {
   const restored = new ModuleGraph();
   restored.restore(mg.toJSON());
 });
+
+test('deps with importer', () => {
+  const mg = new ModuleGraph();
+  mg.onFileChange({
+    file: 'a',
+    deps: [{ file: 'b', isDependency: true, version: '0.0.1' }],
+  });
+
+  mg.snapshotDeps();
+
+  expect(mg.depSnapshotModules).toEqual({
+    b: { file: 'b', version: '0.0.1', importer: 'a' },
+  });
+});
+
+test('deps compare ignore importer', () => {
+  const mg = new ModuleGraph();
+  mg.onFileChange({
+    file: 'a',
+    deps: [{ file: 'b', isDependency: true, version: '0.0.1' }],
+  });
+
+  mg.snapshotDeps();
+
+  mg.onFileChange({
+    file: 'a',
+    deps: [],
+  });
+  mg.onFileChange({
+    file: 'c',
+    deps: [{ file: 'b', isDependency: true, version: '0.0.1' }],
+  });
+
+  expect(mg.hasDepChanged()).toEqual(false);
+});
+
+test('deps compare ignore importer when no importer', () => {
+  const mg = new ModuleGraph();
+  mg.onFileChange({
+    file: 'a',
+    deps: [{ file: 'b', isDependency: true, version: '0.0.1' }],
+  });
+
+  mg.depSnapshotModules = {
+    b: { file: 'b', version: '0.0.1' },
+  };
+
+  expect(mg.hasDepChanged()).toEqual(false);
+});

--- a/packages/mfsu/src/moduleGraph.ts
+++ b/packages/mfsu/src/moduleGraph.ts
@@ -132,10 +132,12 @@ export class ModuleGraph {
   }
 
   getDepInfo(mod: ModuleNode) {
+    const [importer] = mod.importers;
+
     return {
       file: mod.file,
       version: mod.version!,
-      importer: Array.from(mod.importers)[0]?.file,
+      importer: importer?.file,
     };
   }
 

--- a/packages/mfsu/src/moduleGraph.ts
+++ b/packages/mfsu/src/moduleGraph.ts
@@ -1,4 +1,3 @@
-import { lodash } from '@umijs/utils';
 import type { DepModule } from './depInfo';
 
 class ModuleNode {
@@ -136,12 +135,33 @@ export class ModuleGraph {
     return {
       file: mod.file,
       version: mod.version!,
+      importer: Array.from(mod.importers)[0]?.file,
     };
   }
 
   hasDepChanged() {
     const depModulesInfo = this.getDepsInfo(this.depToModules);
-    return !lodash.isEqual(depModulesInfo, this.depSnapshotModules);
+
+    const depKeys = Object.keys(depModulesInfo);
+    const snapshotKeys = Object.keys(this.depSnapshotModules);
+
+    if (depKeys.length !== snapshotKeys.length) {
+      return true;
+    }
+
+    for (const k of depKeys) {
+      const dep = depModulesInfo[k];
+      const snapshot = this.depSnapshotModules[k];
+      if (dep.file !== snapshot?.file) {
+        return true;
+      }
+
+      if (dep.version !== snapshot?.version) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   onFileChange(opts: { file: string; deps: IDep[] }) {


### PR DESCRIPTION
1. Dep  新增  importer 字段，取值为 imprters 集合里面的第一个，获取依赖地址时，优先基于 cwd 来解析包地址，兜底用 `dirname(importer)` 。
2. normal 模式下依赖比较忽略 importer 字段，以避免额外的依赖构建
3. mf-va_*  模块使用依赖的<del>绝对路径 ，需要讨论这样的路径容易失效</del>；使用依赖的软链地址，避免升级物理文件地址不存在，导致编译错误。

