### PR TITLE
fix: 处理配置文件内, 判断是否启用webpack5的逻辑修改.

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,9 @@
     "open": "^8.0.2",
     "prettier": "^2.3.0",
     "prettier-plugin-organize-imports": "^2.1.0",
-    "yorkie": "^2.0.0"
+    "yorkie": "^2.0.0",
+    "esprima": "^4.0.1"
+
   },
   "repository": {
     "type": "git",

--- a/packages/umi/src/initWebpack.ts
+++ b/packages/umi/src/initWebpack.ts
@@ -3,7 +3,8 @@ import { init } from '@umijs/deps/compiled/webpack';
 import { createDebug } from '@umijs/utils';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
-
+const esprima = require('esprima');
+const ts = require('typescript');
 const debug = createDebug('umi:cli:initWebpack');
 
 const DEFAULT_CONFIG_FILES = [
@@ -31,15 +32,63 @@ export default () => {
   }
   const configFile = getConfigFile({ cwd });
   const configContent = configFile ? readFileSync(configFile, 'utf-8') : '';
-
+  let haveWebpack5 = false;
   // TODO: detect with ast
-  const haveWebpack5 =
-    (configContent.includes('webpack5:') &&
-      !configContent.includes('// webpack5:') &&
-      !configContent.includes('//webpack5:')) ||
-    (configContent.includes('mfsu:') &&
-      !configContent.includes('// mfsu:') &&
-      !configContent.includes('//mfsu:'));
+  try {
+    // 拿到js代码
+    const jscode = ts.transpileModule(configContent, {}).outputText;
+    // ast解析
+    const ast = esprima.parseModule(jscode);
+
+    // 循环ast节点, 判断是否有 mfsu 或者 webpack5
+    for (let i = 0; i < ast.body.length; i++) {
+      const node = ast.body[i];
+      if (
+        node.type === 'ExpressionStatement' &&
+        node.expression.type === 'AssignmentExpression' &&
+        node.expression.left.type === 'MemberExpression' &&
+        node.expression.left.object.type === 'Identifier' &&
+        node.expression.left.object.name === 'exports' &&
+        node.expression.left.property.type === 'Identifier' &&
+        node.expression.left.property.name === 'default'
+      ) {
+        // 深度优先 递归查找node.expression.right 下所有的属性, 看是否有key为name 值为mfsu 或者 webpack5的属性
+        const find = (node: any) => {
+          for (const key in node) {
+            if (Object.hasOwnProperty.call(node, key)) {
+              const element = node[key];
+              if (
+                key === 'name' &&
+                (element === 'mfsu' || element === 'webpack5')
+              ) {
+                return true;
+              } else if (typeof element === 'object') {
+                const result = find(element);
+                if (result) {
+                  return true;
+                }
+              }
+            }
+          }
+          return false;
+        };
+        const result = find(node.expression.right);
+        if (result) {
+          haveWebpack5 = true;
+          break;
+        }
+      }
+    }
+  } catch (error) {
+    console.log('error: ', error);
+    haveWebpack5 =
+      (configContent.includes('webpack5:') &&
+        !configContent.includes('// webpack5:') &&
+        !configContent.includes('//webpack5:')) ||
+      (configContent.includes('mfsu:') &&
+        !configContent.includes('// mfsu:') &&
+        !configContent.includes('//mfsu:'));
+  }
 
   debug(`haveWebpack5: ${haveWebpack5}`);
   debug(`process.env.USE_WEBPACK_5: ${process.env.USE_WEBPACK_5}`);


### PR DESCRIPTION
* 问题描述: 配置文件内部, 关于webpack5配置的字段, 如下图所示
  * ![image](https://user-images.githubusercontent.com/67814702/218055060-117f88bc-8e0c-41cc-8f5b-ece0d9d048df.png)
  * 因为 "// webpack5" 这段注释文本的存在会导致 haveWebpack5 这个变量判断错误, 但是实际上这只是一段注释代码.
* 所产生的影响:
  * 会错误的使用webpack4去进行打包, 从而导致api找不到而打包失败
  * ![image](https://user-images.githubusercontent.com/67814702/218055931-5da7ea00-1b53-438d-b38b-b2e8bd22f1c1.png)
