### PR TITLE
fix: Http proxy CORS problem, Keep origin by default.

### DIFF
--- a/packages/bundler-utils/src/proxy.ts
+++ b/packages/bundler-utils/src/proxy.ts
@@ -32,8 +32,8 @@ export function createProxy(
         ...proxy,
         onProxyReq(proxyReq, req: any, res) {
           // add origin in request header
-          if (proxyReq.getHeader('origin')) {
-            proxyReq.setHeader('origin', new URL(proxy.target!)?.href || '');
+          if (proxy.changeOrigin && proxyReq.getHeader('origin')) {
+            proxyReq.setHeader('origin', new URL(proxy.target!)?.origin || '');
           }
           proxy.onProxyReq?.(proxyReq, req, res, proxy);
         },


### PR DESCRIPTION
#10692 
我修改了一下这段代码，默认情况下不修改Header中的Origin字段，以避免CORS问题
在开启changeOrigin的情况下，http-proxy库会修改Header中的host字段，但是不会修改Origin字段，所以也会导致CORS问题
我加了个判定，changeOrigin开启的时候，修改Origin字段。 这样做既可以让changeOrgin这个控制参数更符合预期，同时避免了CORS问题

修改之后的changeOrigin行为：
* changeOrigin为false：默认行为，不改变请求的origin和host
* changeOrigin为true：请求的origin和host会替换为target的origin
两种模式都不会有CORS问题
