### PR TITLE
fix: respect unexpectedly for babel config file

### DIFF
--- a/packages/bundler-webpack/src/config/javaScriptRules.ts
+++ b/packages/bundler-webpack/src/config/javaScriptRules.ts
@@ -134,6 +134,7 @@ export async function addJavaScriptRules(opts: IOpts) {
           // https://github.com/webpack/webpack/issues/4039#issuecomment-419284940
           sourceType: 'unambiguous',
           babelrc: false,
+          configFile: false,
           cacheDirectory: false,
           browserslistConfigFile: false,
           // process.env.BABEL_CACHE !== 'none'

--- a/packages/preset-umi/src/features/legacy/legacy.ts
+++ b/packages/preset-umi/src/features/legacy/legacy.ts
@@ -185,6 +185,7 @@ function useBabelTransformSvgr(memo: WebpackChainConfig, api: IApi) {
     .options({
       sourceType: 'unambiguous',
       babelrc: false,
+      configFile: false,
       cacheDirectory: false,
       browserslistConfigFile: false,
       targets: api.config.targets,


### PR DESCRIPTION
修复编译时意外读取 `babel.config.js` 的问题