### PR TITLE
fix(doc): 修复了文档站点中对国际化(多语言)的错误指向

### DIFF
--- a/docs/docs/max/introduce.md
+++ b/docs/docs/max/introduce.md
@@ -32,7 +32,7 @@ $ npx max g jest
 - [dva](./dva)
 - [initial-state](../api/runtime-config#getinitialstate)
 - [布局和菜单](./layout-menu)
-- [多语言](./locale)
+- [国际化(多语言)](./i18n)
 - [model](./data-flow)
 - [乾坤微前端](./micro-frontend)
 - [请求库](./request)


### PR DESCRIPTION
null

-----
[View rendered docs/docs/max/introduce.md](https://github.com/FriedRiceNoodles/umi/blob/master/docs/docs/max/introduce.md)