### PR TITLE
feat(bundler-webpack): webpack pre-compiled support workerize-loader

### DIFF
--- a/examples/with-workerize-loader/.umirc.ts
+++ b/examples/with-workerize-loader/.umirc.ts
@@ -1,0 +1,5 @@
+export default {
+  mfsu: {
+    exclude: [/workerize-loader/],
+  },
+};

--- a/examples/with-workerize-loader/package.json
+++ b/examples/with-workerize-loader/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@example/with-workerize-loader",
+  "private": true,
+  "scripts": {
+    "build": "umi build",
+    "dev": "umi dev",
+    "setup": "umi setup",
+    "start": "npm run dev"
+  },
+  "dependencies": {
+    "@umijs/plugins": "4.0.50",
+    "antd": "^4.20.6",
+    "umi": "4.0.50"
+  },
+  "devDependencies": {
+    "workerize-loader": "^2.0.2"
+  }
+}

--- a/examples/with-workerize-loader/pages/index.tsx
+++ b/examples/with-workerize-loader/pages/index.tsx
@@ -1,0 +1,17 @@
+import React, { useEffect } from 'react';
+// @ts-ignore
+import worker from 'workerize-loader!./worker';
+
+export default function Page() {
+  useEffect(() => {
+    let instance = worker(); // `new` is optional
+    instance.expensive(1000).then((count) => {
+      console.log(`Ran ${count} loops`);
+    });
+  }, []);
+  return (
+    <div>
+      <h1>with web worker</h1>
+    </div>
+  );
+}

--- a/examples/with-workerize-loader/pages/worker.ts
+++ b/examples/with-workerize-loader/pages/worker.ts
@@ -1,0 +1,6 @@
+export function expensive(time: number) {
+  let start = Date.now(),
+    count = 0;
+  while (Date.now() - start < time) count++;
+  return count;
+}

--- a/packages/bundler-webpack/bundles/webpack/bundle.js
+++ b/packages/bundler-webpack/bundles/webpack/bundle.js
@@ -9,10 +9,17 @@ const UseEffectRulePlugin = require('webpack/lib/rules/UseEffectRulePlugin')
 const ObjectMatcherRulePlugin = require('webpack/lib/rules/ObjectMatcherRulePlugin')
 const RuleSetCompiler = require('webpack/lib/rules/RuleSetCompiler')
 
+// workerize-loader
+const NodeTargetPlugin = require('webpack/lib/node/NodeTargetPlugin')
+const WebWorkerTemplatePlugin = require('webpack/lib/webworker/WebWorkerTemplatePlugin')
+
 export {
   BasicEffectRulePlugin,
   BasicMatcherRulePlugin,
   UseEffectRulePlugin,
   ObjectMatcherRulePlugin,
   RuleSetCompiler,
+
+  NodeTargetPlugin,
+  WebWorkerTemplatePlugin
 }

--- a/packages/bundler-webpack/bundles/webpack/bundle.js
+++ b/packages/bundler-webpack/bundles/webpack/bundle.js
@@ -9,9 +9,15 @@ const UseEffectRulePlugin = require('webpack/lib/rules/UseEffectRulePlugin')
 const ObjectMatcherRulePlugin = require('webpack/lib/rules/ObjectMatcherRulePlugin')
 const RuleSetCompiler = require('webpack/lib/rules/RuleSetCompiler')
 
-// workerize-loader
+// refer to nextjs https://github.com/vercel/next.js/blob/canary/packages/next/src/bundles/webpack/bundle5.js
+const BasicEvaluatedExpression =require('webpack/lib/javascript/BasicEvaluatedExpression')
 const NodeTargetPlugin = require('webpack/lib/node/NodeTargetPlugin')
+const NodeTemplatePlugin = require('webpack/lib/node/NodeTemplatePlugin')
+const LimitChunkCountPlugin = require('webpack/lib/optimize/LimitChunkCountPlugin')
 const WebWorkerTemplatePlugin = require('webpack/lib/webworker/WebWorkerTemplatePlugin')
