### PR TITLE
fix: 🐛  src code compiled twice problme

### DIFF
--- a/.umirc.ts
+++ b/.umirc.ts
@@ -2,7 +2,7 @@ export default {
   favicons: [
     'https://img.alicdn.com/tfs/TB1YHEpwUT1gK0jSZFhXXaAtVXa-28-27.svg',
   ],
-  mfsu: false,
+  mfsu: { strategy: 'normal' },
   routePrefetch: {},
   manifest: {},
   plugins: ['@umijs/plugin-docs'],

--- a/packages/mfsu/src/babelPlugins/awaitImport/checkMatch.test.ts
+++ b/packages/mfsu/src/babelPlugins/awaitImport/checkMatch.test.ts
@@ -49,8 +49,12 @@ test('start with mf/', () => {
   expect(
     checkMatch({
       value: 'mf/foo',
-    }).isMatch,
-  ).toEqual(false);
+    }),
+  ).toEqual({
+    isMatch: true,
+    value: 'foo',
+    replaceValue: 'mf/foo',
+  });
 });
 
 test('babel/svgr-webpack', () => {

--- a/packages/mfsu/src/babelPlugins/awaitImport/checkMatch.ts
+++ b/packages/mfsu/src/babelPlugins/awaitImport/checkMatch.ts
@@ -64,13 +64,13 @@ export function checkMatch({
 
   const unMatchLibsRegex = genUnMatchLibsRegex(opts.unMatchLibs);
 
+  const mfPathInitial = `${remoteName}/`;
+
   if (
     // unMatch specified libs
     unMatchLibsRegex?.test(value) ||
     // do not match bundler-webpack/client/client/client.js
     value.includes('client/client/client.js') ||
-    // already handled
-    value.startsWith(`${remoteName}/`) ||
     // don't match dynamic path
     // e.g. @umijs/deps/compiled/babel/svgr-webpack.js?-svgo,+titleProp,+ref!./umi.svg
     winPath(value).includes('babel/svgr-webpack') ||
@@ -83,6 +83,9 @@ export function checkMatch({
     value.startsWith('.')
   ) {
     isMatch = false;
+    // already handled
+  } else if (value.startsWith(mfPathInitial)) {
+    isMatch = true;
   } else if (isAbsolute(value)) {
     isMatch = RE_NODE_MODULES.test(value) || isUmiLocalDev(value);
   } else {
@@ -110,7 +113,13 @@ export function checkMatch({
   }
 
   if (isMatch) {
-    replaceValue = `${remoteName}/${winPath(value)}`;
+    // in case src file compiled twice or more
+    if (value.startsWith(mfPathInitial)) {
+      replaceValue = value;
+      value = value.replace(mfPathInitial, '');
+    } else {
+      replaceValue = `${remoteName}/${winPath(value)}`;
+    }
   }
 
   // @ts-ignore


### PR DESCRIPTION
使用 APP_ROOT 的方式会让 client.js  babel 编译两次，导致 react-error-overlay 依赖丢失

通过此 PR 解决类似多次编译的问题。

