### PR TITLE
feat: add `useSelectedRoutes`

### DIFF
--- a/docs/docs/api/api.md
+++ b/docs/docs/api/api.md
@@ -686,12 +686,13 @@ function App() {
 
 ### useSelectedRoutes
 
-用于读取当前路径命中的所有路由信息。比如在 `layout` 中可以获取到当前命中的所有子路由信息，同时可以获取到在 `routes` 配置中的参数，这格外有用。
+用于读取当前路径命中的所有路由信息。比如在 `layout` 布局中可以获取到当前命中的所有子路由信息，同时可以获取到在 `routes` 配置中的参数，这格外有用。
 
 实例：
 
 ```tsx
-// layout.ts
+// layouts/index.tsx
+
 import { useSelectedRoutes } from 'umi'
 
 export default function Layout() {

--- a/docs/docs/api/api.md
+++ b/docs/docs/api/api.md
@@ -684,6 +684,32 @@ function App() {
 }
 ```
 
+### useSelectedRoutes
+
+用于读取当前路径命中的所有路由信息。比如在 `layout` 中可以获取到当前命中的所有子路由信息，同时可以获取到在 `routes` 配置中的参数，这格外有用。
+
+实例：
+
+```tsx
+// layout.ts
+import { useSelectedRoutes } from 'umi'
+
+export default function Layout() {
+  const routes = useSelectedRoutes()
+  const lastRoute = routes.at(-1)
+
+  if (lastRoute?.pathname === '/some/path') {
+    return <div>1 : <Outlet /></div>
+  }
+
+  if (lastRoute?.extraProp) {
+    return <div>2 : <Outlet /></div>
+  }
+
+  return <Outlet />
+}
+```
+
 ### useSearchParams
 
 `useSearchParams` 用于读取和修改当前 URL 的 query string。类似 React 的 `useState`，其返回包含两个值的数组，当前 URL 的 search 参数和用于更新 search 参数的函数。

--- a/packages/renderer-react/src/appContext.ts
+++ b/packages/renderer-react/src/appContext.ts
@@ -6,6 +6,7 @@ import {
   IRouteComponents,
   IRoutesById,
 } from './types';
+import { useLocation, matchRoutes } from 'react-router-dom';
 
 interface IAppContextType {
   routes: IRoutesById;
@@ -26,6 +27,13 @@ export const AppContext = React.createContext<IAppContextType>(
 
 export function useAppData() {
   return React.useContext(AppContext);
+}
+
+export function useSelectedRoutes() {
+  const location = useLocation();
+  const { clientRoutes } = useAppData();
+  const routes = matchRoutes(clientRoutes, location.pathname);
+  return routes || [];
 }
 
 export function useServerLoaderData() {

--- a/packages/renderer-react/src/appContext.ts
+++ b/packages/renderer-react/src/appContext.ts
@@ -32,6 +32,7 @@ export function useAppData() {
 export function useSelectedRoutes() {
   const location = useLocation();
   const { clientRoutes } = useAppData();
+  // use `useLocation` get location without `basename`, not need `basename` param
   const routes = matchRoutes(clientRoutes, location.pathname);
   return routes || [];
 }

--- a/packages/renderer-react/src/index.ts
+++ b/packages/renderer-react/src/index.ts
@@ -26,6 +26,7 @@ export {
 export { Helmet } from 'react-helmet-async';
 export {
   useAppData,
+  useSelectedRoutes,
   useClientLoaderData,
   useServerLoaderData,
 } from './appContext';


### PR DESCRIPTION
多次遇到有人提问：

1. 如何获取 `routes` 的自定义参数

2. 如何在 layout 里条件渲染

3. 如何查看当前所有命中的路由

故新增 `useSelectedRoutes` 来解决这些问题。

命名灵感来自于 https://beta.nextjs.org/docs/api-reference/use-selected-layout-segments