### PR TITLE
refactor: 🎨 improve performance onLoad should better use async function

### DIFF
--- a/packages/preset-umi/src/features/icons/esbuildIconPlugin.ts
+++ b/packages/preset-umi/src/features/icons/esbuildIconPlugin.ts
@@ -13,8 +13,8 @@ export function esbuildIconPlugin(opts: {
       const loaders: Loader[] = ['js', 'jsx', 'ts', 'tsx'];
       loaders.forEach((loader) => {
         const filter = new RegExp(`\\.(${loader})$`);
-        build.onLoad({ filter }, (args) => {
-          const contents = fs.readFileSync(args.path, 'utf-8');
+        build.onLoad({ filter }, async (args) => {
+          const contents = await fs.promises.readFile(args.path, 'utf-8');
           const icons = extractIcons(contents);
           logger.debug(`[icons] ${args.path} > ${icons}`);
           icons.forEach((icon) => {


### PR DESCRIPTION

参考

> Keep in mind that many callbacks may be running concurrently. In JavaScript, if your callback does expensive work that can run on another thread such as fs.readFileSync(), you should make the callback async and use await (in this case with fs.promises.readFile()) to allow other code to run in the meantime. In Go, each callback may be run on a separate goroutine. Make sure you have appropriate synchronization in place if your plugin uses any shared data structures.    
> 
> --from https://esbuild.github.io/plugins/#on-load
  