### PR TITLE
feat: support callback for browser render

### DIFF
--- a/packages/plugins/libs/qiankun/slave/lifecycles.ts
+++ b/packages/plugins/libs/qiankun/slave/lifecycles.ts
@@ -77,17 +77,17 @@ export function genMount(mountElementId: string) {
 
       // 更新 clientRender 配置
       const clientRenderOpts = {
-        // 默认开启
-        // 如果需要手动控制 loading，通过主应用配置 props.autoSetLoading false 可以关闭
         callback: () => {
+          // 默认开启
+          // 如果需要手动控制 loading，通过主应用配置 props.autoSetLoading false 可以关闭
           if (props.autoSetLoading && typeof props.setLoading === 'function') {
             props.setLoading(false);
           }
 
-          // // 支持将子应用的 history 回传给父应用
-          // if (typeof props?.onHistoryInit === 'function') {
-          //   props.onHistoryInit(history);
-          // }
+          // 支持将子应用的 history 回传给父应用
+          if (typeof props?.onHistoryInit === 'function') {
+            props.onHistoryInit(history);
+          }
         },
         // 支持通过 props 注入 container 来限定子应用 mountElementId 的查找范围
         // 避免多个子应用出现在同一主应用时出现 mount 冲突
@@ -125,14 +125,6 @@ export function genMount(mountElementId: string) {
       defer.resolve();
     }
 
-    // 如果需要手动控制 loading，通过主应用配置 props.autoSetLoading false 可以关闭
-    // 考虑到 react 18 之后 callback 不再准
-    // 所以在这里直接返回，而不使用 ReactDOM.render 的第三个参数
-    if (typeof props !== 'undefined') {
-      if (props.autoSetLoading && typeof props.setLoading === 'function') {
-        props.setLoading(false);
-      }
-    }
     hasMountedAtLeastOnce = true;
   };
 }

--- a/packages/preset-umi/templates/umi.tpl
+++ b/packages/preset-umi/templates/umi.tpl
@@ -59,6 +59,7 @@ async function render() {
           ...contextOpts.historyOpts,
         }),
         basename,
+        callback: contextOpts.callback,
       };
       const modifiedContext = pluginManager.applyPlugins({
         key: 'modifyClientRenderOpts',

--- a/packages/renderer-react/src/browser.tsx
+++ b/packages/renderer-react/src/browser.tsx
@@ -1,5 +1,10 @@
 import { History } from 'history';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useState,
+} from 'react';
 // compatible with < react@18 in @umijs/preset-umi/src/features/react
 import { HelmetProvider } from 'react-helmet-async';
 import ReactDOM from 'react-dom/client';
@@ -33,8 +38,8 @@ function BrowserRoutes(props: {
     action: history.action,
     location: history.location,
   });
-  React.useLayoutEffect(() => history.listen(setState), [history]);
-  React.useLayoutEffect(() => {
+  useLayoutEffect(() => history.listen(setState), [history]);
+  useLayoutEffect(() => {
     function onRouteChange(opts: any) {
       props.pluginManager.applyPlugins({
         key: 'onRouteChange',
@@ -127,6 +132,10 @@ export type RenderClientOpts = {
    * 此模式下，路由组件的 props 会包含 location、match、history 和 params 属性，和 react-router 5 的保持一致。
    */
   reactRouter5Compat?: boolean;
+  /**
+   * 应用渲染完成的回调函数
+   */
+  callback?: () => void;
 };
 /**
  * umi max 所需要的所有插件列表，用于获取provide
@@ -282,6 +291,10 @@ const getBrowser = (
       return opts.history.listen((e) => {
         handleRouteChange(e.location.pathname);
       });
+    }, []);
+
+    useLayoutEffect(() => {
+      if (typeof opts.callback === 'function') opts.callback();
     }, []);
 
     return (


### PR DESCRIPTION
1. 重新支持 render callback，用于支持 qiankun `MicroApp` 的 `onHistoryInit` 回调函数
2. 将 qiankun slave lifecycle 中的 callback 触发方式改回原样，实现精准触发
3. 将 qiankun slave lifecycle 中的 onHistoryInit 回调重新启用，实现子应用 history 回传，在海兔场景下需要它控制子应用页面切换