### PR TITLE
fix: add default publicPath

### DIFF
--- a/packages/mfsu/src/mfsu/mfsu.test.ts
+++ b/packages/mfsu/src/mfsu/mfsu.test.ts
@@ -1,0 +1,23 @@
+import { resolvePublicPath } from './mfsu';
+
+test('resolvePublicPath if no output', () => {
+  expect(resolvePublicPath({})).toStrictEqual('/');
+});
+
+test('resolvePublicPath if no publicPath', () => {
+  expect(
+    resolvePublicPath({
+      output: {},
+    }),
+  ).toStrictEqual('/');
+});
+
+test('resolvePublicPath has publicPath', () => {
+  expect(
+    resolvePublicPath({
+      output: {
+        publicPath: 'custom',
+      },
+    }),
+  ).toStrictEqual('custom');
+});

--- a/packages/mfsu/src/mfsu/mfsu.ts
+++ b/packages/mfsu/src/mfsu/mfsu.ts
@@ -202,7 +202,8 @@ export class MFSU {
     opts.config.plugins = opts.config.plugins || [];
 
     // support publicPath auto
-    this.publicPath = resolvePublicPath(opts.config);
+    let publicPath = resolvePublicPath(opts.config);
+    this.publicPath = publicPath;
 
     opts.config.plugins!.push(
       ...[

--- a/packages/mfsu/src/mfsu/mfsu.ts
+++ b/packages/mfsu/src/mfsu/mfsu.ts
@@ -388,7 +388,7 @@ export function resolvePublicPath(config: Configuration): string {
 
   assert(typeof publicPath === 'string', 'Not support function publicPath now');
 
-  return String(publicPath);
+  return publicPath;
 }
 
 export interface IMFSUStrategy {

--- a/packages/mfsu/src/mfsu/mfsu.ts
+++ b/packages/mfsu/src/mfsu/mfsu.ts
@@ -202,11 +202,7 @@ export class MFSU {
     opts.config.plugins = opts.config.plugins || [];
 
     // support publicPath auto
-    let publicPath = opts.config.output!.publicPath;
-    if (publicPath === 'auto') {
-      publicPath = '/';
-    }
-    this.publicPath = publicPath as string;
+    this.publicPath = resolvePublicPath(opts.config);
 
     opts.config.plugins!.push(
       ...[
@@ -382,6 +378,17 @@ promise new Promise(resolve => {
   public getCacheFilePath() {
     return this.strategy.getCacheFilePath();
   }
+}
+
+export function resolvePublicPath(config: Configuration): string {
+  let publicPath = config.output?.publicPath ?? 'auto';
+  if (publicPath === 'auto') {
+    publicPath = '/';
+  }
+
+  assert(typeof publicPath === 'string', 'Not support function publicPath now');
+
+  return String(publicPath);
 }
 
 export interface IMFSUStrategy {


### PR DESCRIPTION
fix: #9785 

改动点：

1. 如果 webpack 配置中没有指定 `output` 或者 `output.publicPath`，则设置为 `'/'`
2. 对使用函数形式的 `publicPath` 进行提示（不确定这样提示是不是友好）
