### PR TITLE
fix(ast): try stringify config value

### DIFF
--- a/packages/ast/src/setConfigByName/setConfigByName.ts
+++ b/packages/ast/src/setConfigByName/setConfigByName.ts
@@ -4,6 +4,9 @@ import { parseExpression } from '@umijs/bundler-utils/compiled/babel/parser';
 import * as t from '@umijs/bundler-utils/compiled/babel/types';
 
 export function setConfigByName(ast: t.File, name: string, value: string) {
+  if (typeof value !== 'string') {
+    value = JSON.stringify(value);
+  }
   let isChanged: boolean = false;
   let valueObject: t.Expression = t.stringLiteral(value);
   try {


### PR DESCRIPTION
close #9937

`setConfigByName` 的逻辑改动没和之前对齐，之前有大量非 `string` 的调用，这里尝试去字符串化 `value` 。