### PR TITLE
fix: 🐛 onload esbuild plungin call  override js[x] file loader

### DIFF
--- a/examples/max/components/decorator.jsx
+++ b/examples/max/components/decorator.jsx
@@ -1,0 +1,12 @@
+@decorator
+class TestDecorator {
+  render() {
+    return '1';
+  }
+}
+
+function decorator(x) {
+  return x;
+}
+
+export { TestDecorator };

--- a/examples/max/pages/index.tsx
+++ b/examples/max/pages/index.tsx
@@ -1,8 +1,10 @@
 // @ts-ignore
 import { history, Icon, useAccess, useIntl, useModel } from '@umijs/max';
 // @ts-ignore
+import { TestDecorator } from '@/components/decorator';
 import { Button, DatePicker, Input } from 'antd';
 import styles from './index.less';
+console.log(TestDecorator);
 
 const icons = ['local:rice', 'ant-design:fire-twotone'];
 


### PR DESCRIPTION
修复开启  icon  配置，js[x] 中使用 decorator 在 prepare 阶段报错的问题。

p.s  语法形式 1 , esbuild 目前[刚支持](https://github.com/microsoft/TypeScript/pull/52582), 所以我们的框架如果出现 ，暂时可以先绕过。
```ts
export @decorator class XXX {}   // 1
// 绕过
@decorator export class XXX {}  
```