### PR TITLE
Revert "fix: 🐛  mfsu 错误的去读取通过 npm link 过的包的源码文件"

### DIFF
--- a/packages/mfsu/src/mfsu/strategyStaticAnalyze.ts
+++ b/packages/mfsu/src/mfsu/strategyStaticAnalyze.ts
@@ -130,18 +130,18 @@ export class StaticAnalyzeStrategy implements IMFSUStrategy {
           c.removedFiles,
         );
 
-        const srcPath = this.staticDepInfo.opts.srcCodeCache.getSrcPath();
+        const cwd = this.mfsu.opts.cwd!;
 
         const fileEvents = [
           ...this.staticDepInfo.opts.srcCodeCache.replayChangeEvents(),
 
-          ...extractJSCodeFiles(srcPath, c.modifiedFiles).map((f) => {
+          ...extractJSCodeFiles(cwd, c.modifiedFiles).map((f) => {
             return {
               event: 'change' as const,
               path: f,
             };
           }),
-          ...extractJSCodeFiles(srcPath, c.removedFiles).map((f) => {
+          ...extractJSCodeFiles(cwd, c.removedFiles).map((f) => {
             return {
               event: 'unlink' as const,
               path: f,
@@ -191,11 +191,7 @@ function extractJSCodeFiles(folderBase: string, files: ReadonlySet<string>) {
   }
 
   for (let file of files.values()) {
-    if (
-      file.startsWith(folderBase) &&
-      REG_CODE_EXT.test(file) &&
-      file.indexOf('node_modules') === -1
-    ) {
+    if (file.startsWith(folderBase) && REG_CODE_EXT.test(file)) {
       jsFiles.push(file);
     }
   }

--- a/packages/mfsu/src/staticDepInfo/staticDepInfo.ts
+++ b/packages/mfsu/src/staticDepInfo/staticDepInfo.ts
@@ -24,7 +24,6 @@ type AutoUpdateSrcCodeCache = {
   getMergedCode(): MergedCodeInfo;
   handleFileChangeEvents(events: FileChangeEvent[]): void;
   replayChangeEvents(): FileChangeEvent[];
-  getSrcPath(): string;
 };
 
 interface IOpts {

--- a/packages/preset-umi/src/libs/folderCache/LazySourceCodeCache.ts
+++ b/packages/preset-umi/src/libs/folderCache/LazySourceCodeCache.ts
@@ -56,10 +56,6 @@ export class LazySourceCodeCache {
     await this.loadFiles(files);
   }
 
-  getSrcPath() {
-    return this.srcPath;
-  }
-
   public async loadFiles(files: string[]) {
     const loaded = await this.filesLoader(files);
 


### PR DESCRIPTION
Reverts umijs/umi#10194