### PR TITLE
wip: set esbuild minify iife format

### DIFF
--- a/packages/bundler-webpack/src/config/compressPlugin.ts
+++ b/packages/bundler-webpack/src/config/compressPlugin.ts
@@ -48,6 +48,8 @@ export async function addCompressPlugin(opts: IOpts) {
       target: esbuildTarget,
       // remove all comments
       legalComments: 'none',
+      // See https://github.com/esbuild-kit/esbuild-loader/issues/139
+      format: 'iife',
     } as EsbuildOpts;
   } else if (jsMinifier === JSMinifier.terser) {
     minify = TerserPlugin.terserMinify;


### PR DESCRIPTION
在这个 issue https://github.com/esbuild-kit/esbuild-loader/issues/139 中，为了解决 esbuild minify 污染全局变量问题，调整 format 为 `iife` ，我们也同步一下。