### PR TITLE
fix(bundler-webpack type): wrong srcTranspiler type

### DIFF
--- a/packages/bundler-webpack/src/types.ts
+++ b/packages/bundler-webpack/src/types.ts
@@ -91,7 +91,7 @@ export interface IConfig {
   publicPath?: string;
   purgeCSS?: { [key: string]: any };
   sassLoader?: { [key: string]: any };
-  srcTranspiler?: Transpiler;
+  srcTranspiler?: `${Transpiler}`;
   styleLoader?: { [key: string]: any };
   svgr?: { [key: string]: any };
   svgo?: { [key: string]: any } | false;


### PR DESCRIPTION
srcTranspiler类型错误导致配置的时候srcTranspiler类型提示为undefined