### PR TITLE
feat(preset-umi): disable prerender for partial routes in exporStatic

### DIFF
--- a/docs/docs/api/config.md
+++ b/docs/docs/api/config.md
@@ -548,7 +548,7 @@ export default {
 
 ## exportStatic
 
-- 类型：`{ extraRoutePaths: string[] | (() => string[] | Promise<string[]>) }`
+- 类型：`{ extraRoutePaths: IUserExtraRoute[] | (() => IUserExtraRoute[] | Promise<IUserExtraRoute[]>) }`
 - 默认值：`undefined`
 
 开启该配置后会针对每个路由单独输出 HTML 文件，通常用于静态站点托管。例如项目有如下路由：
@@ -604,6 +604,19 @@ dist/news/:id/index.html
 dist/news/1/index.html
 dist/news/2/index.html
 ```
+
+`extraRoutePaths` 除了支持配置字符串数据，还可以配置成对象数组，用于启用 SSR 时又希望对部分路由禁用预渲染的场景，例如：
+
+```ts
+// .umirc.ts
+export default {
+  exportStatic: {
+    // 输出额外页面文件但跳过预渲染
+    extraRoutePaths: [{ path: '/news/1', prerender: false }],
+  },
+}
+```
+
 
 ## favicons
 

--- a/packages/preset-umi/src/features/exportStatic/exportStatic.ts
+++ b/packages/preset-umi/src/features/exportStatic/exportStatic.ts
@@ -14,7 +14,10 @@ interface IExportHtmlItem {
     redirect?: string;
   };
   file: string;
+  prerender: boolean;
 }
+
+type IUserExtraRoute = string | { path: string; prerender: boolean };
 
 /**
  * get export html data from routes
@@ -42,6 +45,7 @@ function getExportHtmlData(routes: Record<string, IRoute>): IExportHtmlItem[] {
           path: is404 ? '/404' : route.absPath,
           redirect: route.redirect,
         },
+        prerender: route.prerender !== false,
         file,
       });
     }
@@ -88,18 +92,29 @@ export default (api: IApi) => {
    * convert user `exportStatic.extraRoutePaths` config to routes
    */
   async function getRoutesFromUserExtraPaths(
-    routePaths: string[] | (() => string[] | Promise<string[]>),
+    routePaths:
+      | IUserExtraRoute[]
+      | (() => IUserExtraRoute[] | Promise<IUserExtraRoute[]>),
   ) {
     const paths =
       typeof routePaths === 'function' ? await routePaths() : routePaths;
 
-    return paths.reduce<Record<string, IRoute>>(
-      (acc, p) => ({
-        ...acc,
-        [p]: { id: p, absPath: p, path: p.slice(1), file: '' },
-      }),
-      {},
-    );
+    return paths.reduce<Record<string, IRoute>>((acc, item) => {
+      const routePath = typeof item === 'string' ? item : item.path;
+
+      acc[routePath] = {
+        id: routePath,
+        absPath: routePath,
+        path: routePath.slice(1),
+        file: '',
+        // allow user to disable prerender for extra route
+        ...(typeof item === 'object' && item.prerender === false
+          ? { prerender: false }
+          : {}),
+      };
+
+      return acc;
+    }, {});
   }
 
   api.describe({
@@ -133,7 +148,7 @@ export default (api: IApi) => {
     );
     const htmlFiles: { path: string; content: string }[] = [];
 
-    for (const { file, route } of htmlData) {
+    for (const { file, route, prerender } of htmlData) {
       let { markupArgs } = opts;
 
       // handle relative publicPath, such as `./`
@@ -201,9 +216,10 @@ export default (api: IApi) => {
 
       htmlFiles.push({
         path: file,
-        content: api.config.ssr
-          ? await getPreRenderedHTML(api, htmlContent, route.path)
-          : htmlContent,
+        content:
+          api.config.ssr && prerender
+            ? await getPreRenderedHTML(api, htmlContent, route.path)
+            : htmlContent,
       });
     }
 


### PR DESCRIPTION
允许对 `exportStatic.extraRoutePaths` 配置的路由部分禁用预渲染

背景是 dumi 会利用该配置将所有 demo 的独立访问路由（例如 `/~demos/button-demo-basic`）变成静态路由，但 demo 路由不需要被搜索引擎爬取，且 demo 数量很多时（比如 antd 项目）会导致构建极慢

虽然预渲染以后有首屏加载优势，但独立打开 demo 链接的场景不多，平衡之下还是默认禁用比较好，故 Umi 层增加该配置，随后 dumi 再做修改