### PR TITLE
fix(plugins): string history not working in qiankun slave

### DIFF
--- a/packages/plugins/libs/qiankun/slave/lifecycles.ts
+++ b/packages/plugins/libs/qiankun/slave/lifecycles.ts
@@ -23,22 +23,22 @@ let hasMountedAtLeastOnce = false;
 export default () => defer.promise;
 export const contextOptsStack: any[] = [];
 
-// function normalizeHistory(
-//   history?: 'string' | Record<string, any>,
-//   base?: string,
-// ) {
-//   let normalizedHistory: Record<string, any> = {};
-//   if (base) normalizedHistory.basename = base;
-//   if (history) {
-//     if (typeof history === 'string') {
-//       normalizedHistory.type = history;
-//     } else {
-//       normalizedHistory = history;
-//     }
-//   }
-//
-//   return normalizedHistory;
-// }
+function normalizeHistory(
+  history?: 'string' | Record<string, any>,
+  base?: string,
+) {
+  let normalizedHistory: Record<string, any> = {};
+  if (base) normalizedHistory.basename = base;
+  if (history) {
+    if (typeof history === 'string') {
+      normalizedHistory.type = history;
+    } else {
+      normalizedHistory = history;
+    }
+  }
+
+  return normalizedHistory;
+}
 
 async function getSlaveRuntime() {
   const config = await getPluginManager().applyPlugins({
@@ -73,7 +73,10 @@ export function genMount(mountElementId: string) {
         await slaveRuntime.mount(props);
       }
 
-      const { type, ...historyOpts } = props?.history || {};
+      const { type, ...historyOpts } = normalizeHistory(
+        props?.history || {},
+        props?.base,
+      );
 
       // 更新 clientRender 配置
       const clientRenderOpts = {


### PR DESCRIPTION
修复用 qiankun `MircroApp` 传入字符串 history 时，子应用没有转换导致 history 参数异常的问题

该转换在 Umi 3 时是支持的，改回去以解决父/子应用 history 类型不相同时渲染异常的问题