### PR TITLE
chore: 🎨 jest.config.ts 增加可追踪性

### DIFF
--- a/packages/preset-umi/src/commands/generators/jest.ts
+++ b/packages/preset-umi/src/commands/generators/jest.ts
@@ -52,7 +52,7 @@ export default (api: IApi) => {
           }
         : basicDeps;
       h.addDevDeps(packageToInstall);
-      h.addScript('test', 'jest');
+      h.addScript('test', 'TS_NODE_TRANSPILE_ONLY=yes jest --passWithNoTests');
 
       const setupImports = res.willUseTLR
         ? [
@@ -91,20 +91,28 @@ export default (api: IApi) => {
 import { Config, configUmiAlias, createConfig } from '${importSource}/test';
 
 export default async () => {
-  return (await configUmiAlias({
-    ...createConfig({
-      target: 'browser',
-      jsTransformer: 'esbuild',
-      // config opts for esbuild , it will pass to esbuild directly
-      jsTransformerOpts: { jsx: 'automatic' },
-    }),
-    ${res.willUseTLR ? `setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],` : ''}
-    collectCoverageFrom: [
-${collectCoverageFrom.map((v) => `      '${v}'`).join(',\n')}
-    ],
-    // if you require some es-module npm package, please uncomment below line and insert your package name
-    // transformIgnorePatterns: ['node_modules/(?!.*(lodash-es|your-es-pkg-name)/)']
-  })) as Config.InitialOptions;
+  try{
+    return (await configUmiAlias({
+      ...createConfig({
+        target: 'browser',
+        jsTransformer: 'esbuild',
+        // config opts for esbuild , it will pass to esbuild directly
+        jsTransformerOpts: { jsx: 'automatic' },
+      }),
+    
+      ${
+        res.willUseTLR ? `setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],` : ''
+      }
+      collectCoverageFrom: [
+  ${collectCoverageFrom.map((v) => `      '${v}'`).join(',\n')}
+      ],
+      // if you require some es-module npm package, please uncomment below line and insert your package name
+      // transformIgnorePatterns: ['node_modules/(?!.*(lodash-es|your-es-pkg-name)/)']
+    })) as Config.InitialOptions;
+  }catch(e){
+    console.log(e);
+    throw e;
+  }
 };
 `.trimLeft(),
       );


### PR DESCRIPTION
why 

目前如果 jest.config.ts 中有错误，报错栈是在 jest 里面，不方便排查

![image](https://user-images.githubusercontent.com/415655/206470408-dede8b32-a467-4aff-9155-f2f4eec96481.png)

解：
如果配置升级有错，打印错误栈。
