### PR TITLE
fix(server): specific script type not working for vite mode

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -66,11 +66,14 @@ export async function getMarkup(
       props: script,
       filters: ['src', 'content'],
     });
+    // allow specific type from config
+    const isEsmScript = opts.esmScript && !('type' in script);
+
     return script.src
-      ? `<script${opts.esmScript ? ' type="module"' : ''} ${attrs} src="${
+      ? `<script${isEsmScript ? ' type="module"' : ''} ${attrs} src="${
           script.src
         }"></script>`
-      : `<script${opts.esmScript ? ' type="module"' : ''} ${attrs}>${
+      : `<script${isEsmScript ? ' type="module"' : ''} ${attrs}>${
           script.content
         }</script>`;
   }


### PR DESCRIPTION
修复在 Vite 模式下无法指定 script type 的 bug

背景：燕鸥场景下会插入一个 `type="tern-app-config"` 的 script，这个 script 会交给燕鸥服务端生成最终的 `tern-site-config`，如果标记为 `module` 就会被 Vite 处理成远程的临时 js，导致原有功能失效