### PR TITLE
Revert "Revert "fix: 🐛  mfsu 错误的去读取通过 npm link 过的包的源码文件 (#10194)" (#1…

### DIFF
--- a/packages/mfsu/src/mfsu/strategyStaticAnalyze.ts
+++ b/packages/mfsu/src/mfsu/strategyStaticAnalyze.ts
@@ -130,18 +130,18 @@ export class StaticAnalyzeStrategy implements IMFSUStrategy {
           c.removedFiles,
         );
 
-        const cwd = this.mfsu.opts.cwd!;
+        const srcPath = this.staticDepInfo.opts.srcCodeCache.getSrcPath();
 
         const fileEvents = [
           ...this.staticDepInfo.opts.srcCodeCache.replayChangeEvents(),
 
-          ...extractJSCodeFiles(cwd, c.modifiedFiles).map((f) => {
+          ...extractJSCodeFiles(srcPath, c.modifiedFiles).map((f) => {
             return {
               event: 'change' as const,
               path: f,
             };
           }),
-          ...extractJSCodeFiles(cwd, c.removedFiles).map((f) => {
+          ...extractJSCodeFiles(srcPath, c.removedFiles).map((f) => {
             return {
               event: 'unlink' as const,
               path: f,
@@ -191,7 +191,11 @@ function extractJSCodeFiles(folderBase: string, files: ReadonlySet<string>) {
   }
 
   for (let file of files.values()) {
-    if (file.startsWith(folderBase) && REG_CODE_EXT.test(file)) {
+    if (
+      file.startsWith(folderBase) &&
+      REG_CODE_EXT.test(file) &&
+      file.indexOf('node_modules') === -1
+    ) {
       jsFiles.push(file);
     }
   }

--- a/packages/mfsu/src/staticDepInfo/staticDepInfo.ts
+++ b/packages/mfsu/src/staticDepInfo/staticDepInfo.ts
@@ -24,6 +24,7 @@ type AutoUpdateSrcCodeCache = {
   getMergedCode(): MergedCodeInfo;
   handleFileChangeEvents(events: FileChangeEvent[]): void;
   replayChangeEvents(): FileChangeEvent[];
+  getSrcPath(): string;
 };
 
 interface IOpts {

--- a/packages/preset-umi/src/libs/folderCache/LazySourceCodeCache.ts
+++ b/packages/preset-umi/src/libs/folderCache/LazySourceCodeCache.ts
@@ -56,6 +56,10 @@ export class LazySourceCodeCache {
     await this.loadFiles(files);
   }
 
+  getSrcPath() {
+    return this.srcPath;
+  }
+
   public async loadFiles(files: string[]) {
     const loaded = await this.filesLoader(files);
 


### PR DESCRIPTION
…0196)"

This reverts commit 6086f4ae89fd4d56156dd2587e617e4102be0c1f.

e2e  case 覆盖了这个场景 

https://github.com/umijs/umi/blob/7afa4330bde3bae798ca086ed62bdabf9a2b940b/examples/mfsu-e2e/cypress/e2e/smoke.cy.ts#L25-L38
