### PR TITLE
fix(preset-umi): incorrect relative public path when export static

### DIFF
--- a/packages/preset-umi/src/features/exportStatic/exportStatic.ts
+++ b/packages/preset-umi/src/features/exportStatic/exportStatic.ts
@@ -148,7 +148,7 @@ export default (api: IApi) => {
         // prefix for all assets
         if (rltPrefix) {
           // HINT: clone for keep original markupArgs unmodified
-          const picked = lodash.clone(
+          const picked = lodash.cloneDeep(
             lodash.pick(markupArgs, [
               'favicons',
               'links',


### PR DESCRIPTION
修复当 `publicPath` 设置为相对路径时，`exportStatic` 产出的资源引用路径错误的问题，原因是遍历处理 `markupArgs` 时原始对象被修改了