### PR TITLE
fix(plugin): `mini-css-extract-plugin` with speed measure

### DIFF
--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -313,7 +313,6 @@ export async function getConfig(opts: IOpts): Promise<Configuration> {
   let webpackConfig = config.toConfig();
 
   // speed measure
-  // TODO: mini-css-extract-plugin 报错
   webpackConfig = await addSpeedMeasureWebpackPlugin({
     webpackConfig,
   });

--- a/packages/bundler-webpack/src/config/speedMeasureWebpackPlugin.ts
+++ b/packages/bundler-webpack/src/config/speedMeasureWebpackPlugin.ts
@@ -10,6 +10,12 @@ interface IOpts {
 export async function addSpeedMeasureWebpackPlugin(opts: IOpts) {
   let webpackConfig = opts.webpackConfig;
   if (process.env.SPEED_MEASURE) {
+    const miniCssExtractPluginIdx = webpackConfig.plugins?.findIndex(
+      (plugin) => plugin.constructor.name === 'MiniCssExtractPlugin',
+    );
+    const miniCssExtractPlugin =
+      webpackConfig.plugins?.[miniCssExtractPluginIdx!];
+
     const smpOption =
       process.env.SPEED_MEASURE === 'JSON'
         ? {
@@ -18,6 +24,11 @@ export async function addSpeedMeasureWebpackPlugin(opts: IOpts) {
           }
         : { outputFormat: 'human', outputTarget: console.log };
     webpackConfig = new SpeedMeasurePlugin(smpOption).wrap(webpackConfig);
+
+    // https://github.com/stephencookdev/speed-measure-webpack-plugin/issues/167#issuecomment-1318684127
+    if (miniCssExtractPlugin) {
+      webpackConfig.plugins![miniCssExtractPluginIdx!] = miniCssExtractPlugin;
+    }
   }
   return webpackConfig;
 }


### PR DESCRIPTION
fix #9897

解决 `mini-css-extract-plugin` 在和 speed measure 插件一起用会保存的问题。

FYI ：

 - https://github.com/stephencookdev/speed-measure-webpack-plugin/issues/167#issuecomment-1318684127