### PR TITLE
fix: 🐛  mfsu 错误的去读取通过 npm link 过的包的源码文件

### DIFF
--- a/packages/mfsu/src/mfsu/strategyStaticAnalyze.ts
+++ b/packages/mfsu/src/mfsu/strategyStaticAnalyze.ts
@@ -130,18 +130,18 @@ export class StaticAnalyzeStrategy implements IMFSUStrategy {
           c.removedFiles,
         );
 
-        const cwd = this.mfsu.opts.cwd!;
+        const srcPath = this.staticDepInfo.opts.srcCodeCache.getSrcPath();
 
         const fileEvents = [
           ...this.staticDepInfo.opts.srcCodeCache.replayChangeEvents(),
 
-          ...extractJSCodeFiles(cwd, c.modifiedFiles).map((f) => {
+          ...extractJSCodeFiles(srcPath, c.modifiedFiles).map((f) => {
             return {
               event: 'change' as const,
               path: f,
             };
           }),
-          ...extractJSCodeFiles(cwd, c.removedFiles).map((f) => {
+          ...extractJSCodeFiles(srcPath, c.removedFiles).map((f) => {
             return {
               event: 'unlink' as const,
               path: f,
@@ -191,7 +191,11 @@ function extractJSCodeFiles(folderBase: string, files: ReadonlySet<string>) {
   }
 
   for (let file of files.values()) {
-    if (file.startsWith(folderBase) && REG_CODE_EXT.test(file)) {
+    if (
+      file.startsWith(folderBase) &&
+      REG_CODE_EXT.test(file) &&
+      file.indexOf('node_modules') === -1
+    ) {
       jsFiles.push(file);
     }
   }

--- a/packages/mfsu/src/staticDepInfo/staticDepInfo.ts
+++ b/packages/mfsu/src/staticDepInfo/staticDepInfo.ts
@@ -24,6 +24,7 @@ type AutoUpdateSrcCodeCache = {
   getMergedCode(): MergedCodeInfo;
   handleFileChangeEvents(events: FileChangeEvent[]): void;
   replayChangeEvents(): FileChangeEvent[];
+  getSrcPath(): string;
 };
 
 interface IOpts {

--- a/packages/preset-umi/src/libs/folderCache/LazySourceCodeCache.ts
+++ b/packages/preset-umi/src/libs/folderCache/LazySourceCodeCache.ts
@@ -56,6 +56,10 @@ export class LazySourceCodeCache {
     await this.loadFiles(files);
   }
 
+  getSrcPath() {
+    return this.srcPath;
+  }
+
   public async loadFiles(files: string[]) {
     const loaded = await this.filesLoader(files);
 


### PR DESCRIPTION
### why

如果  `npm link   ../pkg_a_src`,  修改 pkg_a_src 下的内容，期望 mfsu eager 不用加载和分析这个改动的文件的。

由于 webpack 的 bug ，会出发两个文件修改的事件 
1.   ./node_modules/pkg_a/src/index.ts （未过滤）
2.  ../pkg_a/src/index.ts  （过滤不关注）

未过滤的文件，fileCache 会加载失败


