### PR TITLE
fix(esbuild): `import.meta.x` parsed name undefined

### DIFF
--- a/packages/utils/src/isStyleFile.ts
+++ b/packages/utils/src/isStyleFile.ts
@@ -16,5 +16,5 @@ export const isStyleFile = ({
   filename?: string;
   ext?: string;
 }) => {
-  return AUTO_CSS_MODULE_EXTS.includes(ext || extname(filename!));
+  return filename && AUTO_CSS_MODULE_EXTS.includes(ext || extname(filename));
 };


### PR DESCRIPTION
vite 兼容引入的 `import.meta.xxx` 会导致 es-module-lexer 解析到 `undefined` 的 import 。

fix #10144