### PR TITLE
chore(esbuild): set utf-8 charset for esbuild

### DIFF
--- a/packages/bundler-esbuild/src/build.ts
+++ b/packages/bundler-esbuild/src/build.ts
@@ -35,6 +35,7 @@ export async function build(opts: IOpts) {
   return await buildWithESBuild({
     entryPoints: opts.entry,
     bundle: true,
+    charset: 'utf8',
     format: opts.format || 'iife',
     logLevel: 'error',
     // splitting: true,

--- a/packages/bundler-esbuild/src/plugins/style.ts
+++ b/packages/bundler-esbuild/src/plugins/style.ts
@@ -108,7 +108,11 @@ export function style({
           namespace: inlineStyle ? 'style-content' : 'file',
         },
         async (args) => {
-          const options = { entryPoints: [args.path], ...opt };
+          const options: BuildOptions = {
+            entryPoints: [args.path],
+            charset: 'utf8',
+            ...opt,
+          };
           const { errors, warnings, outputFiles } = await esbuild.build(
             options,
           );

--- a/packages/bundler-utils/src/index.ts
+++ b/packages/bundler-utils/src/index.ts
@@ -15,6 +15,7 @@ export function parseModuleSync(opts: { content: string; path: string }) {
   if (opts.path.endsWith('.tsx') || opts.path.endsWith('.jsx')) {
     try {
       content = transformSync(content, {
+        charset: 'utf8',
         loader: extname(opts.path).slice(1) as Loader,
         format: 'esm',
       }).code;

--- a/packages/bundler-vite/src/plugins/svgr.ts
+++ b/packages/bundler-vite/src/plugins/svgr.ts
@@ -50,6 +50,7 @@ export default function svgrPlugin(
         }
 
         const result = await transform(componentCode, {
+          charset: 'utf8',
           loader: 'jsx',
           sourcefile: id,
           sourcemap: true,

--- a/packages/bundler-webpack/src/config/compressPlugin.ts
+++ b/packages/bundler-webpack/src/config/compressPlugin.ts
@@ -45,6 +45,7 @@ export async function addCompressPlugin(opts: IOpts) {
   if (jsMinifier === JSMinifier.esbuild) {
     minify = TerserPlugin.esbuildMinify;
     terserOptions = {
+      charset: 'utf8',
       target: esbuildTarget,
       // remove all comments
       legalComments: 'none',
@@ -87,6 +88,7 @@ export async function addCompressPlugin(opts: IOpts) {
   if (cssMinifier === CSSMinifier.esbuild) {
     cssMinify = CSSMinimizerWebpackPlugin.esbuildMinify;
     minimizerOptions = {
+      charset: 'utf8',
       target: esbuildTarget,
     } as EsbuildOpts;
   } else if (cssMinifier === CSSMinifier.cssnano) {

--- a/packages/bundler-webpack/src/loader/svgr.ts
+++ b/packages/bundler-webpack/src/loader/svgr.ts
@@ -14,6 +14,7 @@ const tranformSvg = callbackify(
   async (contents: string, options: Config, state: Partial<State>) => {
     const jsCode = await transform(contents, options, state);
     const result = await defaultEsbuildTransform(jsCode, {
+      charset: 'utf8',
       loader: 'tsx',
       target: 'es2015',
     });

--- a/packages/mfsu/src/dep/getModuleExports.ts
+++ b/packages/mfsu/src/dep/getModuleExports.ts
@@ -14,6 +14,7 @@ export async function getModuleExports({
   if (filePath && /\.(tsx|jsx)$/.test(filePath)) {
     content = (
       await transform(content, {
+        charset: 'utf8',
         sourcemap: false,
         sourcefile: filePath,
         format: 'esm',

--- a/packages/mfsu/src/loader/esbuild.ts
+++ b/packages/mfsu/src/loader/esbuild.ts
@@ -2,6 +2,7 @@ import { init, parse } from '@umijs/bundler-utils/compiled/es-module-lexer';
 import {
   Loader as EsbuildLoader,
   transform as transformInternal,
+  type TransformOptions,
 } from '@umijs/bundler-utils/compiled/esbuild';
 import { extname } from 'path';
 import type { LoaderContext } from 'webpack';
@@ -19,8 +20,9 @@ async function esbuildTranspiler(
   const filePath = this.resourcePath;
   const ext = extname(filePath).slice(1) as EsbuildLoader;
 
-  const transformOptions = {
+  const transformOptions: TransformOptions = {
     ...otherOptions,
+    charset: 'utf8',
     target: options.target ?? 'es2015',
     loader: ext ?? 'js',
     sourcemap: this.sourceMap,

--- a/packages/plugins/src/utils/modelUtils.ts
+++ b/packages/plugins/src/utils/modelUtils.ts
@@ -74,6 +74,7 @@ export class Model {
     // to reduce unexpected ast problem
     const loader = extname(this.file).slice(1) as Loader;
     const result = transformSync(content, {
+      charset: 'utf8',
       loader,
       sourcemap: false,
       minify: false,
@@ -180,6 +181,7 @@ export class ModelUtils {
     // to reduce unexpected ast problem
     const loader = extname(file).slice(1) as Loader;
     const result = transformSync(content, {
+      charset: 'utf8',
       loader,
       sourcemap: false,
       minify: false,

--- a/packages/preset-umi/src/features/apiRoute/dev-server/esbuild.ts
+++ b/packages/preset-umi/src/features/apiRoute/dev-server/esbuild.ts
@@ -12,6 +12,7 @@ export default async function (api: IApi, apiRoutes: IRoute[]) {
   );
 
   await esbuild.build({
+    charset: 'utf8',
     format: 'cjs',
     platform: 'node',
     bundle: true,

--- a/packages/preset-umi/src/features/apiRoute/vercel/esbuild.ts
+++ b/packages/preset-umi/src/features/apiRoute/vercel/esbuild.ts
@@ -13,6 +13,7 @@ export default async function (api: IApi, apiRoutes: IRoute[]) {
   const pkg = require(join(api.cwd, './package.json'));
 
   await esbuild.build({
+    charset: 'utf8',
     format: 'cjs',
     platform: 'node',
     bundle: true,

--- a/packages/preset-umi/src/features/clientLoader/clientLoader.ts
+++ b/packages/preset-umi/src/features/clientLoader/clientLoader.ts
@@ -43,6 +43,7 @@ ${clientLoaderDefines.join('\n')}
   // core/loader.js 会被 core/route.ts 引用，将每个 route 的 clientLoader 注入进去
   api.onBeforeCompiler(async () => {
     await esbuild.build({
+      charset: 'utf8',
       format: 'esm',
       platform: 'browser',
       target: 'esnext',

--- a/packages/preset-umi/src/features/mpa/extractExports.ts
+++ b/packages/preset-umi/src/features/mpa/extractExports.ts
@@ -5,6 +5,7 @@ export async function extractExports(opts: {
   exportName: string;
 }) {
   const res = await esbuild.build({
+    charset: 'utf8',
     format: 'cjs',
     platform: 'browser',
     target: 'esnext',

--- a/packages/preset-umi/src/features/ssr/builder/assets-loader.ts
+++ b/packages/preset-umi/src/features/ssr/builder/assets-loader.ts
@@ -1,4 +1,4 @@
-import esbuild from '@umijs/bundler-utils/compiled/esbuild';
+import type { Plugin } from '@umijs/bundler-utils/compiled/esbuild';
 import { winPath } from '@umijs/utils';
 import { existsSync, readFileSync, statSync } from 'fs';
 import { join } from 'path';
@@ -6,7 +6,7 @@ import { ensureLastSlash } from './css-loader';
 
 const NAMESPACE = 'staticAssets';
 
-export function assetsLoader(opts: { cwd: string }): esbuild.Plugin {
+export function assetsLoader(opts: { cwd: string }): Plugin {
   const assetsFilter = /\.(png|jpg|jpeg|gif|woff|woff2|ttf|eot|mp3|mp4)$/;
   return {
     name: 'assets-loader',

--- a/packages/preset-umi/src/features/ssr/builder/builder.ts
+++ b/packages/preset-umi/src/features/ssr/builder/builder.ts
@@ -16,6 +16,7 @@ export async function build(opts: { api: IApi; watch?: boolean }) {
   // TODO: 支持通用的 alias
   // TODO: external all import from package.json.dependencies
   await esbuild.build({
+    charset: 'utf8',
     format: 'cjs',
     platform: 'node',
     target: 'esnext',

--- a/packages/preset-umi/src/features/ssr/builder/css-loader.ts
+++ b/packages/preset-umi/src/features/ssr/builder/css-loader.ts
@@ -1,4 +1,4 @@
-import esbuild from '@umijs/bundler-utils/compiled/esbuild';
+import type { Plugin } from '@umijs/bundler-utils/compiled/esbuild';
 import { parcelCSS } from '@umijs/bundler-webpack/dist/parcelCSS';
 import { winPath } from '@umijs/utils';
 import { readFileSync } from 'fs';
@@ -30,7 +30,7 @@ export function getClassNames(code: Buffer, filename: string) {
   return Object.keys(exports || {});
 }
 
-export function cssLoader(opts: { cwd: string }): esbuild.Plugin {
+export function cssLoader(opts: { cwd: string }): Plugin {
   return {
     name: 'css-loader',
     setup(build) {

--- a/packages/preset-umi/src/features/ssr/builder/less-loader.ts
+++ b/packages/preset-umi/src/features/ssr/builder/less-loader.ts
@@ -1,4 +1,7 @@
-import esbuild, { PartialMessage } from '@umijs/bundler-utils/compiled/esbuild';
+import type {
+  PartialMessage,
+  Plugin,
+} from '@umijs/bundler-utils/compiled/esbuild';
 import less from '@umijs/bundler-utils/compiled/less';
 import { winPath } from '@umijs/utils';
 import { readFileSync } from 'fs';
@@ -8,7 +11,7 @@ import { ensureLastSlash, getClassNames, hashString } from './css-loader';
 export const lessLoader = (opts: {
   cwd: string;
   lessOptions?: Less.Options;
-}): esbuild.Plugin => {
+}): Plugin => {
   const { lessOptions = {} } = opts;
   return {
     name: 'less-loader',

--- a/packages/preset-umi/src/features/ssr/builder/svg-loader.ts
+++ b/packages/preset-umi/src/features/ssr/builder/svg-loader.ts
@@ -1,9 +1,9 @@
-import esbuild from '@umijs/bundler-utils/compiled/esbuild';
+import type { Plugin } from '@umijs/bundler-utils/compiled/esbuild';
 import { readFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 
 // esbuild plugin for umi.server.js bundler to handle svg assets
-function svgLoader(opts: { cwd: string }): esbuild.Plugin {
+function svgLoader(opts: { cwd: string }): Plugin {
   opts;
   return {
     name: 'svg-loader',

--- a/packages/preset-umi/src/libs/folderCache/AutoUpdateSourceCodeCache.ts
+++ b/packages/preset-umi/src/libs/folderCache/AutoUpdateSourceCodeCache.ts
@@ -85,6 +85,7 @@ export class AutoUpdateSrcCodeCache {
       await esBuild({
         entryPoints: files,
         bundle: false,
+        charset: 'utf8',
         outdir: this.cachePath,
         outbase: this.srcPath,
         loader: {

--- a/packages/preset-umi/src/libs/folderCache/LazySourceCodeCache.ts
+++ b/packages/preset-umi/src/libs/folderCache/LazySourceCodeCache.ts
@@ -182,6 +182,7 @@ async function esbuildTransform(
     await esBuild({
       entryPoints: files,
       bundle: false,
+      charset: 'utf8',
       outdir: opts.cachePath,
       outbase: opts.srcPath,
       loader: {

--- a/packages/preset-umi/src/libs/scan.ts
+++ b/packages/preset-umi/src/libs/scan.ts
@@ -67,6 +67,7 @@ export async function getContent(path: string) {
   // es-module-lexer don't support jsx
   if (path.endsWith('.tsx') || path.endsWith('.jsx')) {
     content = transformSync(content, {
+      charset: 'utf8',
       loader: extname(path).slice(1) as Loader,
       format: 'esm',
     }).code;

--- a/packages/testing/src/transformers/esbuild/index.ts
+++ b/packages/testing/src/transformers/esbuild/index.ts
@@ -70,6 +70,7 @@ const createTransformer = (
       const result = transformSync(rawCode, {
         ...options,
         ...(config.globals['jest-esbuild'] as UserOptions),
+        charset: 'utf8',
         loader: userOptions.loader || (extname(path).slice(1) as Loader),
         sourcefile: path,
         sourcesContent: false,


### PR DESCRIPTION
原因：esbuild 默认 ascii 编码产物会非常大。

See https://github.com/vitejs/vite/pull/10753