### PR TITLE
style(create-umi): 🎨 author与模版之间增加空格

### DIFF
--- a/packages/create-umi/templates/max/package.json.tpl
+++ b/packages/create-umi/templates/max/package.json.tpl
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "author":"{{{ author }}}",
+  "author": "{{{ author }}}",
   "scripts": {
     "dev": "max dev",
     "build": "max build",


### PR DESCRIPTION
create-umi脚手架创建max项目后，
package.json文件中的author字段与模版之间缺少一个空格，
如果在package.json修改某个字段后，commit提交会触发lint-staged中的"prettier --cache --write"逻辑，
由此而引发author会附带着这处commit信息