### PR TITLE
chore: check independent version pkgs publish when release

### DIFF
--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -30,7 +30,7 @@
     "@tanstack/react-query": "^4.22.0",
     "@tanstack/react-query-devtools": "^4.22.0",
     "@umijs/bundler-utils": "4.0.47",
-    "@umijs/valtio": "^1.0.2",
+    "@umijs/valtio": "^1.0.3",
     "antd-dayjs-webpack-plugin": "^1.0.6",
     "axios": "^0.27.2",
     "babel-plugin-import": "^1.13.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1567,7 +1567,7 @@ importers:
       '@tanstack/react-query': ^4.22.0
       '@tanstack/react-query-devtools': ^4.22.0
       '@umijs/bundler-utils': 4.0.47
-      '@umijs/valtio': ^1.0.2
+      '@umijs/valtio': ^1.0.3
       antd: ^4.24.1
       antd-dayjs-webpack-plugin: ^1.0.6
       axios: ^0.27.2

--- a/scripts/.internal/constants.ts
+++ b/scripts/.internal/constants.ts
@@ -7,6 +7,7 @@ export const PATHS = {
   EXAMPLES: join(ROOT, './examples'),
   LERNA_CONFIG: join(ROOT, './lerna.json'),
   JEST_TURBO_CONFIG: join(ROOT, './jest.turbo.config.ts'),
+  INDEPENDENT_PACKAGES: [join(ROOT, './libs/valtio')],
 } as const;
 
 export const SCRIPTS = {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -129,12 +129,12 @@ import { assert, eachPkg, getPkgs } from './.internal/utils';
 
   // check independent package version
   logger.event('check independent package version');
-  PATHS.INDEPENDENT_PACKAGES.forEach((fromPkg) => {
-    checkIndependentPackageChanged({
+  for await (const fromPkg of PATHS.INDEPENDENT_PACKAGES) {
+    await checkIndependentPackageChanged({
       pkgDirPath: fromPkg,
       updateTo: pkgsJsonPath,
     });
-  });
+  }
 
   // update pnpm lockfile
   logger.event('update pnpm lockfile');

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -15,6 +15,9 @@ import { assert, eachPkg, getPkgs } from './.internal/utils';
   logger.info(`branch: ${branch}`);
   const pkgs = getPkgs();
   logger.info(`pkgs: ${pkgs.join(', ')}`);
+  const pkgsJsonPath = pkgs.map((pkg) =>
+    join(PATHS.PACKAGES, pkg, 'package.json'),
+  );
 
   // check git status
   logger.event('check git status');
@@ -106,6 +109,7 @@ import { assert, eachPkg, getPkgs } from './.internal/utils';
       !dir.startsWith('.') && existsSync(join(examplesDir, dir, 'package.json'))
     );
   });
+  const allPkgsName = pkgsJsonPath.map((p) => require(p).name);
   examples.forEach((example) => {
     const pkg = require(join(examplesDir, example, 'package.json'));
     pkg.scripts ||= {};
@@ -114,20 +118,22 @@ import { assert, eachPkg, getPkgs } from './.internal/utils';
     setDepsVersion({
       pkg,
       version,
-      deps: [
-        'umi',
-        '@umijs/max',
-        '@umijs/plugins',
-        '@umijs/bundler-vite',
-        '@umijs/preset-vue',
-        '@umijs/mfsu',
-      ],
+      deps: allPkgsName,
     });
     delete pkg.version;
     fs.writeFileSync(
       join(examplesDir, example, 'package.json'),
       `${JSON.stringify(pkg, null, 2)}\n`,
     );
+  });
+
+  // check independent package version
+  logger.event('check independent package version');
+  PATHS.INDEPENDENT_PACKAGES.forEach((fromPkg) => {
+    checkIndependentPakcageChanged({
+      pkgDirPath: fromPkg,
+      updateTo: pkgsJsonPath,
+    });
   });
 
   // update pnpm lockfile
