### PR TITLE
fix(esbuild): css file inline image url loader

### DIFF
--- a/packages/bundler-esbuild/src/plugins/style.ts
+++ b/packages/bundler-esbuild/src/plugins/style.ts
@@ -46,9 +46,20 @@ export function style({
         charset,
         minify,
         loader: {
+          // images
           '.svg': 'dataurl',
-          // file ?
+          '.png': 'dataurl',
+          '.jpg': 'dataurl',
+          '.jpeg': 'dataurl',
+          '.gif': 'dataurl',
+          '.ico': 'dataurl',
+          '.webp': 'dataurl',
+          // font
           '.ttf': 'dataurl',
+          '.otf': 'dataurl',
+          '.woff': 'dataurl',
+          '.woff2': 'dataurl',
+          '.eot': 'dataurl',
         },
       };
 


### PR DESCRIPTION
close #10023

在 css 文件内使用内联图片的类型 loader ，需要补全一下。