### PR TITLE
fix: 🐛 修复 monorepo 下非 src 下文件改动进入到代码列表

### DIFF
--- a/packages/mfsu/src/mfsu/strategyStaticAnalyze.ts
+++ b/packages/mfsu/src/mfsu/strategyStaticAnalyze.ts
@@ -130,16 +130,18 @@ export class StaticAnalyzeStrategy implements IMFSUStrategy {
           c.removedFiles,
         );
 
+        const cwd = this.mfsu.opts.cwd!;
+
         const fileEvents = [
           ...this.staticDepInfo.opts.srcCodeCache.replayChangeEvents(),
 
-          ...extractJSCodeFiles(c.modifiedFiles).map((f) => {
+          ...extractJSCodeFiles(cwd, c.modifiedFiles).map((f) => {
             return {
               event: 'change' as const,
               path: f,
             };
           }),
-          ...extractJSCodeFiles(c.removedFiles).map((f) => {
+          ...extractJSCodeFiles(cwd, c.removedFiles).map((f) => {
             return {
               event: 'unlink' as const,
               path: f,
@@ -182,14 +184,14 @@ export class StaticAnalyzeStrategy implements IMFSUStrategy {
 
 const REG_CODE_EXT = /\.(jsx|js|ts|tsx)$/;
 
-function extractJSCodeFiles(files: ReadonlySet<string>) {
+function extractJSCodeFiles(folderBase: string, files: ReadonlySet<string>) {
   const jsFiles: string[] = [];
   if (!files) {
     return jsFiles;
   }
 
   for (let file of files.values()) {
-    if (REG_CODE_EXT.test(file)) {
+    if (file.startsWith(folderBase) && REG_CODE_EXT.test(file)) {
       jsFiles.push(file);
     }
   }


### PR DESCRIPTION
在 monorepo 的情况，webpack 会 监听在非常当前的源码目录的文件，这类文件不能进入，srcCache 的列表。

PS 
eager  模式下 monorepo 中的子包源码和所有依赖都会在 项目代码一起构建，mfsu 加速效果不佳。


close https://github.com/umijs/umi/issues/9752
