### PR TITLE
fix: 🐛 dev 模式下不使用 hash， 方便调试

### DIFF
--- a/packages/plugins/src/mf.ts
+++ b/packages/plugins/src/mf.ts
@@ -64,10 +64,12 @@ export default function mf(api: IApi) {
       );
     }
 
+    const useHash = api.config.hash && api.env !== 'development';
+
     const mfConfig = {
       name,
       remotes,
-      filename: api.config.hash ? 'remote.[contenthash:8].js' : 'remote.js',
+      filename: useHash ? 'remote.[contenthash:8].js' : 'remote.js',
       exposes,
       shared,
       library: api.config.mf.library,


### PR DESCRIPTION
# why

内部一个插件， 默认开启 hash ，导致 dev 时 remote 的产物是 remote.xxx.js  ，调试非常不方便（需要开启 writeToDisk 才知道文件 hash 是什么）
