### PR TITLE
chore:  🐛 test case use the wrong param

### DIFF
--- a/packages/preset-umi/src/commands/config/config.test.ts
+++ b/packages/preset-umi/src/commands/config/config.test.ts
@@ -26,7 +26,7 @@ test('remove config:abc', async () => {
 
 test('set config:abc', async () => {
   await runGenerator({
-    _: ['config', 'set', 'abc', true],
+    _: ['config', 'set', 'abc', 'true'],
   });
   const config = readFileSync(join(cwd, 'config.ts'), 'utf-8');
   expect(config).toContain('abc: true');


### PR DESCRIPTION
params from cli are all string type
