### PR TITLE
fix(preset-umi): route chunk compatible with monorepo root dep

### DIFF
--- a/packages/preset-umi/src/features/monorepo/redirect.ts
+++ b/packages/preset-umi/src/features/monorepo/redirect.ts
@@ -114,7 +114,7 @@ async function collectAllProjects(opts: IOpts) {
 }
 
 const MONOREPO_FILE = ['pnpm-workspace.yaml', 'lerna.json'];
-function isMonorepo(opts: IOpts) {
+export function isMonorepo(opts: IOpts) {
   const pkgPath = join(opts.root, 'package.json');
   let pkg: Record<string, any> = {};
   try {


### PR DESCRIPTION
路由文件 chunkName 的生成逻辑支持处理 monorepo 仓库中 root node_modules 里的路由文件，比如 dumi 默认的 Layout 有可能在根目录的 node_modules 内