### PR TITLE
feat: add name and originPath for createServerRoute

### DIFF
--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -27,7 +27,8 @@ export function createServerRoute(opts: { route: IRoute }) {
   const { route } = opts;
   return {
     id: route.id,
-    path: route.path,
+    path: route.path || route.originPath,
     index: route.index,
+    name: route.name,
   };
 }

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -3,6 +3,8 @@ export interface IRoute {
   path?: string;
   index?: boolean;
   parentId?: string;
+  name?: string;
+  originPath?: string;
 }
 
 export interface IRoutesById {


### PR DESCRIPTION
提供给 雨燕/TernAdmin 部署时使用，生成 tern.json 文件中 routes 缺少 name 属性，当路由中声明了 wrappers 时，会给当前的路由增加一层嵌套路由， 使当前路由的 path 属性为空，增加 originPath 属性。