### PR TITLE
fix(preset-umi): wrong polyfill when user put .babelrc

### DIFF
--- a/packages/lint/src/config/eslint/index.ts
+++ b/packages/lint/src/config/eslint/index.ts
@@ -42,6 +42,8 @@ module.exports = {
       jsx: true,
     },
     babelOptions: {
+      babelrc: false,
+      configFile: false,
       presets: [require.resolve('@umijs/babel-preset-umi')],
     },
     requireConfigFile: false,

--- a/packages/lint/src/config/eslint/legacy.ts
+++ b/packages/lint/src/config/eslint/legacy.ts
@@ -27,6 +27,8 @@ module.exports = {
       jsx: true,
     },
     babelOptions: {
+      babelrc: false,
+      configFile: false,
       presets: [require.resolve('@umijs/babel-preset-umi')],
     },
     requireConfigFile: false,

--- a/packages/preset-umi/src/features/polyfill/polyfill.ts
+++ b/packages/preset-umi/src/features/polyfill/polyfill.ts
@@ -49,6 +49,7 @@ export {};
         plugins: [
           require.resolve('@umijs/babel-preset-umi/dist/plugins/lockCoreJS'),
         ],
+        babelrc: false,
       },
     )!;
     api.writeTmpFile({

--- a/packages/preset-umi/src/features/polyfill/polyfill.ts
+++ b/packages/preset-umi/src/features/polyfill/polyfill.ts
@@ -50,6 +50,7 @@ export {};
           require.resolve('@umijs/babel-preset-umi/dist/plugins/lockCoreJS'),
         ],
         babelrc: false,
+        configFile: false,
       },
     )!;
     api.writeTmpFile({


### PR DESCRIPTION
修复项目里存在 `.babelrc` 时 polyfill 可能生成不正确的问题