### PR TITLE
fix(splitChunks): prevent escape of base64 chars

### DIFF
--- a/packages/preset-umi/src/features/codeSplitting/codeSplitting.ts
+++ b/packages/preset-umi/src/features/codeSplitting/codeSplitting.ts
@@ -126,7 +126,11 @@ export default (api: IApi) => {
                   }, ''),
                 )
                 .digest('base64')
-                .replace(/\//g, '');
+                // replace `+=/` that may be escaped in the url
+                // https://github.com/umijs/umi/issues/9845
+                .replace(/\//g, '')
+                .replace(/\+/g, '-')
+                .replace(/=/g, '_');
               return `shared-${cryptoName}`;
             },
             chunks: 'async',


### PR DESCRIPTION
换掉 base64 中可能在 url 中被转义的字符。

resolve #9845