### PR TITLE
fix(icons): import start with alias `@`

### DIFF
--- a/packages/preset-umi/src/features/icons/esbuildPlugins/esbuildExternalPlugin.ts
+++ b/packages/preset-umi/src/features/icons/esbuildPlugins/esbuildExternalPlugin.ts
@@ -22,7 +22,13 @@ export function esbuildExternalPlugin(): Plugin {
         if (args.kind === 'entry-point') {
           return null;
         }
-        if (args.path.startsWith('/') && !args.path.includes('node_modules')) {
+        const isAliasImport =
+          args.path.startsWith('@/') || args.path.startsWith('@@/');
+        const isNodeModuleImport = args.path.includes('node_modules');
+        if (
+          (args.path.startsWith('/') || isAliasImport) &&
+          !isNodeModuleImport
+        ) {
           return null;
         }
         return {


### PR DESCRIPTION
fix #10338 

修复：

1. `@` 和 `@@` 开头的别名导入被 external 掉了，导致不识别的 BUG 。（因为 tsconfig 不能自定义 `paths` 的关系，等价于没法拓展显示的 alias ，先只做这两个）

2. `icons.tsx` 是异步生成的，第一次没有，esbuild 解析报错了，所以在初始化的时候写个空的。