### PR TITLE
feat: deadcode with more args

### DIFF
--- a/examples/ant-design-pro/package.json
+++ b/examples/ant-design-pro/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "max build",
-    "deadcode": "max deadcode",
+    "deadcode": "max deadcode --out unused.json --git-info",
     "dev": "max dev",
     "setup": "max setup",
     "start": "npm run dev",

--- a/packages/preset-umi/src/commands/deadcode.ts
+++ b/packages/preset-umi/src/commands/deadcode.ts
@@ -153,7 +153,7 @@ export default (api: IApi) => {
       const tsconfig = (await tsconfigPaths.loadConfig(cwd)) as ITsconfig;
 
       // 是否生成文件
-      const outFile = api.args?.pathPrefix;
+      const outFile = api.args?.outFile;
       // 生成文件包含更多文件创建、最新修改等信息
       const verbose = api.args?.verbose;
       // monorepo git目录不在当前项目目录，一般需要添加 ../.. 的path前缀定位

--- a/packages/utils/src/getFileGitIno.ts
+++ b/packages/utils/src/getFileGitIno.ts
@@ -1,0 +1,127 @@
+import type { SpawnOptions } from 'child_process';
+import crossSpawn from 'cross-spawn';
+import { logger } from './index';
+
+const promisifySpawn = (
+  cmd: string,
+  args: string[],
+  {
+    onlyOnce,
+    ...rest
+  }: {
+    onlyOnce?: boolean;
+  } & SpawnOptions,
+) =>
+  new Promise<string[]>((resolve, reject) => {
+    const cp = crossSpawn(cmd, args, rest);
+    const error: string[] = [];
+    const stdout: string[] = [];
+
+    cp.stdout?.on('data', (data: Buffer) => {
+      stdout.push(data.toString());
+      if (onlyOnce) {
+        cp.kill('SIGKILL');
+      }
+    });
+
+    cp.on('error', (e) => {
+      error.push(e.toString());
+    });
+
+    cp.on('close', () => {
+      if (error.length) {
+        reject(error.join(''));
+      } else {
+        resolve(stdout);
+      }
+    });
+  });
+
+interface ICreateInfo {
+  createTime?: string;
+  creator?: string;
+  creatorEmail?: string;
+  createSince?: string;
+}
+interface IModifyInfo {
+  modifyTime?: string;
+  modifier?: string;
+  modifierEmail?: string;
+  modifySince?: string;
+}
+/**
+ * 获取文件创建信息
+ * @param filePath 文件路径，绝对或相对 .git
+ * @param gitDirPath .git路径
+ * @returns
+ */
+export const getFileCreateInfo = async (
+  filePath: string,
+  gitDirPath?: string,
+) => {
+  return promisifySpawn(
+    'git',
+    // time|name|email|since
+    ['log', '--reverse', '-1000000', "--pretty='%ad|%an|%ae|%ar'", filePath],
+    {
+      cwd: gitDirPath,
+      onlyOnce: true,
+      shell: true,
+    },
+  )
+    .then<ICreateInfo>((info) => {
+      if (info.length && info[0]) {
+        const firstCommit = info[0].slice(0, info[0].indexOf('\n')).split('|');
+        return {
+          createTime: firstCommit.at(0),
+          creator: firstCommit.at(1),
+          creatorEmail: firstCommit.at(2),
+          createSince: firstCommit.at(3),
+        };
+      } else {
+        return {};
+      }
+    })
+    .catch((e) => {
+      logger.warn(e);
+      return {};
+    });
+};
+
+/**
+ * 获取文件最新修改信息
+ * @param filePath 文件路径，绝对或相对 .git
+ * @param gitDirPath .git路径
+ * @returns
+ */
+export const getFileLastModifyInfo = async (
+  filePath: string,
+  gitDirPath?: string,
+) => {
+  return promisifySpawn(
+    'git',
+    ['log', '-1', "--pretty='%ad|%an|%ae|%ar'", filePath],
+    {
+      cwd: gitDirPath,
+      onlyOnce: true,
+      shell: true,
+    },
+  )
+    .then<IModifyInfo>((info: string[]) => {
+      if (info.length && info[0]) {
+        const firstCommit = info[0].slice(0, info[0].indexOf('\n')).split('|');
+        return {
+          modifyTime: firstCommit.at(0),
+          modifier: firstCommit.at(1),
+          modifierEmail: firstCommit.at(2),
+          modifySince: firstCommit.at(3),
+        };
+      } else {
+        return {};
+      }
+    })
+    .catch((e) => {
+      logger.warn(e);
+      return {};
+    });
+};

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -39,7 +39,7 @@ import updatePackageJSON from './updatePackageJSON';
 export * as aliasUtils from './aliasUtils';
 export * from './getCorejsVersion';
 export * from './getDevBanner';
-export * from './getFileGitIno';
+export * as git from './getFileGitIno';
 export * from './importLazy';
 export * from './isLocalDev';
 export * from './isMonorepo';

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -39,6 +39,7 @@ import updatePackageJSON from './updatePackageJSON';
 export * as aliasUtils from './aliasUtils';
 export * from './getCorejsVersion';
 export * from './getDevBanner';
+export * from './getFileGitIno';
 export * from './importLazy';
 export * from './isLocalDev';
 export * from './isMonorepo';


### PR DESCRIPTION
增强 deadcode 功能：
metion：#10623
默认直接输出文件 url，通过命令行点击进入文件，可输出json文件，开启verbose模式，可在生成文件中记录更多信息；
很多 老旧业务、多人协作水平不均 的业务，需要定期记录 deadcode 的情况，以做治理规划；

增加cli 参数：
- --out-file 是否生成文件，默认生成未使用文件数组json；
- --verbose 生成文件携带更多信息，包括文件创建时及最新修改的信息（通过git）；
- --path-prefix monorepo .git 文件夹通常不在项目文件夹，需添加路径前缀寻找；

ant-design-pro example 测试：

`node_modules/.bin/max deadcode`
![image](https://user-images.githubusercontent.com/21687167/224016041-92a8bf32-ad20-41ee-870c-f1c9eeed6ad7.png)

`node_modules/.bin/max deadcode --out-file --verbose --path-prefix=../..`
![image](https://user-images.githubusercontent.com/21687167/224017647-a252793f-7d1f-43c1-ac66-3c387c687389.png)

