### PR TITLE
feat: ✨ 支持 external 为 function，函数接口和 webpack 对齐

### DIFF
--- a/packages/mfsu/src/babelPlugins/awaitImport/isExternals.ts
+++ b/packages/mfsu/src/babelPlugins/awaitImport/isExternals.ts
@@ -28,9 +28,20 @@ export function isExternal({
     return !!external[value];
   } else if (typeof external === 'function') {
     let ret = false;
-    external({}, value, (_: any, b: any) => {
-      ret = !!b;
-    });
+    external(
+      {
+        __mfsu: true,
+        context: '',
+        request: value,
+        contextInfo: {
+          issuer: '',
+        },
+        dependencyType: 'esm',
+      },
+      (_error: any, result: any) => {
+        ret = !!result;
+      },
+    );
     return ret;
   } else {
     return false;


### PR DESCRIPTION
但是 mfsu 调用 external 函数时 已经没有很多上下文信息，增加 __mfsu 来表明调用 来自 mfsu，做实现的兼容；
目前只能支持同步的 external。

```ts
function ({ context, request, contextInfo, getResolve }, callback)
```

ref: https://webpack.js.org/configuration/externals/#function