### PR TITLE
fix(preset-umi): 修复不存在 .umirc.ts时，多次调用 set ， .umirc.ts 被覆写的问题

### DIFF
--- a/packages/preset-umi/src/commands/config/set.ts
+++ b/packages/preset-umi/src/commands/config/set.ts
@@ -13,6 +13,9 @@ export function set(api: IApi, name: string, value: string) {
     const content = `export default {};`;
     writeFileSync(absPath, content, 'utf-8');
     mainConfigFile = absPath;
+
+    // 需要在首次 set 时，设置 mainConfigFile 路径
+    api.appData.mainConfigFile = absPath;
   }
 
   const ast = getASTByFilePath(mainConfigFile);


### PR DESCRIPTION
修复初始化调用 ```npx umi g tailwindcss``` 时，
```.umirc.ts``` 中自动写入配置缺失 ```tailwindcss: {}``` 的问题