### PR TITLE
docs:modify the usage of clientloader

### DIFF
--- a/docs/docs/api/config.md
+++ b/docs/docs/api/config.md
@@ -165,7 +165,7 @@ export default {
 import { useClientLoaderData } from 'umi';
 
 export default function SomePage() {
-  const data = useClientLoaderData();
+  const { data } = useClientLoaderData();
   return <div>{data}</div>;
 }
 

--- a/docs/docs/guides/client-loader.md
+++ b/docs/docs/guides/client-loader.md
@@ -25,7 +25,7 @@ export default {
 import { useClientLoaderData } from 'umi';
 
 export default function SomePage() {
-  const data = useClientLoaderData();
+  const { data } = useClientLoaderData();
   return <div>{data}</div>;
 }
 


### PR DESCRIPTION
[c8a1c68](https://github.com/umijs/umi/commit/c8a1c68919d8e43d8b6247f03ba2abc0100ebe32#diff-e97c0c6dfa654aac9778a8bc6fc1b9d94cf2eb8056624bb53b272d25dcf5c8eb)为useClientLoader添加一层data
```js
return { data: appData.clientLoaderData[route.route.id] };
```
`Docs-路由数据加载-使用方式`中相关示例并未更新。
```js
export default function SomePage() {
  const data = useClientLoaderData();
  return <div>{data}</div>;
}
```
