### PR TITLE
fix: page not prerendered should not hydrate

### DIFF
--- a/packages/preset-umi/src/features/exportStatic/exportStatic.ts
+++ b/packages/preset-umi/src/features/exportStatic/exportStatic.ts
@@ -232,7 +232,7 @@ export default (api: IApi) => {
     api.appData.exportHtmlData = htmlData;
 
     api.writeTmpFile({
-      path: 'exportStaticRuntimePlugin.ts',
+      path: 'core/exportStaticRuntimePlugin.ts',
       content: Mustache.render(
         `
 export function modifyClientRenderOpts(memo: any) {
@@ -252,18 +252,11 @@ export function modifyClientRenderOpts(memo: any) {
           ),
         },
       ),
+      noPluginDir: true,
     });
   });
 
   api.addRuntimePlugin(() => {
-    return [
-      winPath(
-        join(
-          api.paths.absTmpPath,
-          `plugin-${api.plugin.key}`,
-          'exportStaticRuntimePlugin.ts',
-        ),
-      ),
-    ];
+    return [`@@/core/exportStaticRuntimePlugin.ts`];
   });
 };


### PR DESCRIPTION
## Background

当前在 `exportStatic` 中配置了 `prerender: false` 的页面仍然会在客户端注水，因为 dom 不匹配会导致 SSR 警告转为 CSR。

比如 antd 官网的 demo 页：https://ant-design.antgroup.com/~demos/components-button-demo-basic

![image](https://user-images.githubusercontent.com/27722486/224286716-f7a11e63-7d37-419f-8d70-91ea3f484a58.png)


## Solution

配置了 `prerender: false` 的页面直接客户端渲染，不走注水逻辑。