### PR TITLE
fix: refresh `appData.routes` when config routes change

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -11,7 +11,7 @@ import {
   SHORT_ENV,
   WATCH_DEBOUNCE_STEP,
 } from '../constants';
-import { Env, ConfigChangeType } from '../types';
+import { Env, type IOnChangeTypes } from '../types';
 import { addExt, getAbsFiles } from './utils';
 
 interface IOpts {
@@ -22,8 +22,6 @@ interface IOpts {
 }
 
 type ISchema = Record<string, any>;
-
-type IOnChangeTypes = Record<string, string | `${ConfigChangeType}` | Function>;
 
 export class Config {
   public opts: IOpts;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -11,7 +11,7 @@ import {
   SHORT_ENV,
   WATCH_DEBOUNCE_STEP,
 } from '../constants';
-import { Env } from '../types';
+import { Env, ConfigChangeType } from '../types';
 import { addExt, getAbsFiles } from './utils';
 
 interface IOpts {
@@ -23,7 +23,7 @@ interface IOpts {
 
 type ISchema = Record<string, any>;
 
-type IOnChangeTypes = Record<string, string | Function>;
+type IOnChangeTypes = Record<string, string | `${ConfigChangeType}` | Function>;
 
 export class Config {
   public opts: IOpts;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -36,6 +36,9 @@ export enum ConfigChangeType {
   regenerateTmpFiles = 'regenerateTmpFiles',
 }
 
+export type ChangeTypeValue = string | `${ConfigChangeType}` | Function;
+export type IOnChangeTypes = Record<string, ChangeTypeValue>;
+
 export enum ApplyPluginsType {
   add = 'add',
   modify = 'modify',

--- a/packages/preset-umi/src/commands/build.ts
+++ b/packages/preset-umi/src/commands/build.ts
@@ -2,7 +2,7 @@ import { getMarkup } from '@umijs/server';
 import { chalk, fsExtra, logger, rimraf } from '@umijs/utils';
 import { writeFileSync } from 'fs';
 import { dirname, join, resolve } from 'path';
-import { IApi, IFileInfo } from '../types';
+import type { IApi, IOnGenerateFiles } from '../types';
 import { lazyImportFromCurrentPkg } from '../utils/lazyImportFromCurrentPkg';
 import { getAssetsMap } from './dev/getAssetsMap';
 import { getBabelOpts } from './dev/getBabelOpts';
@@ -47,10 +47,7 @@ umi build --clean
       });
 
       // generate files
-      async function generate(opts: {
-        isFirstTime?: boolean;
-        files?: IFileInfo;
-      }) {
+      async function generate(opts: IOnGenerateFiles) {
         await api.applyPlugins({
           key: 'onGenerateFiles',
           args: {

--- a/packages/preset-umi/src/commands/dev/dev.ts
+++ b/packages/preset-umi/src/commands/dev/dev.ts
@@ -12,7 +12,7 @@ import { existsSync, readFileSync, readdirSync } from 'fs';
 import { basename, join } from 'path';
 import { Worker } from 'worker_threads';
 import { DEFAULT_HOST, DEFAULT_PORT } from '../../constants';
-import { IApi, IFileInfo } from '../../types';
+import type { IApi, IOnGenerateFiles } from '../../types';
 import { lazyImportFromCurrentPkg } from '../../utils/lazyImportFromCurrentPkg';
 import { createRouteMiddleware } from './createRouteMiddleware';
 import { faviconMiddleware } from './faviconMiddleware';
@@ -88,10 +88,7 @@ PORT=8888 umi dev
       // );
 
       // generate files
-      async function generate(opts: {
-        isFirstTime?: boolean;
-        files?: IFileInfo;
-      }) {
+      async function generate(opts: IOnGenerateFiles) {
         await api.applyPlugins({
           key: 'onGenerateFiles',
           args: {

--- a/packages/preset-umi/src/commands/dev/dev.ts
+++ b/packages/preset-umi/src/commands/dev/dev.ts
@@ -182,7 +182,6 @@ PORT=8888 umi dev
               return;
             }
             await api.service.resolveConfig();
-            // after some key change, can contain both `regenerateTmpFiles` and `fns() for custom logic`
             if (data.changes[api.ConfigChangeType.regenerateTmpFiles]) {
               logger.event(
                 `config ${data.changes[

--- a/packages/preset-umi/src/commands/setup.ts
+++ b/packages/preset-umi/src/commands/setup.ts
@@ -1,5 +1,5 @@
 import { logger, rimraf } from '@umijs/utils';
-import { IApi } from '../types';
+import type { IApi, IOnGenerateFiles } from '../types';
 
 export default (api: IApi) => {
   api.registerCommand({
@@ -16,7 +16,7 @@ export default (api: IApi) => {
         args: {
           files: null,
           isFirstTime: true,
-        },
+        } satisfies IOnGenerateFiles,
       });
     },
   });

--- a/packages/preset-umi/src/features/appData/appData.ts
+++ b/packages/preset-umi/src/features/appData/appData.ts
@@ -71,7 +71,7 @@ export default (api: IApi) => {
   });
 
   api.registerMethod({
-    name: 'refreshRoutes',
+    name: '_refreshRoutes',
     async fn() {
       api.appData.routes = await getRoutes({
         api,

--- a/packages/preset-umi/src/features/appData/appData.ts
+++ b/packages/preset-umi/src/features/appData/appData.ts
@@ -6,7 +6,7 @@ import { parse } from '../../../compiled/ini';
 import { osLocale } from '../../../compiled/os-locale';
 import { expandCSSPaths, expandJSPaths } from '../../commands/dev/watch';
 import { createResolver, scan } from '../../libs/scan';
-import { IApi } from '../../types';
+import type { IApi, IOnGenerateFiles } from '../../types';
 import { getOverridesCSS } from '../overrides/overrides';
 import { getApiRoutes, getRoutes } from '../tmpFiles/routes';
 
@@ -87,7 +87,7 @@ export default (api: IApi) => {
   // Execute earliest, so that other onGenerateFiles can get it
   api.register({
     key: 'onGenerateFiles',
-    async fn(args: any) {
+    async fn(args: IOnGenerateFiles) {
       if (!args.isFirstTime) {
         api.appData.appJS = await getAppJsInfo();
         const { globalCSS, globalJS, overridesCSS } = getGlobalFiles();

--- a/packages/preset-umi/src/features/appData/appData.ts
+++ b/packages/preset-umi/src/features/appData/appData.ts
@@ -70,19 +70,14 @@ export default (api: IApi) => {
     return memo;
   });
 
-  function findGitDir(dir: string): string | null {
-    if (dir === resolve('/')) {
-      return null;
-    }
-    if (existsSync(join(dir, '.git'))) {
-      return join(dir, '.git');
-    }
-    const parent: string | null = findGitDir(join(dir, '..'));
-    if (parent) {
-      return parent;
-    }
-    return null;
-  }
+  api.registerMethod({
+    name: 'refreshRoutes',
+    async fn() {
+      api.appData.routes = await getRoutes({
+        api,
+      });
+    },
+  });
 
   // Execute earliest, so that other onGenerateFiles can get it
   api.register({
@@ -170,3 +165,17 @@ export default (api: IApi) => {
     };
   }
 };
+
+function findGitDir(dir: string): string | null {
+  if (dir === resolve('/')) {
+    return null;
+  }
+  if (existsSync(join(dir, '.git'))) {
+    return join(dir, '.git');
+  }
+  const parent: string | null = findGitDir(join(dir, '..'));
+  if (parent) {
+    return parent;
+  }
+  return null;
+}

--- a/packages/preset-umi/src/features/configPlugins/configPlugins.ts
+++ b/packages/preset-umi/src/features/configPlugins/configPlugins.ts
@@ -90,7 +90,7 @@ export default (api: IApi) => {
       config.default = configDefaults[key];
     }
 
-    // when `routes...icon` changes, need to refresh the `routes` data
+    // when `routes#icon` changes, need to refresh the `appData.routes`
     // otherwise the `icon` will not update
     if (['routes'].includes(key)) {
       const onRoutesChange: OnConfigChangeFn = async ({ generate }) => {

--- a/packages/preset-umi/src/features/configPlugins/configPlugins.ts
+++ b/packages/preset-umi/src/features/configPlugins/configPlugins.ts
@@ -2,7 +2,7 @@ import { getSchemas as getViteSchemas } from '@umijs/bundler-vite/dist/schema';
 import { getSchemas as getWebpackSchemas } from '@umijs/bundler-webpack/dist/schema';
 import { resolve } from '@umijs/utils';
 import { dirname, join } from 'path';
-import type { IApi, OnConfigChangeFn } from '../../types';
+import type { IApi, OnConfigChangeFn, IApiInternalProps } from '../../types';
 import { getSchemas as getExtraSchemas } from './schema';
 
 function resolveProjectDep(opts: { pkg: any; cwd: string; dep: string }) {
@@ -94,7 +94,7 @@ export default (api: IApi) => {
     // otherwise the `icon` will not update
     if (['routes'].includes(key)) {
       const onRoutesChange: OnConfigChangeFn = async ({ generate }) => {
-        await api.refreshRoutes();
+        await (api as any as IApiInternalProps)._refreshRoutes();
         await generate({ isFirstTime: false });
       };
       config.onChange = onRoutesChange;

--- a/packages/preset-umi/src/features/configPlugins/configPlugins.ts
+++ b/packages/preset-umi/src/features/configPlugins/configPlugins.ts
@@ -2,7 +2,7 @@ import { getSchemas as getViteSchemas } from '@umijs/bundler-vite/dist/schema';
 import { getSchemas as getWebpackSchemas } from '@umijs/bundler-webpack/dist/schema';
 import { resolve } from '@umijs/utils';
 import { dirname, join } from 'path';
-import { IApi } from '../../types';
+import type { IApi, OnConfigChangeFn } from '../../types';
 import { getSchemas as getExtraSchemas } from './schema';
 
 function resolveProjectDep(opts: { pkg: any; cwd: string; dep: string }) {
@@ -90,9 +90,14 @@ export default (api: IApi) => {
       config.default = configDefaults[key];
     }
 
-    // change type is regenerateTmpFiles
+    // when `routes...icon` changes, need to refresh the `routes` data
+    // otherwise the `icon` will not update
     if (['routes'].includes(key)) {
-      config.onChange = api.ConfigChangeType.regenerateTmpFiles;
+      const onRoutesChange: OnConfigChangeFn = async ({ generate }) => {
+        await api.refreshRoutes();
+        await generate({ isFirstTime: false });
+      };
+      config.onChange = onRoutesChange;
     }
 
     api.registerPlugins([

--- a/packages/preset-umi/src/features/icons/icons.ts
+++ b/packages/preset-umi/src/features/icons/icons.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { IApi } from '../../types';
+import type { IApi, IOnGenerateFiles } from '../../types';
 import { build } from './build';
 import { logger } from '@umijs/utils';
 import { generateIconName, generateSvgr } from './svgr';
@@ -33,7 +33,7 @@ export default (api: IApi) => {
 
   api.register({
     key: 'onGenerateFiles',
-    async fn({ isFirstTime }: { isFirstTime: boolean }) {
+    async fn({ isFirstTime }: IOnGenerateFiles) {
       if (!isFirstTime) return;
       const entryFile = path.join(api.paths.absTmpPath, 'umi.ts');
       const iconsSet: Set<string> = new Set();

--- a/packages/preset-umi/src/types.ts
+++ b/packages/preset-umi/src/types.ts
@@ -70,6 +70,10 @@ export type IEntryImport = {
 };
 export type IRoute = ICoreRoute;
 export type IFileInfo = Array<{ event: string; path: string }>;
+export interface IOnGenerateFiles {
+  files?: IFileInfo | null;
+  isFirstTime?: boolean;
+}
 
 export type IApi = PluginAPI &
   IServicePluginAPI & {
@@ -175,10 +179,7 @@ export type IApi = PluginAPI &
       stats: webpack.Stats;
       time: number;
     }>;
-    onGenerateFiles: IEvent<{
-      files?: IFileInfo | null;
-      isFirstTime?: boolean;
-    }>;
+    onGenerateFiles: IEvent<IOnGenerateFiles>;
     onPatchRoute: IEvent<{
       route: IRoute;
     }>;

--- a/packages/preset-umi/src/types.ts
+++ b/packages/preset-umi/src/types.ts
@@ -191,7 +191,7 @@ export type IApi = PluginAPI &
       current: Record<string, any>;
       origin: Record<string, any>;
     }>;
-    refreshRoutes: () => void;
+    refreshRoutes: () => Promise<void>;
     restartServer: () => void;
     writeTmpFile: (opts: {
       content?: string;

--- a/packages/preset-umi/src/types.ts
+++ b/packages/preset-umi/src/types.ts
@@ -74,6 +74,10 @@ export interface IOnGenerateFiles {
   files?: IFileInfo | null;
   isFirstTime?: boolean;
 }
+export type GenerateFilesFn = (opts: IOnGenerateFiles) => Promise<void>;
+export type OnConfigChangeFn = (opts: {
+  generate: GenerateFilesFn;
+}) => void | Promise<void>;
 
 export type IApi = PluginAPI &
   IServicePluginAPI & {
@@ -187,6 +191,7 @@ export type IApi = PluginAPI &
       current: Record<string, any>;
       origin: Record<string, any>;
     }>;
+    refreshRoutes: () => void;
     restartServer: () => void;
     writeTmpFile: (opts: {
       content?: string;

--- a/packages/preset-umi/src/types.ts
+++ b/packages/preset-umi/src/types.ts
@@ -191,7 +191,6 @@ export type IApi = PluginAPI &
       current: Record<string, any>;
       origin: Record<string, any>;
     }>;
-    refreshRoutes: () => Promise<void>;
     restartServer: () => void;
     writeTmpFile: (opts: {
       content?: string;
@@ -202,3 +201,12 @@ export type IApi = PluginAPI &
       tplPath?: string;
     }) => void;
   };
+
+export interface IApiInternalProps {
+  /**
+   * 如果不刷新 routes，修改 icon 不会热更新
+   * See https://github.com/umijs/umi/issues/10137
+   * TODO: 不公开这个方法，先解问题，但此问题应该有更好的解法
+   */
+  _refreshRoutes: () => Promise<void>;
+}


### PR DESCRIPTION
fix #10137

这个解决方案的思路是：

1. 提供一个 `api.refreshRoutes` 方法，和 `appData` 的逻辑在一个文件方便管理，以后如果有任何刷新 routes appData 的需求都可以用这个方法。

2. 用户 `routes` 的配置变化时，触发函数，先 `api.refreshRoutes` 刷新 routes 数据，再重新生成临时文件，不需要 restart dev server 。

