### PR TITLE
chore: replace next.umijs.org into current domain

### DIFF
--- a/packages/ast/src/setConfigByName/setConfigByName.ts
+++ b/packages/ast/src/setConfigByName/setConfigByName.ts
@@ -1,6 +1,6 @@
+import { parseExpression } from '@umijs/bundler-utils/compiled/babel/parser';
 import type { NodePath } from '@umijs/bundler-utils/compiled/babel/traverse';
 import * as traverse from '@umijs/bundler-utils/compiled/babel/traverse';
-import { parseExpression } from '@umijs/bundler-utils/compiled/babel/parser';
 import * as t from '@umijs/bundler-utils/compiled/babel/types';
 
 export function setConfigByName(ast: t.File, name: string, value: string) {
@@ -56,7 +56,7 @@ export function setConfigByName(ast: t.File, name: string, value: string) {
 
     if (!modified) {
       console.error(
-        `export config format can not be analysis, please reference to \nhttps://next.umijs.org/zh-CN/docs/guides/config-convention`,
+        `export config format can not be analysis, please reference to \nhttps://umijs.org/docs/guides/config-convention`,
       );
       throw Error(`Can't modify config file, due to file format`);
     }

--- a/packages/create-umi/templates/max/src/access.ts
+++ b/packages/create-umi/templates/max/src/access.ts
@@ -1,6 +1,6 @@
 export default (initialState: API.UserInfo) => {
   // 在这里按照初始化数据定义项目中的权限，统一管理
-  // 参考文档 https://next.umijs.org/docs/max/access
+  // 参考文档 https://umijs.org/docs/max/access
   const canSeeAdmin = !!(
     initialState && initialState.name !== 'dontHaveAccess'
   );

--- a/packages/create-umi/templates/max/src/app.ts
+++ b/packages/create-umi/templates/max/src/app.ts
@@ -1,7 +1,7 @@
 // 运行时配置
 
 // 全局初始化数据配置，用于 Layout 用户信息和权限初始化
-// 更多信息见文档：https://next.umijs.org/docs/api/runtime-config#getinitialstate
+// 更多信息见文档：https://umijs.org/docs/api/runtime-config#getinitialstate
 export async function getInitialState(): Promise<{ name: string }> {
   return { name: '@umijs/max' };
 }


### PR DESCRIPTION
1. 代码和注释中存在指向 `next.umijs.org` 的链接，替换为 `umijs.org`
2. 修复 `@umijs/bundler-utils/compiled/babel/parser` 导入顺序（lint 自动引入）