### PR TITLE
feat: support dynamically modify the base path

### DIFF
--- a/packages/preset-umi/templates/umi.tpl
+++ b/packages/preset-umi/templates/umi.tpl
@@ -36,7 +36,7 @@ async function render() {
         type: ApplyPluginsType.modify,
         initialValue: {},
       });
-      const basename = contextOpts.basename || '{{{ basename }}}';
+      const basename = contextOpts.basename || window.routerBase || '{{{ basename }}}';
       const context = {
 {{#hydrate}}
         hydrate: true,


### PR DESCRIPTION
关联 issue: https://github.com/umijs/umi/issues/5915

原因：微前端场景下，子应用支持独立访问、也支持在父应用站点访问

为什么这样做？
因为父应用可能是不稳定的，在父应用不稳定的情况，支持用户降级到子应用的站点域名去访问。

在上面所述的这种场景下，父应用有约定好的 basename: /app1，而子应用有自己的 basename: /，子应用为了能在微前端环境跑和独立跑，需要支持动态配置  base，做 ```window.routerBase = window.__POWERED_BY_QIANKUN__ ? '/app1' : '/'``` 的逻辑，这个逻辑在 umi3 是 ok，相信也有不少用户做了这样的逻辑（可见 issue）

希望 umi 维护者能把这项特性加进来，真的很有很有必要~

尝试用 https://github.com/umijs/umi/discussions/8475 的方式解决，路由 / 一直会自动重定向到 ```/ant-design-pro``` ，怀疑是插件的执行机制导致的，所以，只能提 pr 了



