### PR TITLE
feat: upgrade valtio to 1.19.0

### DIFF
--- a/libs/valtio/package.json
+++ b/libs/valtio/package.json
@@ -22,7 +22,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "valtio": "1.8.2"
+    "valtio": "1.9.0"
   },
   "packageManager": "pnpm@7.3.0",
   "publishConfig": {

--- a/libs/valtio/src/index.ts
+++ b/libs/valtio/src/index.ts
@@ -1,13 +1,14 @@
-export { proxy, useSnapshot, snapshot, subscribe } from 'valtio';
+export { proxy, snapshot, subscribe, useSnapshot } from 'valtio';
 export {
-  proxyWithComputed,
-  proxyWithHistory,
+  derive,
   devtools as proxyWithDevtools,
   proxyMap,
   proxySet,
-  derive,
-  underive,
+  proxyWithComputed,
+  proxyWithHistory,
   subscribeKey,
+  underive,
+  useProxy,
 } from 'valtio/utils';
 
 // TODO:

--- a/packages/plugins/src/valtio.ts
+++ b/packages/plugins/src/valtio.ts
@@ -1,6 +1,6 @@
-import { IApi } from 'umi';
-import { dirname } from 'path';
 import { winPath } from '@umijs/utils';
+import { dirname } from 'path';
+import { IApi } from 'umi';
 
 // TODO:
 // - generator
@@ -39,6 +39,7 @@ export {
   proxySet,
   derive,
   underive,
+  useProxy,
 } from '${libPath}';
       `,
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1132,9 +1132,9 @@ importers:
 
   libs/valtio:
     specifiers:
-      valtio: 1.8.2
+      valtio: 1.9.0
     dependencies:
-      valtio: 1.8.2
+      valtio: 1.9.0
 
   packages/ast:
     specifiers:
@@ -38420,9 +38420,9 @@ packages:
       use-sync-external-store: 1.2.0_react@17.0.2
     dev: true
 
-  /valtio/1.8.2:
-    resolution: {integrity: sha512-ypFWPi3aY04tojWAFPbTYBDw5iFaCDbKAJ2XqhmY2XOSorNtaCZJNg++FSssv8gMJwmPXfrU/RjncQtsoOHbUg==}
-    engines: {node: '>=12.7.0'}
+  /valtio/1.9.0:
+    resolution: {integrity: sha512-mQLFsAlKbYascZygFQh6lXuDjU5WHLoeZ8He4HqMnWfasM96V6rDbeFkw1XeG54xycmDonr/Jb4xgviHtuySrA==}
+    engines: {node: '>=12.20.0'}
     peerDependencies:
       react: '>=16.8'
     peerDependenciesMeta:


### PR DESCRIPTION
升级 valtio 到 1.19.0 版本，导出 useProxy 方法

相关 [issue](https://github.com/umijs/umi/issues/10306)