### PR TITLE
fix: 修复errorThrower无效的问题

### DIFF
--- a/packages/plugins/src/request.ts
+++ b/packages/plugins/src/request.ts
@@ -195,10 +195,9 @@ const getRequestInstance = (): AxiosInstance => {
        requestInstance.interceptors.response.use(interceptor);
   });
 
-  // 当响应的数据 success 是 false 的时候，抛出 error 以供 errorHandler 处理。
   requestInstance.interceptors.response.use((response) => {
     const { data } = response;
-    if(data?.success === false && config?.errorConfig?.errorThrower){
+    if(config?.errorConfig?.errorThrower){
       config.errorConfig.errorThrower(data);
     }
     return response;


### PR DESCRIPTION
这里对响应体的判断非常无厘头，这是一个通用的框架，为何要默认后端返回的响应里要有`success `?

```typescript
if(data?.success === false && config?.errorConfig?.errorThrower){
```


这样做会导致那些后端返回的格式不按照这个**隐性设定** 来的玩儿家`errorThrower`失效，也会导致多执行对`success`判断的无效逻辑，强行给按上了一个没有任何作用的 `reponse interceptor`

这多不美呀，还是去掉罢