### PR TITLE
fix: 修复MicroAppWithMemoHistory切换子应用history不符合预期的问题

### DIFF
--- a/packages/plugins/libs/qiankun/master/MicroAppWithMemoHistory.tsx
+++ b/packages/plugins/libs/qiankun/master/MicroAppWithMemoHistory.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck
 /* eslint-disable */
 
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { MicroApp, Props as MicroAppProps } from './MicroApp';
 
 export interface Props extends MicroAppProps {
@@ -10,6 +10,7 @@ export interface Props extends MicroAppProps {
 
 export function MicroAppWithMemoHistory(componentProps: Props) {
   const { url, ...rest } = componentProps;
+  const [name, setName] = useState(componentProps.name);
   const history = useRef();
   // url 的变更不会透传给下游，组件内自己会处理掉，所以这里直接用 ref 来存
   const historyOpts = useRef({
@@ -20,6 +21,14 @@ export function MicroAppWithMemoHistory(componentProps: Props) {
   const historyInitHandler = useCallback((h) => (history.current = h), []);
 
   useEffect(() => {
+    // reset the history when name changed
+    historyOpts.current.initialEntries = [url];
+    historyOpts.current.initialIndex = 1;
+    history.current = undefined;
+    setName(componentProps.name);
+  }, [componentProps.name]);
+
+  useEffect(() => {
     // push history for slave app when url property changed
     // the initial url will be ignored because the history has not been initialized
     if (history.current && url) {
@@ -27,15 +36,10 @@ export function MicroAppWithMemoHistory(componentProps: Props) {
     }
   }, [url]);
 
-  useEffect(() => {
-    // reset the history when name changed
-    historyOpts.current.initialEntries = [url];
-    historyOpts.current.initialIndex = 1;
-  }, [componentProps.name]);
-
   return (
     <MicroApp
       {...rest}
+      name={name}
       history={historyOpts.current}
       onHistoryInit={historyInitHandler}
     />


### PR DESCRIPTION
原逻辑在 useEffect 中处理 historyOpts 晚于 historyOpts 传递给子应用的时机，导致修改无效。 新逻辑添加 name state，通过在 useEffect 中 change name 来触发子应用的更新以使 historyOpts 的变更符合预期。