### PR TITLE
fix(script): script path may contain space

### DIFF
--- a/scripts/bin/umi-scripts.js
+++ b/scripts/bin/umi-scripts.js
@@ -25,9 +25,12 @@ if (throughArgs.length) {
   throughArgs.unshift('--')
 }
 
+// current dir path may contain spaces
+// https://github.com/umijs/umi/issues/9865
+const scriptPathAsStr = JSON.stringify(scriptsPath)
 const spawn = sync(
   'tsx',
-  [scriptsPath, ...throughArgs],
+  [scriptPathAsStr, ...throughArgs],
   {
     env: process.env,
     cwd: process.cwd(),


### PR DESCRIPTION
修复脚本路径可能含有空格被分割

fix #9865