+const FetchCompileAsyncWasmPlugin = require('webpack/lib/web/FetchCompileAsyncWasmPlugin')
+const FetchCompileWasmPlugin = require('webpack/lib/web/FetchCompileWasmPlugin')
+const StringXor = require('webpack/lib/util/StringXor')
 
 export {
   BasicEffectRulePlugin,
@@ -20,6 +26,12 @@ export {
   ObjectMatcherRulePlugin,
   RuleSetCompiler,
 
+  BasicEvaluatedExpression,
   NodeTargetPlugin,
-  WebWorkerTemplatePlugin
+  NodeTemplatePlugin,
+  LimitChunkCountPlugin,
+  WebWorkerTemplatePlugin,
+  FetchCompileAsyncWasmPlugin,
+  FetchCompileWasmPlugin,
+  StringXor
 }

--- a/packages/bundler-webpack/bundles/webpack/packages/BasicEvaluatedExpression.js
+++ b/packages/bundler-webpack/bundles/webpack/packages/BasicEvaluatedExpression.js
@@ -1,0 +1,1 @@
+module.exports = require('./').BasicEvaluatedExpression;

--- a/packages/bundler-webpack/bundles/webpack/packages/ExternalsPlugin.js
+++ b/packages/bundler-webpack/bundles/webpack/packages/ExternalsPlugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./').ExternalsPlugin;

--- a/packages/bundler-webpack/bundles/webpack/packages/FetchCompileAsyncWasmPlugin.js
+++ b/packages/bundler-webpack/bundles/webpack/packages/FetchCompileAsyncWasmPlugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./').FetchCompileAsyncWasmPlugin;

--- a/packages/bundler-webpack/bundles/webpack/packages/FetchCompileWasmPlugin.js
+++ b/packages/bundler-webpack/bundles/webpack/packages/FetchCompileWasmPlugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./').FetchCompileWasmPlugin;

--- a/packages/bundler-webpack/bundles/webpack/packages/LimitChunkCountPlugin.js
+++ b/packages/bundler-webpack/bundles/webpack/packages/LimitChunkCountPlugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./').LimitChunkCountPlugin;

--- a/packages/bundler-webpack/bundles/webpack/packages/NodeTargetPlugin.js
+++ b/packages/bundler-webpack/bundles/webpack/packages/NodeTargetPlugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./').NodeTargetPlugin;

--- a/packages/bundler-webpack/bundles/webpack/packages/NodeTemplatePlugin.js
+++ b/packages/bundler-webpack/bundles/webpack/packages/NodeTemplatePlugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./').NodeTemplatePlugin;

--- a/packages/bundler-webpack/bundles/webpack/packages/StringXor.js
+++ b/packages/bundler-webpack/bundles/webpack/packages/StringXor.js
@@ -1,0 +1,1 @@
+module.exports = require('./').StringXor;

--- a/packages/bundler-webpack/bundles/webpack/packages/WebWorkerTemplatePlugin.js
+++ b/packages/bundler-webpack/bundles/webpack/packages/WebWorkerTemplatePlugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./').WebWorkerTemplatePlugin;

--- a/packages/bundler-webpack/bundles/webpack/packages/deepImports.json
+++ b/packages/bundler-webpack/bundles/webpack/packages/deepImports.json
@@ -15,5 +15,12 @@
   "webpack/lib/rules/RuleSetCompiler",
   "webpack/lib/rules/UseEffectRulePlugin",
   "webpack/lib/node/NodeTargetPlugin",
-  "webpack/lib/webworker/WebWorkerTemplatePlugin"
+  "webpack/lib/webworker/WebWorkerTemplatePlugin",
+  "webpack/lib/ExternalsPlugin",
+  "webpack/lib/javascript/BasicEvaluatedExpression",
+  "webpack/lib/node/NodeTemplatePlugin",
+  "webpack/lib/optimize/LimitChunkCountPlugin",
+  "webpack/lib/web/FetchCompileAsyncWasmPlugin",
+  "webpack/lib/web/FetchCompileWasmPlugin",
+  "webpack/lib/util/StringXor"
 ]

