### PR TITLE
feat: modifyClientRenderOpts

### DIFF
--- a/examples/boilerplate/app.tsx
+++ b/examples/boilerplate/app.tsx
@@ -38,3 +38,8 @@ export function patchClientRoutes({ routes }: any) {
 //     </div>
 //   );
 // }
+
+export const modifyClientRenderOpts = (opts: any) => {
+  console.log('modifyClientRenderOpts: ', opts);
+  return opts;
+};

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -379,6 +379,7 @@ export default function EmptyRoute() {
         'patchRoutes',
         'patchClientRoutes',
         'modifyContextOpts',
+        'modifyClientRenderOpts',
         'rootContainer',
         'innerProvider',
         'i18nProvider',

--- a/packages/preset-umi/templates/TestBrowser.tpl
+++ b/packages/preset-umi/templates/TestBrowser.tpl
@@ -43,7 +43,7 @@ export function TestBrowser(props: TestBrowserProps) {
         type: 'memory',
         basename,
       });
-      return {
+      const context = {
         routes,
         routeComponents,
         pluginManager,
@@ -54,6 +54,12 @@ export function TestBrowser(props: TestBrowserProps) {
         basename,
         components: true,
       };
+      const modifiedContext = pluginManager.applyPlugins({
+        key: 'modifyClientRenderOpts',
+        type: ApplyPluginsType.modify,
+        initialValue: context,
+      });
+      return modifiedContext;
     };
     genContext().then((context) => {
       setContext(context);

--- a/packages/preset-umi/templates/umi.tpl
+++ b/packages/preset-umi/templates/umi.tpl
@@ -60,7 +60,12 @@ async function render() {
         }),
         basename,
       };
-      return renderClient(context);
+      const modifiedContext = pluginManager.applyPlugins({
+        key: 'modifyClientRenderOpts',
+        type: ApplyPluginsType.modify,
+        initialValue: context,
+      });
+      return renderClient(modifiedContext);
     },
   }))();
 }


### PR DESCRIPTION
来自于 resolve #9761 的问题

umi v3 中的一个修改 render 入参的功能在 v4 中支持。