### PR TITLE
fix(app.ts): `defineApp` undefined

### DIFF
--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -636,9 +636,16 @@ export default function EmptyRoute() {
           runtimeConfigType,
         },
       });
-      exports.push(`export { defineApp } from './core/defineApp'`);
-      // https://javascript.plainenglish.io/leveraging-type-only-imports-and-exports-with-typescript-3-8-5c1be8bd17fb
-      exports.push(`export type {  RuntimeConfig } from './core/defineApp'`);
+      // FIXME: if exported after plugins, circular dependency:
+      //        `app.ts -> exports.ts -> plugin -> core/plugin.ts -> app.ts`
+      //        we will get a `defineApp` of `undefined`
+      // https://github.com/umijs/umi/issues/9702
+      // https://github.com/umijs/umi/issues/10412
+      exports.unshift(
+        `export { defineApp } from './core/defineApp'`,
+        // https://javascript.plainenglish.io/leveraging-type-only-imports-and-exports-with-typescript-3-8-5c1be8bd17fb
+        `export type { RuntimeConfig } from './core/defineApp'`,
+      );
       api.writeTmpFile({
         noPluginDir: true,
         path: 'exports.ts',


### PR DESCRIPTION
在 #10412 发现了更多循环依赖问题，其中 `defineApp` 在 max 中 `app.ts` 使用会崩溃 `undefined` ，所以把 #9708 这个 PR 一部分致命的问题先拆出来解掉。
