### PR TITLE
fix: 🐛 修复 MFSU 提前生成 cache 文件的错误

### DIFF
--- a/packages/mfsu/src/depBuilder/depBuilder.ts
+++ b/packages/mfsu/src/depBuilder/depBuilder.ts
@@ -95,7 +95,7 @@ export class DepBuilder {
           opts.onBuildComplete();
           worker.off('message', onMessage);
           if (done.withError) {
-            logger.error('[MFSU][eager] build failed', done.withError);
+            logger.debug('[MFSU][eager][main] build failed', done.withError);
             reject(done.withError);
           } else {
             resolve();

--- a/packages/mfsu/src/depBuilder/depBuilder.ts
+++ b/packages/mfsu/src/depBuilder/depBuilder.ts
@@ -86,22 +86,20 @@ export class DepBuilder {
       const onMessage = ({
         progress,
         done,
-        error,
       }: {
-        done: boolean;
+        done: { withError: any };
         error: any;
         progress: any;
       }) => {
         if (done) {
           opts.onBuildComplete();
           worker.off('message', onMessage);
-          resolve();
-        }
-        if (error) {
-          worker.off('message', onMessage);
-          opts.onBuildComplete();
-          logger.error('[MFSU][eager] build failed', error);
-          reject(error);
+          if (done.withError) {
+            logger.error('[MFSU][eager] build failed', done.withError);
+            reject(done.withError);
+          } else {
+            resolve();
+          }
         }
 
         if (progress) {

--- a/packages/preset-umi/src/commands/dev/depBuildWorker/depBuildWorker.ts
+++ b/packages/preset-umi/src/commands/dev/depBuildWorker/depBuildWorker.ts
@@ -27,7 +27,7 @@ async function start() {
     logger.info('[MFSU][eager] build worker start to build');
 
     return builder!.build({ deps }).catch((e) => {
-      logger.error('[MFSU][eager] build worker failed', e);
+      logger.debug('[MFSU][eager][worker] build worker failed', e);
       parentPort!.postMessage({ done: { withError: e } });
     });
   }

--- a/packages/preset-umi/src/commands/dev/depBuildWorker/depBuildWorker.ts
+++ b/packages/preset-umi/src/commands/dev/depBuildWorker/depBuildWorker.ts
@@ -28,10 +28,9 @@ async function start() {
 
     return builder!.build({ deps }).catch((e) => {
       logger.error('[MFSU][eager] build worker failed', e);
-      parentPort!.postMessage({ error: e });
+      parentPort!.postMessage({ done: { withError: e } });
     });
   }
-
   function scheduleBuild() {
     if (builder && !builder.isBuilding) {
       const buildReq = bufferedRequest.shift();


### PR DESCRIPTION
close https://github.com/umijs/umi/issues/10265

## why 
原先 worker builder 里面 onComplete 在 webpack 构建中，即使构建失败按照成功调用。导致下游的错误的写下 mfsu 缓存 （认为自己构建成功了）。
当项目安装缺失的依赖，代码未修改不满足重新构建的条件，继续使用构建失败产物。

## solution 

* buildWithXXX 的实现中，只调用成功构建的 onComplete 回调
* 错误情况在 catch 中统一处理
* 调整消息结构，构建结束时只发一条消息, 通过消息内容表征构建是否成功
* 简化了日志输出，内部的采用 logger.debug 
