### PR TITLE
refactor: better import from fs/promises

### DIFF
--- a/codemod/src/prepare.ts
+++ b/codemod/src/prepare.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import fg from 'fast-glob';
-import { existsSync, promises as fs } from 'fs';
+import { existsSync } from 'fs';
+import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { build } from './configBuilder';
 
@@ -50,7 +51,7 @@ export async function prepare(opts: { cwd: string; pattern: any; args?: any }) {
   const fileCache = new Map<string, string>();
   await Promise.all(
     files.map(async (file) => {
-      fileCache.set(file, await fs.readFile(join(opts.cwd, file), 'utf8'));
+      fileCache.set(file, await readFile(join(opts.cwd, file), 'utf8'));
     }),
   );
 

--- a/packages/bundler-esbuild/src/plugins/less.ts
+++ b/packages/bundler-esbuild/src/plugins/less.ts
@@ -1,7 +1,7 @@
 import { Plugin } from '@umijs/bundler-utils/compiled/esbuild';
 import less from '@umijs/bundler-utils/compiled/less';
 import enhancedResolve from 'enhanced-resolve';
-import { promises as fs } from 'fs';
+import { readFile } from 'fs/promises';
 import path from 'path';
 import { IConfig } from '../types';
 import { postcssProcess } from '../utils/postcssProcess';
@@ -145,7 +145,7 @@ export default (
       onLoad(
         { filter: /\.less$/, namespace: inlineStyle ? 'less-content' : 'file' },
         async (args) => {
-          let content = await fs.readFile(args.path, 'utf-8');
+          let content = await readFile(args.path, 'utf-8');
           if (!!alias) {
             content = await aliasLessImports(content, alias, args.path);
           }


### PR DESCRIPTION
## Description
node v14 added a simpler import path for fs promises: fs/promises
