### PR TITLE
fix(ssr): corejs polyfill not available in nodejs

### DIFF
--- a/packages/preset-umi/templates/TestBrowser.tpl
+++ b/packages/preset-umi/templates/TestBrowser.tpl
@@ -6,7 +6,6 @@ import { createPluginManager } from './core/plugin';
 import { getRoutes } from './core/route';
 import type { Location } from 'history';
 
-{{{ polyfillImports }}}
 {{{ importsAhead }}}
 const publicPath = '/';
 const runtimePublicPath = false;


### PR DESCRIPTION
去掉 `<TestBrowser />` 的 polyfill 。

#### 原因

`<TestBrowser />` 带来了一个 `./core/polyill` 的入口，导致 ssr 在开发时会把这部分 corejs 的 polyfill 打包进去。

但是 core-js 含有在 nodejs 里无法使用的 polyfill （这里是 `core-js/modules/web.dom-exception.stack.js` ），导致 ssr 没法用了，类似的问题见 https://github.com/vuejs/vuepress/issues/3065 。

另外 `<TestBrowser />` 在本地 nodejs 里测试用，不需要 polyfill 。
