### PR TITLE
fix: pr_check and log

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -23,7 +23,7 @@ jobs:
 
     output-log:
     runs-on: ubuntu-latest
-    needs: [read-file]
+    needs: read-file
     steps:
       - name: contributors.json
         run: echo "${{ needs.read-file.outputs.require-result }}"
@@ -36,7 +36,7 @@ jobs:
 
   check-merged:
     runs-on: ubuntu-latest
-    needs: [read-file]
+    needs: read-file
     if: contains(fromJSON(needs.read-file.outputs.require-result), github.event.pull_request.user.login) == false && github.event.pull_request.merged == true
     steps:
       - uses: actions-cool/maintain-one-comment@v3

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -11,7 +11,7 @@ jobs:
   read-file:
     runs-on: ubuntu-latest
     outputs:
-      require-result: ${{ steps.contributors.outputs.content}}
+      require-result: ${{ steps.contributors.outputs.content }}
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -21,35 +21,23 @@ jobs:
         with:
           path: ./contributors.json
 
-  check-permission:
-    runs-on: ubuntu-latest
-    outputs:
-      require-result: ${{ steps.checkUser.outputs.require-result }}
-    steps:
-      - uses: actions-cool/check-user-permission@v2
-        id: checkUser
-        with:
-          require: 'write'
-
     output-log:
     runs-on: ubuntu-latest
-    needs: [read-file, check-permission]
+    needs: [read-file]
     steps:
-      - name: check-permission
-        run: echo "${{ needs.check-permission.outputs.require-result }}"
       - name: contributors.json
         run: echo "${{ needs.read-file.outputs.require-result }}"
-      - name: actor
-        run: echo "${{ github.actor }}"
+      - name: creator
+        run: echo "${{ github.event.pull_request.user.login }}"
       - name: contains
-        run: echo "${{ contains(fromJSON(needs.read-file.outputs.require-result), github.actor) }}"
+        run: echo "${{ contains(fromJSON(needs.read-file.outputs.require-result), github.event.pull_request.user.login) }}"
       - name: merged
         run: echo "${{ github.event.pull_request.merged }}"
 
   check-merged:
     runs-on: ubuntu-latest
-    needs: [read-file, check-permission]
-    if: needs.check-permission.outputs.require-result == 'false' && contains(fromJSON(needs.read-file.outputs.require-result), github.actor) == false && github.event.pull_request.merged == true
+    needs: [read-file]
+    if: contains(fromJSON(needs.read-file.outputs.require-result), github.event.pull_request.user.login) == false && github.event.pull_request.merged == true
     steps:
       - uses: actions-cool/maintain-one-comment@v3
         with:

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -31,6 +31,21 @@ jobs:
         with:
           require: 'write'
 
+    output-log:
+    runs-on: ubuntu-latest
+    needs: [read-file, check-permission]
+    steps:
+      - name: check-permission
+        run: echo "${{ needs.check-permission.outputs.require-result }}"
+      - name: contributors.json
+        run: echo "${{ needs.read-file.outputs.require-result }}"
+      - name: actor
+        run: echo "${{ github.actor }}"
+      - name: contains
+        run: echo "${{ contains(fromJSON(needs.read-file.outputs.require-result), github.actor) }}"
+      - name: merged
+        run: echo "${{ github.event.pull_request.merged }}"
+
   check-merged:
     runs-on: ubuntu-latest
     needs: [read-file, check-permission]


### PR DESCRIPTION
## why
这个ci未生效，查原因。 #10461 
![image](https://user-images.githubusercontent.com/9554297/218325642-644dbd10-cbb4-40bf-a731-4d941835aa7d.png)
## what
执行发消息步骤时被跳过了，应该是if判断没有通过。
## how
我在自己仓库复制了umi一样的回去，能够正常运行，排除'true'是字符串导致的问题。
![image](https://user-images.githubusercontent.com/9554297/218325761-035e7bcc-d747-48b4-bbbd-480e30f895e6.png)

判断有3个条件
1. 没有权限
2. 名字不在文件里
3. 必须被merged才会触发

建了个小号模拟，发现github.actor和needs.check-permission.outputs.require-result都是点合并的人的权限
所以前两个条件没通过，这块看一下获取创建pr的名字
![image](https://user-images.githubusercontent.com/9554297/218327343-181c9616-6911-4f9e-976f-9fa13a509787.png)

