### PR TITLE
fix: 建议增加对 PNPM 的幽灵依赖检测

### DIFF
--- a/packages/preset-umi/src/features/phantomDependency/phantomDependency.ts
+++ b/packages/preset-umi/src/features/phantomDependency/phantomDependency.ts
@@ -15,11 +15,11 @@ export default (api: IApi) => {
     enableBy: api.EnableBy.config,
   });
 
-  api.onStart(() => {
-    if (api.appData.npmClient === 'pnpm') {
-      api.logger.warn('Phantom dependencies check is not needed in pnpm.');
-    }
-  });
+//   api.onStart(() => {
+//     if (api.appData.npmClient === 'pnpm') {
+//       api.logger.warn('Phantom dependencies check is not needed in pnpm.');
+//     }
+//   });
 
   api.onPrepareBuildSuccess(({ result }) => {
     const files = Object.keys(result.metafile!.inputs);


### PR DESCRIPTION
PNPM 允许配置自定义依赖提升规则，可以在 `.npmrc` 中配置 `public-hoist-pattern`、`shamefully-hoist` 提升部分或全部依赖，这种情况下还是可能存在幽灵依赖。例如老工程从 yarn 迁移到 pnpm，本地运行会挂，在 `.npmrc` 中配置 `shamefully-hoist` 重新 `pnpm install` 再运行就正常了。出于提升工程质量考虑，建议对这种情况也进行检测。

https://pnpm.io/npmrc#dependency-hoisting-settings
