### PR TITLE
feat: add http2 switch into https user config

### DIFF
--- a/docs/docs/api/config.md
+++ b/docs/docs/api/config.md
@@ -735,11 +735,11 @@ headScripts: [
 
 开启 dev 的 https 模式。
 
-关于参数
+关于参数。
 
 - `cert` 和 `key` 分别用于指定 cert 和 key 文件。
 - `hosts` 用于指定要支持 https 访问的 host，默认是 `['127.0.0.1', 'localhost']`。
-- `http2` 用于指定是否使用 HTTP 2.0 协议（使用 HTTP 2.0 在 Chrome 或 Edge 浏览器中中有偶然出现 `ERR_HTTP2_PROTOCOL_ERRO`报错）。
+- `http2` 用于指定是否使用 HTTP 2.0 协议，默认是 true（使用 HTTP 2.0 在 Chrome 或 Edge 浏览器中中有偶然出现 `ERR_HTTP2_PROTOCOL_ERRO`报错，如有遇到，建议配置为 false）。
 
 示例，
 

--- a/docs/docs/api/config.md
+++ b/docs/docs/api/config.md
@@ -730,12 +730,16 @@ headScripts: [
 
 ## https
 
-- 类型：`{ cert: string; key: string; hosts: string[] }`
+- 类型：`{ cert: string; key: string; hosts: string[]; http2?: boolean }`
 - 默认值：`{ hosts: ['127.0.0.1', 'localhost'] }`
 
 开启 dev 的 https 模式。
 
-关于参数。`cert` 和 `key` 分别用于指定 cert 和 key 文件；`hosts` 用于指定要支持 https 访问的 host，默认是 `['127.0.0.1', 'localhost']`。
+关于参数
+
+- `cert` 和 `key` 分别用于指定 cert 和 key 文件。
+- `hosts` 用于指定要支持 https 访问的 host，默认是 `['127.0.0.1', 'localhost']`。
+- `http2` 用于指定是否使用 HTTP 2.0 协议（使用 HTTP 2.0 在 Chrome 或 Edge 浏览器中中有偶然出现 `ERR_HTTP2_PROTOCOL_ERRO`报错）。
 
 示例，
 

--- a/packages/bundler-utils/src/https.ts
+++ b/packages/bundler-utils/src/https.ts
@@ -93,10 +93,6 @@ function hasHostsChanged(jsonFile: string, hosts: string[]) {
   }
 }
 
-function selectProtocol(httpsConfig: HttpsServerOptions) {
-  return httpsConfig.http2 === false ? https : spdy;
-}
-
 export async function createHttpsServer(
   app: RequestListener,
   httpsConfig: HttpsServerOptions,
@@ -106,8 +102,10 @@ export async function createHttpsServer(
   const { key, cert } = await resolveHttpsConfig(httpsConfig);
 
   // Create server
-  const protocol = selectProtocol(httpsConfig);
-  return protocol.createServer(
+  const createServer = (
+    httpsConfig.http2 === false ? https.createServer : spdy.createServer
+  ) as typeof spdy.createServer;
+  return createServer(
     {
       key: readFileSync(key, 'utf-8'),
       cert: readFileSync(cert, 'utf-8'),

--- a/packages/bundler-utils/src/https.ts
+++ b/packages/bundler-utils/src/https.ts
@@ -1,6 +1,7 @@
 import { chalk, execa, logger } from '@umijs/utils';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { RequestListener } from 'http';
+import https from 'https';
 import { join } from 'path';
 import spdy from 'spdy';
 import { HttpsServerOptions } from './types';
@@ -92,6 +93,10 @@ function hasHostsChanged(jsonFile: string, hosts: string[]) {
   }
 }
 
+function selectProtocol(httpsConfig: HttpsServerOptions) {
+  return httpsConfig.http2 === false ? https : spdy;
+}
+
 export async function createHttpsServer(
   app: RequestListener,
   httpsConfig: HttpsServerOptions,
@@ -101,7 +106,8 @@ export async function createHttpsServer(
   const { key, cert } = await resolveHttpsConfig(httpsConfig);
 
   // Create server
-  return spdy.createServer(
+  const protocol = selectProtocol(httpsConfig);
+  return protocol.createServer(
     {
       key: readFileSync(key, 'utf-8'),
       cert: readFileSync(cert, 'utf-8'),

--- a/packages/bundler-utils/src/types.ts
+++ b/packages/bundler-utils/src/types.ts
@@ -3,6 +3,7 @@ export interface HttpsServerOptions {
   key?: string;
   cert?: string;
   hosts?: string[]; // 默认值 ['localhost', '127.0.0.1']
+  http2?: boolean;
 }
 
 type HPMFnArgs = Parameters<NonNullable<HPMOptions['onProxyReq']>>;

--- a/packages/bundler-utils/src/types.ts
+++ b/packages/bundler-utils/src/types.ts
@@ -1,16 +1,115 @@
-import type { Options as HPMOptions } from '../compiled/http-proxy-middleware';
-export interface HttpsServerOptions {
-  key?: string;
-  cert?: string;
-  hosts?: string[]; // 默认值 ['localhost', '127.0.0.1']
-  http2?: boolean;
+import { chalk, execa, logger } from '@umijs/utils';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { RequestListener } from 'http';
+import https from 'https';
+import { join } from 'path';
+import spdy from 'spdy';
+import { HttpsServerOptions } from './types';
+
+const defaultHttpsHosts: HttpsServerOptions['hosts'] = [
+  'localhost',
+  '127.0.0.1',
+];
+
+export type { Server as SpdyServer } from 'spdy';
+
+// vite mode requires a key cert
+export async function resolveHttpsConfig(httpsConfig: HttpsServerOptions) {
+  let { key, cert, hosts } = httpsConfig;
+
+  // if the key and cert are provided return directly
+  if (key && cert) {
+    return {
+      key,
+      cert,
+    };
+  }
+
+  // Check if mkcert is installed
+  try {
+    // use mkcert -help instead of mkcert --version for checking if mkcert is installed, cause mkcert --version does not exists in Linux
+    await execa.execa('mkcert', ['-help']);
+  } catch (e) {
+    logger.error('[HTTPS] The mkcert has not been installed.');
+    logger.info('[HTTPS] Please follow the guide to install manually.');
+    switch (process.platform) {
+      case 'darwin':
+        console.log(chalk.green('$ brew install mkcert'));
+        console.log(chalk.gray('# If you use firefox, please install nss.'));
+        console.log(chalk.green('$ brew install nss'));
+        console.log(chalk.green('$ mkcert -install'));
+        break;
+      case 'win32':
+        console.log(
+          chalk.green('Checkout https://github.com/FiloSottile/mkcert#windows'),
+        );
+        break;
+      case 'linux':
+        console.log(
+          chalk.green('Checkout https://github.com/FiloSottile/mkcert#linux'),
+        );
+        break;
+      default:
+        break;
+    }
+    throw new Error(`[HTTPS] mkcert not found.`, { cause: e });
+  }
+
+  hosts = hosts || defaultHttpsHosts;
+  key = join(__dirname, 'umi.https.key.pem');
+  cert = join(__dirname, 'umi.https.pem');
+  const json = join(__dirname, 'umi.https.json');
+
+  // Generate cert and key files if they are not exist.
+  if (
+    !existsSync(key) ||
+    !existsSync(cert) ||
+    !existsSync(json) ||
+    !hasHostsChanged(json, hosts!)
+  ) {
+    logger.wait('[HTTPS] Generating cert and key files...');
+    await execa.execa('mkcert', [
+      '-cert-file',
+      cert,
+      '-key-file',
+      key,
+      ...hosts!,
+    ]);
+    writeFileSync(json, JSON.stringify({ hosts }), 'utf-8');
+  }
+
+  return {
+    key,
+    cert,
+  };
 }
 
-type HPMFnArgs = Parameters<NonNullable<HPMOptions['onProxyReq']>>;
-export interface ProxyOptions extends HPMOptions {
-  target?: string;
-  context?: string | string[];
-  bypass?: (
-    ...args: [HPMFnArgs[1], HPMFnArgs[2], HPMFnArgs[3]]
-  ) => string | boolean | null | void;
+function hasHostsChanged(jsonFile: string, hosts: string[]) {
+  try {
+    const json = JSON.parse(readFileSync(jsonFile, 'utf-8'));
+    return json.hosts.join(',') === hosts.join(',');
+  } catch (e) {
+    return true;
+  }
+}
+
+export async function createHttpsServer(
+  app: RequestListener,
+  httpsConfig: HttpsServerOptions,
+) {
+  logger.wait('[HTTPS] Starting service in https mode...');
+
+  const { key, cert } = await resolveHttpsConfig(httpsConfig);
+
+  // Create server
+  const createServer = (
+    httpsConfig.http2 === false ? https.createServer : spdy.createServer
+  ) as typeof spdy.createServer;
+  return createServer(
+    {
+      key: readFileSync(key, 'utf-8'),
+      cert: readFileSync(cert, 'utf-8'),
+    },
+    app,
+  );
 }

--- a/packages/bundler-utils/src/types.ts
+++ b/packages/bundler-utils/src/types.ts
@@ -1,115 +1,16 @@
-import { chalk, execa, logger } from '@umijs/utils';
-import { existsSync, readFileSync, writeFileSync } from 'fs';
-import { RequestListener } from 'http';
-import https from 'https';
-import { join } from 'path';
-import spdy from 'spdy';
-import { HttpsServerOptions } from './types';
-
-const defaultHttpsHosts: HttpsServerOptions['hosts'] = [
-  'localhost',
-  '127.0.0.1',
-];
-
-export type { Server as SpdyServer } from 'spdy';
-
-// vite mode requires a key cert
-export async function resolveHttpsConfig(httpsConfig: HttpsServerOptions) {
-  let { key, cert, hosts } = httpsConfig;
-
-  // if the key and cert are provided return directly
-  if (key && cert) {
-    return {
-      key,
-      cert,
-    };
-  }
-
-  // Check if mkcert is installed
-  try {
-    // use mkcert -help instead of mkcert --version for checking if mkcert is installed, cause mkcert --version does not exists in Linux
-    await execa.execa('mkcert', ['-help']);
-  } catch (e) {
-    logger.error('[HTTPS] The mkcert has not been installed.');
-    logger.info('[HTTPS] Please follow the guide to install manually.');
-    switch (process.platform) {
-      case 'darwin':
-        console.log(chalk.green('$ brew install mkcert'));
-        console.log(chalk.gray('# If you use firefox, please install nss.'));
-        console.log(chalk.green('$ brew install nss'));
-        console.log(chalk.green('$ mkcert -install'));
-        break;
-      case 'win32':
-        console.log(
-          chalk.green('Checkout https://github.com/FiloSottile/mkcert#windows'),
-        );
-        break;
-      case 'linux':
-        console.log(
-          chalk.green('Checkout https://github.com/FiloSottile/mkcert#linux'),
-        );
-        break;
-      default:
-        break;
-    }
-    throw new Error(`[HTTPS] mkcert not found.`, { cause: e });
-  }
-
-  hosts = hosts || defaultHttpsHosts;
-  key = join(__dirname, 'umi.https.key.pem');
-  cert = join(__dirname, 'umi.https.pem');
-  const json = join(__dirname, 'umi.https.json');
-
-  // Generate cert and key files if they are not exist.
-  if (
-    !existsSync(key) ||
-    !existsSync(cert) ||
-    !existsSync(json) ||
-    !hasHostsChanged(json, hosts!)
-  ) {
-    logger.wait('[HTTPS] Generating cert and key files...');
-    await execa.execa('mkcert', [
-      '-cert-file',
-      cert,
-      '-key-file',
-      key,
-      ...hosts!,
-    ]);
-    writeFileSync(json, JSON.stringify({ hosts }), 'utf-8');
-  }
-
-  return {
-    key,
-    cert,
-  };
+import type { Options as HPMOptions } from '../compiled/http-proxy-middleware';
+export interface HttpsServerOptions {
+  key?: string;
+  cert?: string;
+  hosts?: string[]; // 默认值 ['localhost', '127.0.0.1']
+  http2?: boolean;
 }
 
-function hasHostsChanged(jsonFile: string, hosts: string[]) {
-  try {
-    const json = JSON.parse(readFileSync(jsonFile, 'utf-8'));
-    return json.hosts.join(',') === hosts.join(',');
-  } catch (e) {
-    return true;
-  }
-}
-
-export async function createHttpsServer(
-  app: RequestListener,
-  httpsConfig: HttpsServerOptions,
-) {
-  logger.wait('[HTTPS] Starting service in https mode...');
-
-  const { key, cert } = await resolveHttpsConfig(httpsConfig);
-
-  // Create server
-  const createServer = (
-    httpsConfig.http2 === false ? https.createServer : spdy.createServer
-  ) as typeof spdy.createServer;
-  return createServer(
-    {
-      key: readFileSync(key, 'utf-8'),
-      cert: readFileSync(cert, 'utf-8'),
-    },
-    app,
-  );
+type HPMFnArgs = Parameters<NonNullable<HPMOptions['onProxyReq']>>;
+export interface ProxyOptions extends HPMOptions {
+  target?: string;
+  context?: string | string[];
+  bypass?: (
+    ...args: [HPMFnArgs[1], HPMFnArgs[2], HPMFnArgs[3]]
+  ) => string | boolean | null | void;
 }


### PR DESCRIPTION
背景：
https 基于 spdy 实现，开启 https 后多刷几次会报「ERR_HTTP2_PROTOCOL_ERROR」的问题

方案：
https 增加 http2 配置项，配置 https: { http2: false } 后不走 spdy，降级回普通的 https