### PR TITLE
fix(bundler-webpack): process undefined problem with hmr

### DIFF
--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -47,7 +47,7 @@
     "node-libs-browser": "2.2.1",
     "postcss": "^8.4.21",
     "postcss-preset-env": "7.5.0",
-    "react-error-overlay": "6.0.11",
+    "react-error-overlay": "6.0.9",
     "react-refresh": "0.14.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1341,7 +1341,7 @@ importers:
       postcss-loader: 7.0.2
       postcss-preset-env: 7.5.0
       purgecss-webpack-plugin: 4.1.3
-      react-error-overlay: 6.0.11
+      react-error-overlay: 6.0.9
       react-refresh: 0.14.0
       sass-loader: 13.2.0
       schema-utils: 4.0.0
@@ -1380,7 +1380,7 @@ importers:
       node-libs-browser: 2.2.1
       postcss: 8.4.21
       postcss-preset-env: 7.5.0_postcss@8.4.21
-      react-error-overlay: 6.0.11
+      react-error-overlay: 6.0.9
       react-refresh: 0.14.0
     devDependencies:
       '@swc/core': 1.3.24
@@ -33704,7 +33704,6 @@ packages:
 
   /react-error-overlay/6.0.9:
     resolution: {integrity: sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==}
-    dev: true
 
   /react-fast-compare/3.2.0:
     resolution: {integrity: sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==}


### PR DESCRIPTION
why? 

---

from @fz6m 

现状就是 react-error-overlay 没法用了，控制台报错 process undefined。

看了下，这个问题前年就有了，我也不用 react-error-overlay ，不太晓得这个问题：

https://github.com/facebook/create-react-app/issues/11773

https://github.com/facebook/create-react-app/issues/12212

CRA 官方摆烂了，最新版本也是去年 4 月的，都快 1 年没更新了，一些网上的解法：

https://stackoverflow.com/questions/70368760/react-uncaught-referenceerror-process-is-not-defined

目前社区里看起来靠谱的解法是回退到 6.0.9 ，问题的原因是 6.0.10 开始 CRA 把构建工具换成 webpack5 了，但是没配 webpack5 的 node polyfill （webpack 5 开始不包含 polyfill），导致 process 被原模原样输出来了。

还有一个可能的解法，参考：https://github.com/facebook/create-react-app/pull/11799 ，自己 fork 改一下 webpack 配置自己构建一份 react-error-overlay ，但我觉得他这个 PR 有点小问题，process 用 process/browser.js 感觉会更好。

