### PR TITLE
fix(mfsu): fix a cache failure caused by the getCacheDependency content containing a function

### DIFF
--- a/packages/bundler-webpack/src/dev.ts
+++ b/packages/bundler-webpack/src/dev.ts
@@ -36,7 +36,7 @@ type IOpts = {
   onBeforeMiddleware?: Function;
 } & Pick<IConfigOpts, 'cache' | 'pkg'>;
 
-export function ensureSafeValue(obj: any) {
+export function ensureSerializableValue(obj: any) {
   return JSON.parse(
     JSON.stringify(
       obj,
@@ -85,7 +85,7 @@ export async function dev(opts: IOpts) {
       remoteAliases: opts.config.mfsu?.remoteAliases,
       remoteName: opts.config.mfsu?.remoteName,
       getCacheDependency() {
-        return ensureSafeValue({
+        return ensureSerializableValue({
           version: require('../package.json').version,
           mfsu: opts.config.mfsu,
           alias: opts.config.alias,

--- a/packages/bundler-webpack/src/dev.ts
+++ b/packages/bundler-webpack/src/dev.ts
@@ -36,13 +36,19 @@ type IOpts = {
   onBeforeMiddleware?: Function;
 } & Pick<IConfigOpts, 'cache' | 'pkg'>;
 
-export function stripUndefined(obj: any) {
-  Object.keys(obj).forEach((key) => {
-    if (obj[key] === undefined) {
-      delete obj[key];
-    }
-  });
-  return obj;
+export function ensureSafeValue(obj: any) {
+  return JSON.parse(
+    JSON.stringify(
+      obj,
+      (_key, value) => {
+        if (typeof value === 'function') {
+          return value.toString();
+        }
+        return value;
+      },
+      2,
+    ),
+  );
 }
 
 export async function dev(opts: IOpts) {
@@ -79,7 +85,7 @@ export async function dev(opts: IOpts) {
       remoteAliases: opts.config.mfsu?.remoteAliases,
       remoteName: opts.config.mfsu?.remoteName,
       getCacheDependency() {
-        return stripUndefined({
+        return ensureSafeValue({
           version: require('../package.json').version,
           mfsu: opts.config.mfsu,
           alias: opts.config.alias,

--- a/packages/mfsu/src/depInfo.ts
+++ b/packages/mfsu/src/depInfo.ts
@@ -41,12 +41,11 @@ export class DepInfo implements IDepInfo {
   }
 
   shouldBuild() {
-    if (
-      !lodash.isEqual(
-        this.cacheDependency,
-        this.opts.mfsu.opts.getCacheDependency!(),
-      )
-    ) {
+    // 写缓存时 会忽略 function 类型, 这里 处理逻辑变成和缓存前处理一直, 否则缓存永远无法命中
+    const cacheDependency = JSON.parse(
+      JSON.stringify(this.opts.mfsu.opts.getCacheDependency!(), null, 2),
+    );
+    if (!lodash.isEqual(this.cacheDependency, cacheDependency)) {
       return 'cacheDependency has changed';
     }
 

--- a/packages/mfsu/src/depInfo.ts
+++ b/packages/mfsu/src/depInfo.ts
@@ -41,11 +41,12 @@ export class DepInfo implements IDepInfo {
   }
 
   shouldBuild() {
-    // 写缓存时 会忽略 function 类型, 这里 处理逻辑变成和缓存前处理一直, 否则缓存永远无法命中
-    const cacheDependency = JSON.parse(
-      this.stringify(this.opts.mfsu.opts.getCacheDependency!()),
-    );
-    if (!lodash.isEqual(this.cacheDependency, cacheDependency)) {
+    if (
+      !lodash.isEqual(
+        this.cacheDependency,
+        this.opts.mfsu.opts.getCacheDependency!(),
+      )
+    ) {
       return 'cacheDependency has changed';
     }
 
@@ -56,23 +57,8 @@ export class DepInfo implements IDepInfo {
     return false;
   }
 
-  stringify(val: Record<string, any>) {
-    return JSON.stringify(
-      val,
-      (_key, value) => {
-        if (typeof value === 'function') {
-          return value.toString();
-        }
-        return value;
-      },
-      2,
-    );
-  }
-
   snapshot() {
-    this.cacheDependency = JSON.parse(
-      this.stringify(this.opts.mfsu.opts.getCacheDependency!()),
-    );
+    this.cacheDependency = this.opts.mfsu.opts.getCacheDependency!();
     this.moduleGraph.snapshotDeps();
   }
 
@@ -97,11 +83,14 @@ export class DepInfo implements IDepInfo {
 
   writeCache() {
     fsExtra.mkdirpSync(dirname(this.cacheFilePath));
-    const newContent = this.stringify({
-      cacheDependency: this.cacheDependency,
-      moduleGraph: this.moduleGraph.toJSON(),
-    });
-
+    const newContent = JSON.stringify(
+      {
+        cacheDependency: this.cacheDependency,
+        moduleGraph: this.moduleGraph.toJSON(),
+      },
+      null,
+      2,
+    );
     if (
       existsSync(this.cacheFilePath) &&
       readFileSync(this.cacheFilePath, 'utf-8') === newContent


### PR DESCRIPTION
修复 getCacheDependency 内容包含 function 导致的缓存失效

mfsu 可以通过 `chainWebpack` 配置额外的 webpack 配置,  写缓存文件时 会忽略 function 导致缓存结果与实际配置永远不相等, 触发重新编译