--- a/packages/bundler-webpack/bundles/webpack/packages/deepImports.json
+++ b/packages/bundler-webpack/bundles/webpack/packages/deepImports.json
@@ -13,5 +13,7 @@
   "webpack/lib/rules/BasicMatcherRulePlugin",
   "webpack/lib/rules/ObjectMatcherRulePlugin",
   "webpack/lib/rules/RuleSetCompiler",
-  "webpack/lib/rules/UseEffectRulePlugin"
+  "webpack/lib/rules/UseEffectRulePlugin",
+  "webpack/lib/node/NodeTargetPlugin",
+  "webpack/lib/webworker/WebWorkerTemplatePlugin"
 ]

--- a/packages/bundler-webpack/compiled/webpack/BasicEvaluatedExpression.js
+++ b/packages/bundler-webpack/compiled/webpack/BasicEvaluatedExpression.js
@@ -1,0 +1,1 @@
+module.exports = require('./').BasicEvaluatedExpression;

--- a/packages/bundler-webpack/compiled/webpack/ExternalsPlugin.js
+++ b/packages/bundler-webpack/compiled/webpack/ExternalsPlugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./').ExternalsPlugin;

--- a/packages/bundler-webpack/compiled/webpack/FetchCompileAsyncWasmPlugin.js
+++ b/packages/bundler-webpack/compiled/webpack/FetchCompileAsyncWasmPlugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./').FetchCompileAsyncWasmPlugin;

--- a/packages/bundler-webpack/compiled/webpack/FetchCompileWasmPlugin.js
+++ b/packages/bundler-webpack/compiled/webpack/FetchCompileWasmPlugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./').FetchCompileWasmPlugin;

--- a/packages/bundler-webpack/compiled/webpack/LimitChunkCountPlugin.js
+++ b/packages/bundler-webpack/compiled/webpack/LimitChunkCountPlugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./').LimitChunkCountPlugin;

--- a/packages/bundler-webpack/compiled/webpack/NodeTargetPlugin.js
+++ b/packages/bundler-webpack/compiled/webpack/NodeTargetPlugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./').NodeTargetPlugin;

--- a/packages/bundler-webpack/compiled/webpack/NodeTemplatePlugin.js
+++ b/packages/bundler-webpack/compiled/webpack/NodeTemplatePlugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./').NodeTemplatePlugin;

--- a/packages/bundler-webpack/compiled/webpack/StringXor.js
+++ b/packages/bundler-webpack/compiled/webpack/StringXor.js
@@ -1,0 +1,1 @@
+module.exports = require('./').StringXor;

--- a/packages/bundler-webpack/compiled/webpack/WebWorkerTemplatePlugin.js
+++ b/packages/bundler-webpack/compiled/webpack/WebWorkerTemplatePlugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./').WebWorkerTemplatePlugin;

--- a/packages/bundler-webpack/compiled/webpack/deepImports.json
+++ b/packages/bundler-webpack/compiled/webpack/deepImports.json
@@ -15,5 +15,12 @@
   "webpack/lib/rules/RuleSetCompiler",
   "webpack/lib/rules/UseEffectRulePlugin",
   "webpack/lib/node/NodeTargetPlugin",
-  "webpack/lib/webworker/WebWorkerTemplatePlugin"
+  "webpack/lib/webworker/WebWorkerTemplatePlugin",
+  "webpack/lib/ExternalsPlugin",
+  "webpack/lib/javascript/BasicEvaluatedExpression",
+  "webpack/lib/node/NodeTemplatePlugin",
+  "webpack/lib/optimize/LimitChunkCountPlugin",
+  "webpack/lib/web/FetchCompileAsyncWasmPlugin",
+  "webpack/lib/web/FetchCompileWasmPlugin",
+  "webpack/lib/util/StringXor"
 ]