@@ -274,4 +280,69 @@ function generateChangelog(releaseNotes: string) {
     newStr = `# umi changelog\n\n${releaseNotes}`;
   }
   fs.writeFileSync(CHANGELOG_PATH, newStr);
+}
+
+async function checkIndependentPakcageChanged(opts: {
+  pkgDirPath: string;
+  updateTo?: string[];
+}) {
+  console.log(
+    chalk.grey(`> Check independent version packages weather need publish.`),
+  );
+  const { pkgDirPath, updateTo = [] } = opts;
+  $.verbose = false;
+  const latestTag = (await $`git describe --abbrev=0 --tags`).stdout.trim();
+  const diff = (
+    await $`git diff ${latestTag} --name-only ${pkgDirPath}`
+  ).stdout.trim();
+  $.verbose = true;
+  if (!diff?.length) {
+    return;
+  }
+  const answer = await question(
+    `Changes detected in ${chalk.bold.yellow(
+      path.relative(PATHS.ROOT, pkgDirPath),
+    )} since ${chalk.bold.blue(latestTag)}.
+Check published package and update version if necessary.
+Continue? `,
+  );
+  if (answer.toLowerCase() !== 'y') {
+    console.log(chalk.red(`> Cancelled, please check version and publish.`));
+    process.exit(0);
+  }
+  // update version to packages/*
+  const pkgJson = require(path.join(pkgDirPath, 'package.json'));
+  const { name, version } = pkgJson;
+  const newVersion = `^${version}`;
+  updateTo.forEach((p) => {
+    const targetPkgPath = p.endsWith('package.json')
+      ? p
+      : path.join(p, 'package.json');
+    const targetPkg = require(targetPkgPath);
+    const depProd = targetPkg?.dependencies?.[name];
+    const depDev = targetPkg?.devDependencies?.[name];
+    let updated = false;
+    if (depProd && depProd !== newVersion) {
+      targetPkg.dependencies[name] = newVersion;
+      updated = true;
+    }
+    if (depDev && depDev !== newVersion) {
+      targetPkg.devDependencies[name] = newVersion;
+      updated = true;
+    }
+    if (updated) {
+      fs.writeFileSync(
+        targetPkgPath,
+        `${JSON.stringify(targetPkg, null, 2)}\n`,
+      );
+      console.log(
+        `Auto updated package ${chalk.bold.cyan(
+          name,
+        )} version ${chalk.bold.blue(newVersion)} to ${chalk.bold.green(
+          path.relative(PATHS.ROOT, targetPkgPath),
+        )}`,
+      );
+    }
+  });
+  console.log(chalk.grey(`> Check independent version packages end.`));
 }

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -130,7 +130,7 @@ import { assert, eachPkg, getPkgs } from './.internal/utils';
   // check independent package version
   logger.event('check independent package version');
   PATHS.INDEPENDENT_PACKAGES.forEach((fromPkg) => {
-    checkIndependentPakcageChanged({
+    checkIndependentPackageChanged({
       pkgDirPath: fromPkg,
       updateTo: pkgsJsonPath,
     });
@@ -282,7 +282,7 @@ function generateChangelog(releaseNotes: string) {
   fs.writeFileSync(CHANGELOG_PATH, newStr);
 }
 
-async function checkIndependentPakcageChanged(opts: {
+async function checkIndependentPackageChanged(opts: {
   pkgDirPath: string;
   updateTo?: string[];
 }) {


### PR DESCRIPTION
close #10317

发布的时候会去检查独立版本的包，目前只有 `libs/valtio` 一个。

会用 git diff 对比一下从 **上次 tag** 之后发生的变化，如果没变化，就默认继续 release ，如果有变化，提示要去发包了。

如果回答 `n` ，就中断流程，去发包，发完再回来发布。

如果回答 `y` ，证明你已经发过包了，会自动把新版本刷到所有使用的位置，把他变成 `^${newVersion}` ，这样可以解升级 umi 依赖版本但是 umi 依赖的包没有更新的问题，之后继续进行 release 流程。
