### PR TITLE
fix: 🐛 antd5 下 禁用 antd 插件开启 import=true 

### DIFF
--- a/packages/plugins/src/antd.ts
+++ b/packages/plugins/src/antd.ts
@@ -89,11 +89,11 @@ export default (api: IApi) => {
         ...theme,
         ...memo.theme,
       };
-      if (memo.antd?.style) {
-        const errorMessage = `Can't set antd.style while using antd5 (${antdVersion})`;
+      if (memo.antd?.import) {
+        const errorMessage = `Can't set antd.import while using antd5 (${antdVersion})`;
 
         api.logger.fatal(
-          'please remove config antd.style, then start server again',
+          'please change config antd.import to false, then start server again',
         );
 
         throw Error(errorMessage);


### PR DESCRIPTION
背景：
antd 5 的包目录格式已经不符合 babel-plugin-import 的要求，开启 plugin-layout 会触发此问题。

为什么不让 antd5 支持 babel-plugin-import ，做了 benchmark 

内部一个中等规模项目

 | import |构建时间 | 产物大小|
| ----:| ----:| ----:|
|   关闭| 1m8.43 | 6394942 |
| 开启| 1m10.96 | 6394920 | 

因此 直接 antd 插件 禁止开启 import 



