### PR TITLE
feat: ✨ umi config set 命令支持复杂 JSON 值

### DIFF
--- a/packages/ast/src/setConfigByName/setConfigByName.test.ts
+++ b/packages/ast/src/setConfigByName/setConfigByName.test.ts
@@ -23,6 +23,23 @@ test('set object', () => {
   expect(generateCode).toContain('react');
 });
 
+test('set object with deep object', () => {
+  const ast = parse('export default {}');
+  const generateCode = generate(
+    setConfigByName(
+      ast,
+      'p2',
+      JSON.stringify({
+        react: 'aaa',
+        subP2: { a: 1, b: { d: 'ddd' }, c: true },
+      }),
+    )!,
+  );
+  expect(generateCode).toMatchInlineSnapshot(
+    `"export default { p2: { react: \\"aaa\\", subP2: { a: 1, b: { d: \\"ddd\\" }, c: true } } };"`,
+  );
+});
+
 test('set number', () => {
   const ast = getASTByFilePath(join(cwd, '.umirc.ts'));
   if (!ast) return;

--- a/packages/ast/src/setConfigByName/setConfigByName.test.ts
+++ b/packages/ast/src/setConfigByName/setConfigByName.test.ts
@@ -10,7 +10,7 @@ const cwd = join(fixtures, 'app');
 test('normal', () => {
   const ast = getASTByFilePath(join(cwd, '.umirc.ts'));
   if (!ast) return;
-  const generateCode = generate(setConfigByName(ast!, 'abc', false)!);
+  const generateCode = generate(setConfigByName(ast!, 'abc', 'false')!);
   expect(generateCode).toContain('abc: false');
 });
 
@@ -36,14 +36,14 @@ test('set object with deep object', () => {
     )!,
   );
   expect(generateCode).toMatchInlineSnapshot(
-    `"export default { p2: { react: \\"aaa\\", subP2: { a: 1, b: { d: \\"ddd\\" }, c: true } } };"`,
+    `"export default { p2: { \\"react\\": \\"aaa\\", \\"subP2\\": { \\"a\\": 1, \\"b\\": { \\"d\\": \\"ddd\\" }, \\"c\\": true } } };"`,
   );
 });
 
 test('set number', () => {
   const ast = getASTByFilePath(join(cwd, '.umirc.ts'));
   if (!ast) return;
-  const generateCode = generate(setConfigByName(ast, 'num', 2)!);
+  const generateCode = generate(setConfigByName(ast, 'num', '2')!);
   expect(generateCode).toContain('num: 2');
 });
 
@@ -59,13 +59,13 @@ test('set array', () => {
 test('set new config', () => {
   const ast = getASTByFilePath(join(cwd, '.umirc.ts'));
   if (!ast) return;
-  const generateCode = generate(setConfigByName(ast, 'aaa', true)!);
+  const generateCode = generate(setConfigByName(ast, 'aaa', 'true')!);
   expect(generateCode).toContain('aaa');
 });
 
 test('set config in export default defineConfig', () => {
   const ast = parse(`const c= {dav:{}}; export default defineConfig({...c})`);
-  const generateCode = generate(setConfigByName(ast, 'tailwindcss', {})!);
+  const generateCode = generate(setConfigByName(ast, 'tailwindcss', '{}')!);
 
   expect(generateCode).toEqual(
     code(
@@ -76,7 +76,7 @@ test('set config in export default defineConfig', () => {
 
 test('set config in export default object', () => {
   const ast = parse(`const c = {dva:{}}; export default {...c}`);
-  const generateCode = generate(setConfigByName(ast, 'tailwindcss', {})!);
+  const generateCode = generate(setConfigByName(ast, 'tailwindcss', '{}')!);
 
   expect(generateCode).toEqual(
     code(`const c = {dva:{}};export default {...c, tailwindcss:{}}`),

--- a/packages/ast/src/setConfigByName/setConfigByName.ts
+++ b/packages/ast/src/setConfigByName/setConfigByName.ts
@@ -16,7 +16,7 @@ export function setConfigByName(ast: t.File, name: string, value: string) {
     ObjectProperty(path) {
       //@ts-ignore
       if (path.node.key?.name === name) {
-        path.node.value = valueObject!;
+        path.node.value = valueObject;
         isChanged = true;
         path.stop();
       }
@@ -33,7 +33,7 @@ export function setConfigByName(ast: t.File, name: string, value: string) {
           t.isObjectExpression(path.node.arguments[0])
         ) {
           path.node.arguments[0].properties.push(
-            t.objectProperty(t.identifier(name), valueObject!),
+            t.objectProperty(t.identifier(name), valueObject),
           );
           modified = true;
           path.stop();
@@ -43,7 +43,7 @@ export function setConfigByName(ast: t.File, name: string, value: string) {
       ObjectExpression(path: NodePath<t.ObjectExpression>) {
         if (t.isExportDefaultDeclaration(path.parent)) {
           path.node.properties.push(
-            t.objectProperty(t.identifier(name), valueObject!),
+            t.objectProperty(t.identifier(name), valueObject),
           );
           modified = true;
           path.stop();

--- a/packages/preset-umi/src/commands/config/set.ts
+++ b/packages/preset-umi/src/commands/config/set.ts
@@ -4,7 +4,7 @@ import { writeFileSync } from 'fs';
 import { join } from 'path';
 import { IApi } from '../../types';
 
-export function set(api: IApi, name: string, value: any) {
+export function set(api: IApi, name: string, value: string) {
   let { mainConfigFile } = api.appData;
 
   // write empty config if config file not exists


### PR DESCRIPTION
why:

需要在测试中设置切换不同的 mfsu 配置

原来 ` max config  set  '{"strategy":"normal", esbuild:true}' `  会报错 
