### PR TITLE
chore: add type

### DIFF
--- a/packages/plugins/src/request.ts
+++ b/packages/plugins/src/request.ts
@@ -9,12 +9,7 @@ export default (api: IApi) => {
       schema: (Joi) => {
         return Joi.alternatives().try(
           Joi.object({
-            dataField: Joi.alternatives().try(
-              Joi.string()
-                .pattern(/^[a-zA-Z]*$/)
-                .allow(''),
-              Joi.string(),
-            ),
+            dataField: Joi.string(),
           }),
           Joi.boolean().invalid(true),
         );

--- a/packages/plugins/src/request.ts
+++ b/packages/plugins/src/request.ts
@@ -9,9 +9,12 @@ export default (api: IApi) => {
       schema: (Joi) => {
         return Joi.alternatives().try(
           Joi.object({
-            dataField: Joi.string()
-              .pattern(/^[a-zA-Z]*$/)
-              .allow(''),
+            dataField: Joi.alternatives().try(
+              Joi.string()
+                .pattern(/^[a-zA-Z]*$/)
+                .allow(''),
+              Joi.string(),
+            ),
           }),
           Joi.boolean().invalid(true),
         );


### PR DESCRIPTION
## 背景
在使用这个参数的时候，类型提示里生成的是个空字符串，这里应该是个字符串，我看是加了一些判定条件最终导致了生成的类型是个空字符串。这里直接改成`Joi.string()`可以吗 @PeachScript .我觉得这里不会有人去填写奇怪的东西，毕竟是基于接口里面的变量来填写的，json帮我们限制了不能用特殊符号
![image](https://user-images.githubusercontent.com/9554297/221654456-b55c3418-1c5a-4f52-9cb7-3e175ba1ea6f.png)

