### PR TITLE
fix(route): catch inner error instead of interrupting service (#7821)

### DIFF
--- a/packages/core/src/Route/Route.ts
+++ b/packages/core/src/Route/Route.ts
@@ -34,16 +34,12 @@ class Route {
     let isConventional = false;
     if (!routes) {
       assert(root, `opts.root must be supplied for conventional routes.`);
-      try {
-        routes = this.getConventionRoutes({
-          root: root!,
-          config,
-          componentPrefix,
-        });
-        isConventional = true;
-      } catch (err) {
-        console.error(err);
-      }
+      routes = this.getConventionRoutes({
+        root: root!,
+        config,
+        componentPrefix,
+      });
+      isConventional = true;
     }
     await this.patchRoutes(routes, {
       ...opts,

--- a/packages/core/src/Route/Route.ts
+++ b/packages/core/src/Route/Route.ts
@@ -30,16 +30,20 @@ class Route {
   async getRoutes(opts: IGetRoutesOpts) {
     const { config, root, componentPrefix } = opts;
     // 避免修改配置里的 routes，导致重复 patch
-    let routes = lodash.cloneDeep(config.routes);
+    let routes: IRoute[] = lodash.cloneDeep(config.routes);
     let isConventional = false;
     if (!routes) {
       assert(root, `opts.root must be supplied for conventional routes.`);
-      routes = this.getConventionRoutes({
-        root: root!,
-        config,
-        componentPrefix,
-      });
-      isConventional = true;
+      try {
+        routes = this.getConventionRoutes({
+          root: root!,
+          config,
+          componentPrefix,
+        });
+        isConventional = true;
+      } catch (err) {
+        console.error(err);
+      }
     }
     await this.patchRoutes(routes, {
       ...opts,

--- a/packages/core/src/Route/getConventionalRoutes.ts
+++ b/packages/core/src/Route/getConventionalRoutes.ts
@@ -44,9 +44,11 @@ function getFiles(root: string) {
       try {
         if (!isReactComponent(content)) return false;
       } catch (e) {
-        throw new Error(
-          `Parse conventional route component ${absFile} failed, ${e.message}`,
+        // 由 friendly-errors-webpack-plugin 统一处理编译错误信息
+        console.error(
+          `Parse conventional route component ${absFile} failed: ${e.message}`,
         );
+        return true;
       }
     }
     return true;
@@ -100,14 +102,14 @@ function fileToRouteReducer(opts: IOpts, memo: IRoute[], file: string) {
   return memo;
 }
 
-function normalizeRoute(route: IRoute, opts: IOpts) {
+function normalizeRoute(route: IRoute, opts: IOpts): IRoute {
   let props: unknown = undefined;
   if (route.component) {
     try {
       props = getExportProps(readFileSync(route.component, 'utf-8'));
     } catch (e) {
-      throw new Error(
-        `Parse conventional route component ${route.component} failed, ${e.message}`,
+      console.error(
+        `Export props from route component ${route.component} failed: ${e.message}`,
       );
     }
     route.component = winPath(relative(join(opts.root, '..'), route.component));
@@ -188,7 +190,7 @@ function normalizeRoutes(routes: IRoute[]): IRoute[] {
   );
 }
 
-export default function getRoutes(opts: IOpts) {
+export default function getRoutes(opts: IOpts): IRoute[] {
   const { root, relDir = '', config } = opts;
   const files = getFiles(join(root, relDir));
   const routes = normalizeRoutes(

--- a/packages/core/src/Route/getConventionalRoutes.ts
+++ b/packages/core/src/Route/getConventionalRoutes.ts
@@ -44,10 +44,11 @@ function getFiles(root: string) {
       try {
         if (!isReactComponent(content)) return false;
       } catch (e) {
+        // console.error(
+        //   `Parse conventional route component ${absFile} failed: ${e.message}`,
+        // );
+
         // 由 friendly-errors-webpack-plugin 统一处理编译错误信息
-        console.error(
-          `Parse conventional route component ${absFile} failed: ${e.message}`,
-        );
         return true;
       }
     }
@@ -108,9 +109,10 @@ function normalizeRoute(route: IRoute, opts: IOpts): IRoute {
     try {
       props = getExportProps(readFileSync(route.component, 'utf-8'));
     } catch (e) {
-      console.error(
-        `Export props from route component ${route.component} failed: ${e.message}`,
-      );
+      // console.error(
+      //   `Export props from route component ${route.component} failed: ${e.message}`,
+      // );
+      props = undefined;
     }
     route.component = winPath(relative(join(opts.root, '..'), route.component));
     route.component = `${opts.componentPrefix || '@/'}${route.component}`;


### PR DESCRIPTION
## 问题

Due to #7821

![image](https://user-images.githubusercontent.com/42314340/210737049-ec64c7ce-2daa-464f-aa13-28d15373af98.png)

Umi 3.x 版本：路由文件编译报错时，会直接中断本地服务。此时需要用户修改报错，并重新启用开发模式。

而普通组件文件编译报错时，只会打印出错误信息，不会中断本地服务。

## 修复

https://user-images.githubusercontent.com/42314340/210760110-7c5442ea-b39f-4e83-a076-600b2afa1445.mov

此 PR 修复了该问题，现在路由文件编译报错时，只会打印出报错信息（由 `friendly-errors-webpack-plugin` 处理），不会中断本地服务。待用户修复报错问题时，恢复正常状态。