--- a/packages/bundler-webpack/compiled/webpack/deepImports.json
+++ b/packages/bundler-webpack/compiled/webpack/deepImports.json
@@ -13,5 +13,7 @@
   "webpack/lib/rules/BasicMatcherRulePlugin",
   "webpack/lib/rules/ObjectMatcherRulePlugin",
   "webpack/lib/rules/RuleSetCompiler",
-  "webpack/lib/rules/UseEffectRulePlugin"
+  "webpack/lib/rules/UseEffectRulePlugin",
+  "webpack/lib/node/NodeTargetPlugin",
+  "webpack/lib/webworker/WebWorkerTemplatePlugin"
 ]

--- a/packages/bundler-webpack/compiled/webpack/package.json
+++ b/packages/bundler-webpack/compiled/webpack/package.json
@@ -1,1 +1,5 @@
-{"name":"webpack","version":"5.75.0","author":"Tobias Koppers @sokra","license":"MIT","types":"types.d.ts"}
+{
+  "name": "webpack",
+  "author": "Tobias Koppers @sokra",
+  "types": "types.d.ts"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1122,6 +1122,19 @@ importers:
       umi: link:../../packages/umi
       vue: 3.2.45
 
+  examples/with-workerize-loader:
+    specifiers:
+      '@umijs/plugins': 4.0.50
+      antd: ^4.20.6
+      umi: 4.0.50
+      workerize-loader: ^2.0.2
+    dependencies:
+      '@umijs/plugins': link:../../packages/plugins
+      antd: 4.24.7
+      umi: link:../../packages/umi
+    devDependencies:
+      workerize-loader: 2.0.2
+
   examples/x-design:
     specifiers: {}
 
@@ -2158,7 +2171,7 @@ packages:
     dependencies:
       '@ant-design/colors': 6.0.0
       '@ant-design/icons-svg': 4.2.1
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.20.7
       classnames: 2.3.2
       rc-util: 5.27.1
 
@@ -17438,8 +17451,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -24011,7 +24024,7 @@ packages:
       pretty-format: 29.3.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_typescript@4.9.4
+      ts-node: 10.9.1_awa2wsr5thmg3i7jqycphctjfq
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -24727,11 +24740,6 @@ packages:
       minimist: 1.2.6
     dev: true
 
-  /json5/2.2.1:
-    resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
-    engines: {node: '>=6'}
-    hasBin: true
-
   /json5/2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -25177,7 +25185,7 @@ packages:
     dependencies:
       big.js: 5.2.2
       emojis-list: 3.0.0
-      json5: 2.2.1
+      json5: 2.2.3
 
   /loader-utils/3.2.0:
     resolution: {integrity: sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ==}
@@ -39172,6 +39180,17 @@ packages:
 
   /wordwrap/1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
+    dev: true
+
+  /workerize-loader/2.0.2:
+    resolution: {integrity: sha512-HoZ6XY4sHWxA2w0WpzgBwUiR3dv1oo7bS+oCwIpb6n54MclQ/7KXdXsVIChTCygyuHtVuGBO1+i3HzTt699UJQ==}
+    peerDependencies:
+      webpack: '*'
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+    dependencies:
+      loader-utils: 2.0.2
     dev: true
 
   /wrap-ansi/6.2.0:


### PR DESCRIPTION
## 背景
workerize-loader 实现使用了 `webpack/lib/node/NodeTargetPlugin` 和 `webpack/lib/webworker/WebWorkerTemplatePlugin` umi 中预打包后无法正确访问
![image](https://user-images.githubusercontent.com/7599351/216873564-97729e28-8248-4527-9ced-de9d431869e2.png)

## 解法

在 bundles 中 导出 通过 `deepImports` `requireHook` 自动映射
