### PR TITLE
fix(test): not export component when test set false

### DIFF
--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -541,7 +541,7 @@ export default function EmptyRoute() {
           path: '@@/core/terminal.ts',
         });
       }
-      if (api.appData.framework === 'react') {
+      if (api.config.test !== false && api.appData.framework === 'react') {
         if (
           process.env.NODE_ENV === 'test' ||
           // development is for TestBrowser's type


### PR DESCRIPTION
应该可以通过 `test: false` 关闭测试功能，此时不需要写入 export 。