### PR TITLE
fix(prepare): alias handle

### DIFF
--- a/packages/preset-umi/src/features/prepare/build.ts
+++ b/packages/preset-umi/src/features/prepare/build.ts
@@ -16,6 +16,7 @@ export async function build(opts: {
   write?: boolean;
 }) {
   const outdir = path.join(path.dirname(opts.entryPoints[0]), 'out');
+  const alias = opts.config?.alias || {};
   return await esbuild.build({
     format: 'esm',
     platform: 'browser',
@@ -54,8 +55,8 @@ export async function build(opts: {
       // then we import 'foo/bar.less'
       // if we resolve alias first, we will get { path }
       // if we resolve externals first, we will get { external: true }
-      esbuildExternalPlugin(),
-      esbuildAliasPlugin({ alias: opts.config?.alias || {} }),
+      esbuildExternalPlugin({ alias }),
+      esbuildAliasPlugin({ alias }),
       ...(opts.plugins || []),
     ],
   });


### PR DESCRIPTION
修理 【prepare 没有覆盖通过 umi > exports > plugin-xxx/index.ts 链路引入的文件】 这个问题。

是因为对 alias 导入判断逻辑不完整导致的。