### PR TITLE
fix(umi): catch unhandled promise rejction for node 14

### DIFF
--- a/packages/umi/src/cli/cli.ts
+++ b/packages/umi/src/cli/cli.ts
@@ -3,6 +3,7 @@ import { DEV_COMMAND } from '../constants';
 import { Service } from '../service/service';
 import { dev } from './dev';
 import {
+  catchUnhandledRejection,
   checkLocal,
   checkVersion as checkNodeVersion,
   setNodeTitle,
@@ -11,6 +12,8 @@ import {
 interface IOpts {
   presets?: string[];
 }
+
+catchUnhandledRejection();
 
 export async function run(opts?: IOpts) {
   checkNodeVersion();

--- a/packages/umi/src/cli/node.ts
+++ b/packages/umi/src/cli/node.ts
@@ -1,11 +1,12 @@
 import { isLocalDev, logger } from '@umijs/utils';
 import { FRAMEWORK_NAME, MIN_NODE_VERSION } from '../constants';
 
+const ver = parseInt(process.version.slice(1));
+
 export function checkVersion() {
-  const v = parseInt(process.version.slice(1));
-  if (v < MIN_NODE_VERSION || v === 15 || v === 17) {
+  if (ver < MIN_NODE_VERSION || ver === 15 || ver === 17) {
     logger.error(
-      `Your node version ${v} is not supported, please upgrade to ${MIN_NODE_VERSION} or above except 15 or 17.`,
+      `Your node version ${ver} is not supported, please upgrade to ${MIN_NODE_VERSION} or above except 15 or 17.`,
     );
     process.exit(1);
   }
@@ -20,5 +21,16 @@ export function checkLocal() {
 export function setNodeTitle(name?: string) {
   if (process.title === 'node') {
     process.title = name || FRAMEWORK_NAME;
+  }
+}
+
+export function catchUnhandledRejection() {
+  // catch unhandledRejection for Node.js 14
+  // because --unhandled-rejections=throw enabled since Node.js 15
+  // ref: http://nodejs.cn/api/cli/unhandled_rejections_mode.html
+  if (ver <= 14) {
+    process.on('unhandledRejection', (err) => {
+      throw err;
+    });
   }
 }


### PR DESCRIPTION
修复 Node.js v14 下 `UnhandledPromiseRejectionWarning` 只会 warning 不会进程退出的问题；比如在 `onBuildComplete` 钩子里有 Promise 调用且异常没有 `catch`，整个 `build` 命令仍然是成功的，这会导致雨燕等云构建平台给用户传递错误的构建状态

解法：对 <= Node.js v14 监听 `unhandledRejection` 事件手动抛出异常
备注：对 Node.js v15 以上版本无影响，因为 `--unhandled-rejections` 默认值改为 `throw` 了，http://nodejs.cn/api/cli/unhandled_rejections_mode.html