### PR TITLE
fix(lint): remove deprecated eslint rule

### DIFF
--- a/packages/lint/src/config/eslint/rules/recommended.ts
+++ b/packages/lint/src/config/eslint/rules/recommended.ts
@@ -78,7 +78,6 @@ export const jest = {
   'jest/no-identical-title': 2,
   'jest/no-interpolation-in-snapshots': 2,
   'jest/no-jasmine-globals': 2,
-  'jest/no-jest-import': 2,
   'jest/no-mocks-import': 2,
   'jest/no-standalone-expect': 2,
   'jest/valid-describe-callback': 2,


### PR DESCRIPTION
移除已经废弃的 eslint 规则，否则项目执行会提示规则找不到

Breaking change from eslint-plugin-jest: https://github.com/jest-community/eslint-plugin-jest/releases/tag/v27.0.0
Ref: #10609 