### PR TITLE
fix: mfsu cache invalid when define changes

### DIFF
--- a/packages/bundler-webpack/src/dev.ts
+++ b/packages/bundler-webpack/src/dev.ts
@@ -87,6 +87,7 @@ export async function dev(opts: IOpts) {
           theme: opts.config.theme,
           runtimePublicPath: opts.config.runtimePublicPath,
           publicPath: opts.config.publicPath,
+          define: opts.config.define,
         });
       },
       startBuildWorker: opts.startBuildWorker!,


### PR DESCRIPTION
昨天群里的问题，在插件里修改 `define` 时，mfsu 的缓存不会失效，导致还是上一次的数据。