### PR TITLE
fix: 🐛 MFSU[eager] webpack copy plugin 未禁用

### DIFF
--- a/packages/preset-umi/src/commands/dev/depBuildWorker/depBuildWorker.ts
+++ b/packages/preset-umi/src/commands/dev/depBuildWorker/depBuildWorker.ts
@@ -64,6 +64,7 @@ async function start() {
     env: Env.development,
     entry: opts.entry,
     userConfig: opts.config,
+    disableCopy: true,
     hash: true,
     staticPathPrefix: MF_DEP_PREFIX,
     name: MFSU_NAME,


### PR DESCRIPTION
eager 模式下 copy plugin 未禁用 

fix: https://github.com/umijs/umi/issues/10329


