### PR TITLE
fix(favicon): intercept path should with public path

### DIFF
--- a/packages/preset-umi/src/features/favicons/favicons.ts
+++ b/packages/preset-umi/src/features/favicons/favicons.ts
@@ -36,7 +36,7 @@ export default (api: IApi) => {
   api.addBeforeMiddlewares(() => [
     (req, res, next) => {
       const iconFile = (api.appData.faviconFiles || []).find(
-        (file: any) => req.path === `/${file}`,
+        (file: any) => req.path === `${api.config.publicPath}${file}`,
       );
       if (!iconFile) {
         next();


### PR DESCRIPTION
如果设定了 `publicPath` ，也应该在带 `publicPath` 上提供 favicon 。

和这里保持一致：

https://github.com/umijs/umi/blob/47281f6dfa3de3a24bb8214cfbed83145190ed5c/packages/preset-umi/src/features/favicons/favicons.ts#L61-L69