### PR TITLE
fix: qiankun slave no render

### DIFF
--- a/packages/plugins/libs/qiankun/slave/slaveRuntimePlugin.ts
+++ b/packages/plugins/libs/qiankun/slave/slaveRuntimePlugin.ts
@@ -2,14 +2,9 @@
 import qiankunRender, { contextOptsStack } from './lifecycles';
 
 export function render(oldRender: any) {
-  return qiankunRender().then(oldRender);
-}
-
-export function modifyContextOpts(memo: any) {
-  // 每次应用 render 的时候会调 modifyClientRenderOpts，这时尝试从队列中取 render 的配置
-  const clientRenderOpts = contextOptsStack.shift();
-  return {
-    ...memo,
-    ...clientRenderOpts,
-  };
+  return qiankunRender().then(() => {
+    // modifyContextOpts 调整到 render 之前执行，oldRender 应该在 qiankunRender 之后，子应用配置又是动态的，所以在这里取配置最合理
+    const clientRenderOpts = contextOptsStack.shift();
+    oldRender(clientRenderOpts);
+  });
 }

--- a/packages/preset-umi/templates/umi.tpl
+++ b/packages/preset-umi/templates/umi.tpl
@@ -26,17 +26,27 @@ async function render() {
       routeComponents,
     },
   });
+ 
+  const contextOpts = pluginManager.applyPlugins({
+    key: 'modifyContextOpts',
+    type: ApplyPluginsType.modify,
+    initialValue: {},
+  });
+
+  const basename = contextOpts.basename || '{{{ basename }}}';
+
+
+  const history = createHistory({
+    type: contextOpts.historyType || '{{{ historyType }}}',
+    basename,
+    ...contextOpts.historyOpts,
+  });
 
   return (pluginManager.applyPlugins({
     key: 'render',
     type: ApplyPluginsType.compose,
-    initialValue() {
-      const contextOpts = pluginManager.applyPlugins({
-        key: 'modifyContextOpts',
-        type: ApplyPluginsType.modify,
-        initialValue: {},
-      });
-      const basename = contextOpts.basename || '{{{ basename }}}';
+    initialValue(config = {}) {
+     
       const context = {
 {{#hydrate}}
         hydrate: true,
@@ -53,12 +63,9 @@ async function render() {
 {{/loadingComponent}}
         publicPath,
         runtimePublicPath,
-        history: createHistory({
-          type: contextOpts.historyType || '{{{ historyType }}}',
-          basename,
-          ...contextOpts.historyOpts,
-        }),
+        history,
         basename,
+        ...config
       };
       return renderClient(context);
     },


### PR DESCRIPTION
经过 https://github.com/umijs/umi/pull/9765 调整之后，modifyContextOpts 调整到 render 之前执行，
在这里 oldRender 应该在 qiankunRender 之后，子应用配置又是动态的，所以 给 render 传递新的 config ，我觉得比较合理。
