### PR TITLE
fix: clientLoader duplicate

### DIFF
--- a/packages/renderer-react/src/browser.tsx
+++ b/packages/renderer-react/src/browser.tsx
@@ -1,10 +1,5 @@
 import { History } from 'history';
-import React, {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useState,
-} from 'react';
+import React, { useEffect, useLayoutEffect, useRef } from 'react';
 // compatible with < react@18 in @umijs/preset-umi/src/features/react
 import { HelmetProvider } from 'react-helmet-async';
 import ReactDOM from 'react-dom/client';
@@ -206,85 +201,82 @@ const getBrowser = (
    * @returns {React.ReactElement}
    */
   const Browser = () => {
-    const [clientLoaderData, setClientLoaderData] = useState<ILoaderData>({});
-    const [serverLoaderData, setServerLoaderData] = useState<ILoaderData>(
+    const clientLoaderData = useRef<ILoaderData>({});
+    const serverLoaderData = useRef<ILoaderData>(
       // @ts-ignore
       window.__UMI_LOADER_DATA__ || {},
     );
 
-    const handleRouteChange = useCallback(
-      (id: string, isFirst?: boolean) => {
-        // Patched routes has to id
-        const matchedRouteIds = (
-          matchRoutes(clientRoutes, id, basename)?.map(
-            // @ts-ignore
-            (route) => route.route.id,
-          ) || []
-        ).filter(Boolean);
-        matchedRouteIds.forEach((id) => {
-          // preload
+    const handleRouteChange = (id: string, isFirst?: boolean) => {
+      // Patched routes has to id
+      const matchedRouteIds = (
+        matchRoutes(clientRoutes, id, basename)?.map(
           // @ts-ignore
-          const manifest = window.__umi_manifest__;
-          if (manifest) {
-            const routeIdReplaced = id.replace(/[\/\-]/g, '_');
-            const preloadId = `preload-${routeIdReplaced}.js`;
-            if (!document.getElementById(preloadId)) {
-              const keys = Object.keys(manifest).filter((k) =>
-                k.startsWith(routeIdReplaced + '.'),
-              );
-              keys.forEach((key) => {
-                if (!/\.(js|css)$/.test(key)) {
-                  throw Error(`preload not support ${key} file`);
-                }
-                let file = manifest[key];
-                const link = document.createElement('link');
-                link.rel = 'preload';
-                link.as = 'style';
-                if (key.endsWith('.js')) {
-                  link.as = 'script';
-                  link.id = preloadId;
-                }
-                // publicPath already in the manifest,
-                // but if runtimePublicPath is true, we need to replace it
-                if (opts.runtimePublicPath) {
-                  file = file.replace(
-                    new RegExp(`^${opts.publicPath}`),
-                    // @ts-ignore
-                    window.publicPath,
-                  );
-                }
-                link.href = file;
-                document.head.appendChild(link);
-              });
-            }
-          }
-          // server loader
-          // use ?. since routes patched with patchClientRoutes is not exists in opts.routes
-          if (!isFirst && opts.routes[id]?.hasServerLoader) {
-            fetch('/__serverLoader?route=' + id)
-              .then((d) => d.json())
-              .then((data) => {
-                // setServerLoaderData when startTransition because if ssr is enabled,
-                // the component may being hydrated and setLoaderData will break the hydration
-                // @ts-ignore
-                React.startTransition(() => {
-                  setServerLoaderData((d) => ({ ...d, [id]: data }));
-                });
-              })
-              .catch(console.error);
-          }
-          // client loader
-          // onPatchClientRoutes 添加的 route 在 opts.routes 里是不存在的
-          const clientLoader = opts.routes[id]?.clientLoader;
-          if (clientLoader && !clientLoaderData[id]) {
-            clientLoader().then((data: any) => {
-              setClientLoaderData((d: any) => ({ ...d, [id]: data }));
+          (route) => route.route.id,
+        ) || []
+      ).filter(Boolean);
+      matchedRouteIds.forEach((id) => {
+        // preload
+        // @ts-ignore
+        const manifest = window.__umi_manifest__;
+        if (manifest) {
+          const routeIdReplaced = id.replace(/[\/\-]/g, '_');
+          const preloadId = `preload-${routeIdReplaced}.js`;
+          if (!document.getElementById(preloadId)) {
+            const keys = Object.keys(manifest).filter((k) =>
+              k.startsWith(routeIdReplaced + '.'),
+            );
+            keys.forEach((key) => {
+              if (!/\.(js|css)$/.test(key)) {
+                throw Error(`preload not support ${key} file`);
+              }
+              let file = manifest[key];
+              const link = document.createElement('link');
+              link.rel = 'preload';
+              link.as = 'style';
+              if (key.endsWith('.js')) {
+                link.as = 'script';
+                link.id = preloadId;
+              }
+              // publicPath already in the manifest,
+              // but if runtimePublicPath is true, we need to replace it
+              if (opts.runtimePublicPath) {
+                file = file.replace(
+                  new RegExp(`^${opts.publicPath}`),
+                  // @ts-ignore
+                  window.publicPath,
+                );
+              }
+              link.href = file;
+              document.head.appendChild(link);
             });
           }
-        });
-      },
-      [clientLoaderData],
-    );
+        }
+        // server loader
+        // use ?. since routes patched with patchClientRoutes is not exists in opts.routes
+        if (!isFirst && opts.routes[id]?.hasServerLoader) {
+          fetch('/__serverLoader?route=' + id)
+            .then((d) => d.json())
+            .then((data) => {
+              // setServerLoaderData when startTransition because if ssr is enabled,
+              // the component may being hydrated and setLoaderData will break the hydration
+              // @ts-ignore
+              React.startTransition(() => {
+                clientLoaderData.current[id] = data;
+              });
+            })
+            .catch(console.error);
+        }
+        // client loader
+        // onPatchClientRoutes 添加的 route 在 opts.routes 里是不存在的
+        const clientLoader = opts.routes[id]?.clientLoader;
+        if (clientLoader && !clientLoaderData.current[id]) {
+          clientLoader().then((data: any) => {
+            clientLoaderData.current[id] = data;
+          });
+        }
+      });
+    };
 
     useEffect(() => {
       handleRouteChange(window.location.pathname, true);
@@ -307,8 +299,8 @@ const getBrowser = (
             pluginManager: opts.pluginManager,
             rootElement: opts.rootElement!,
             basename,
-            clientLoaderData,
-            serverLoaderData,
+            clientLoaderData: clientLoaderData.current,
+            serverLoaderData: serverLoaderData.current,
             preloadRoute: handleRouteChange,
             history: opts.history,
           }}

--- a/packages/renderer-react/src/browser.tsx
+++ b/packages/renderer-react/src/browser.tsx
@@ -278,7 +278,7 @@ const getBrowser = (
           }
         });
       },
-      [clientLoaderData],
+      [clientLoaderData.current],
     );
 
     useEffect(() => {

--- a/packages/renderer-react/src/browser.tsx
+++ b/packages/renderer-react/src/browser.tsx
@@ -207,76 +207,79 @@ const getBrowser = (
       window.__UMI_LOADER_DATA__ || {},
     );
 
-    const handleRouteChange = useCallback((id: string, isFirst?: boolean) => {
-      // Patched routes has to id
-      const matchedRouteIds = (
-        matchRoutes(clientRoutes, id, basename)?.map(
+    const handleRouteChange = useCallback(
+      (id: string, isFirst?: boolean) => {
+        // Patched routes has to id
+        const matchedRouteIds = (
+          matchRoutes(clientRoutes, id, basename)?.map(
+            // @ts-ignore
+            (route) => route.route.id,
+          ) || []
+        ).filter(Boolean);
+        matchedRouteIds.forEach((id) => {
+          // preload
           // @ts-ignore
-          (route) => route.route.id,
-        ) || []
-      ).filter(Boolean);
-      matchedRouteIds.forEach((id) => {
-        // preload
-        // @ts-ignore
-        const manifest = window.__umi_manifest__;
-        if (manifest) {
-          const routeIdReplaced = id.replace(/[\/\-]/g, '_');
-          const preloadId = `preload-${routeIdReplaced}.js`;
-          if (!document.getElementById(preloadId)) {
-            const keys = Object.keys(manifest).filter((k) =>
-              k.startsWith(routeIdReplaced + '.'),
-            );
-            keys.forEach((key) => {
-              if (!/\.(js|css)$/.test(key)) {
-                throw Error(`preload not support ${key} file`);
-              }
-              let file = manifest[key];
-              const link = document.createElement('link');
-              link.rel = 'preload';
-              link.as = 'style';
-              if (key.endsWith('.js')) {
-                link.as = 'script';
-                link.id = preloadId;
-              }
-              // publicPath already in the manifest,
-              // but if runtimePublicPath is true, we need to replace it
-              if (opts.runtimePublicPath) {
-                file = file.replace(
-                  new RegExp(`^${opts.publicPath}`),
-                  // @ts-ignore
-                  window.publicPath,
-                );
-              }
-              link.href = file;
-              document.head.appendChild(link);
+          const manifest = window.__umi_manifest__;
+          if (manifest) {
+            const routeIdReplaced = id.replace(/[\/\-]/g, '_');
+            const preloadId = `preload-${routeIdReplaced}.js`;
+            if (!document.getElementById(preloadId)) {
+              const keys = Object.keys(manifest).filter((k) =>
+                k.startsWith(routeIdReplaced + '.'),
+              );
+              keys.forEach((key) => {
+                if (!/\.(js|css)$/.test(key)) {
+                  throw Error(`preload not support ${key} file`);
+                }
+                let file = manifest[key];
+                const link = document.createElement('link');
+                link.rel = 'preload';
+                link.as = 'style';
+                if (key.endsWith('.js')) {
+                  link.as = 'script';
+                  link.id = preloadId;
+                }
+                // publicPath already in the manifest,
+                // but if runtimePublicPath is true, we need to replace it
+                if (opts.runtimePublicPath) {
+                  file = file.replace(
+                    new RegExp(`^${opts.publicPath}`),
+                    // @ts-ignore
+                    window.publicPath,
+                  );
+                }
+                link.href = file;
+                document.head.appendChild(link);
+              });
+            }
+          }
+          // server loader
+          // use ?. since routes patched with patchClientRoutes is not exists in opts.routes
+          if (!isFirst && opts.routes[id]?.hasServerLoader) {
+            fetch('/__serverLoader?route=' + id)
+              .then((d) => d.json())
+              .then((data) => {
+                // setServerLoaderData when startTransition because if ssr is enabled,
+                // the component may being hydrated and setLoaderData will break the hydration
+                // @ts-ignore
+                React.startTransition(() => {
+                  serverLoaderData.current[id] = data;
+                });
+              })
+              .catch(console.error);
+          }
+          // client loader
+          // onPatchClientRoutes 添加的 route 在 opts.routes 里是不存在的
+          const clientLoader = opts.routes[id]?.clientLoader;
+          if (clientLoader && !clientLoaderData.current[id]) {
+            clientLoader().then((data: any) => {
+              clientLoaderData.current[id] = data;
             });
           }
-        }
-        // server loader
-        // use ?. since routes patched with patchClientRoutes is not exists in opts.routes
-        if (!isFirst && opts.routes[id]?.hasServerLoader) {
-          fetch('/__serverLoader?route=' + id)
-            .then((d) => d.json())
-            .then((data) => {
-              // setServerLoaderData when startTransition because if ssr is enabled,
-              // the component may being hydrated and setLoaderData will break the hydration
-              // @ts-ignore
-              React.startTransition(() => {
-                clientLoaderData.current[id] = data;
-              });
-            })
-            .catch(console.error);
-        }
-        // client loader
-        // onPatchClientRoutes 添加的 route 在 opts.routes 里是不存在的
-        const clientLoader = opts.routes[id]?.clientLoader;
-        if (clientLoader && !clientLoaderData.current[id]) {
-          clientLoader().then((data: any) => {
-            clientLoaderData.current[id] = data;
-          });
-        }
-      });
-    }, []);
+        });
+      },
+      [clientLoaderData],
+    );
 
     useEffect(() => {
       handleRouteChange(window.location.pathname, true);

--- a/packages/renderer-react/src/browser.tsx
+++ b/packages/renderer-react/src/browser.tsx
@@ -1,5 +1,5 @@
 import { History } from 'history';
-import React, { useEffect, useLayoutEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 // compatible with < react@18 in @umijs/preset-umi/src/features/react
 import { HelmetProvider } from 'react-helmet-async';
 import ReactDOM from 'react-dom/client';
@@ -207,7 +207,7 @@ const getBrowser = (
       window.__UMI_LOADER_DATA__ || {},
     );
 
-    const handleRouteChange = (id: string, isFirst?: boolean) => {
+    const handleRouteChange = useCallback((id: string, isFirst?: boolean) => {
       // Patched routes has to id
       const matchedRouteIds = (
         matchRoutes(clientRoutes, id, basename)?.map(
@@ -276,7 +276,7 @@ const getBrowser = (
           });
         }
       });
-    };
+    }, []);
 
     useEffect(() => {
       handleRouteChange(window.location.pathname, true);


### PR DESCRIPTION
clientLoader 每次都重新请求，可以通过以下简化后的 demo，看出来 listen callback 里面 clientLoaderData 永远是初始化数据。

```ts
import React, { useCallback, useEffect, useState } from 'react';
import { history } from 'umi';
export default () => {
  const [clientLoaderData, setClientLoaderData] = useState({});
  const handleRouteChange = useCallback(
    (id: string) => {
      console.log(clientLoaderData);
      setClientLoaderData({ id });
    },
    [clientLoaderData],
  );
  useEffect(() => {
    handleRouteChange('/');
    return history.listen((e) => {
      console.log('history.listen');
      handleRouteChange(e.location.pathname);
    });
  }, []);
  return (
    <>
      <div>clientLoaderData {JSON.stringify(clientLoaderData)}</div>
    </>
  );
};

```