### PR TITLE
chore(create-umi): 🔨 prettierignore新增两项忽略文件

### DIFF
--- a/packages/create-umi/templates/max/.prettierignore.tpl
+++ b/packages/create-umi/templates/max/.prettierignore.tpl
@@ -1,3 +1,5 @@
 node_modules
 .umi
 .umi-production
+.lintstagedrc
+package.json

--- a/packages/create-umi/templates/max/.umirc.ts.tpl
+++ b/packages/create-umi/templates/max/.umirc.ts.tpl
@@ -32,4 +32,3 @@ export default defineConfig({
   ],
   npmClient: '{{{ npmClient }}}',
 });
-


### PR DESCRIPTION
### 避免因为执行 npm run format 或者因为修改该文件而提交 commit，对该文件执行糟糕格式化
<img width="1253" alt="image" src="https://user-images.githubusercontent.com/63422671/211763289-29c95da5-65e9-4f63-9925-7cb9b46f1020.png">
<img width="1331" alt="image" src="https://user-images.githubusercontent.com/63422671/211763180-aeffca3b-9580-4804-b998-1dd6cfe28b6e.png">

### 删除.umirc.ts 文件底部多余换行，格式化统一
<img width="1031" alt="image" src="https://user-images.githubusercontent.com/63422671/211764032-ba550681-6e45-4d09-8a59-61284b79148f.png">
