### PR TITLE
fix(plugins): wrong history from qiankun slave

### DIFF
--- a/packages/plugins/libs/qiankun/slave/lifecycles.ts
+++ b/packages/plugins/libs/qiankun/slave/lifecycles.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import { getPluginManager } from '@@/core/plugin';
 import ReactDOM from 'react-dom';
-import { ApplyPluginsType, __getRoot } from 'umi';
+import { ApplyPluginsType, __getRoot, history } from 'umi';
 import { setModelState } from './qiankunModel';
 
 const noop = () => {};


### PR DESCRIPTION
修复 qiankun 子应用 `onHistoryInit` 传入的 history 不是应用 history 的 bug