### PR TITLE
fix(c2c): clickToComponent only in dev mode

### DIFF
--- a/packages/preset-umi/src/features/clickToComponent/clickToComponent.ts
+++ b/packages/preset-umi/src/features/clickToComponent/clickToComponent.ts
@@ -41,8 +41,9 @@ return React.createElement(
   (props) => {
     return (
       <>
-        <ClickToComponent editor="${api.config.clickToComponent.editor || 'vscode'
-          }"/>
+        <ClickToComponent editor="${
+          api.config.clickToComponent.editor || 'vscode'
+        }"/>
         {props.children}
       </>
     );

--- a/packages/preset-umi/src/features/clickToComponent/clickToComponent.ts
+++ b/packages/preset-umi/src/features/clickToComponent/clickToComponent.ts
@@ -31,9 +31,10 @@ export default (api: IApi) => {
   api.onGenerateFiles({
     name: 'clickToComponent',
     fn: () => {
-      api.writeTmpFile({
-        path: 'runtime.tsx',
-        content: `
+      if (api.env === 'development') {
+        api.writeTmpFile({
+          path: 'runtime.tsx',
+          content: `
 import { ClickToComponent } from 'click-to-react-component';
 import React from 'react';
 export function rootContainer(container, opts) {
@@ -53,10 +54,16 @@ return React.createElement(
 );
 }
     `,
-      });
+        });
+      }
     },
   });
-  api.addRuntimePlugin(() => [
-    winPath(join(api.paths.absTmpPath, 'plugin-clickToComponent/runtime.tsx')),
-  ]);
+
+  if (api.env === 'development') {
+    api.addRuntimePlugin(() => [
+      winPath(
+        join(api.paths.absTmpPath, 'plugin-clickToComponent/runtime.tsx'),
+      ),
+    ]);
+  }
 };

--- a/packages/preset-umi/src/features/clickToComponent/clickToComponent.ts
+++ b/packages/preset-umi/src/features/clickToComponent/clickToComponent.ts
@@ -12,7 +12,7 @@ export default (api: IApi) => {
         });
       },
     },
-    enableBy: api.EnableBy.config,
+    enableBy: api.env === 'development' ? api.EnableBy.config : () => false,
   });
 
   const pkgPath = dirname(require.resolve('click-to-react-component'));
@@ -31,10 +31,9 @@ export default (api: IApi) => {
   api.onGenerateFiles({
     name: 'clickToComponent',
     fn: () => {
-      if (api.env === 'development') {
-        api.writeTmpFile({
-          path: 'runtime.tsx',
-          content: `
+      api.writeTmpFile({
+        path: 'runtime.tsx',
+        content: `
 import { ClickToComponent } from 'click-to-react-component';
 import React from 'react';
 export function rootContainer(container, opts) {
@@ -42,9 +41,8 @@ return React.createElement(
   (props) => {
     return (
       <>
-        <ClickToComponent editor="${
-          api.config.clickToComponent.editor || 'vscode'
-        }"/>
+        <ClickToComponent editor="${api.config.clickToComponent.editor || 'vscode'
+          }"/>
         {props.children}
       </>
     );
@@ -54,16 +52,10 @@ return React.createElement(
 );
 }
     `,
-        });
-      }
+      });
     },
   });
-
-  if (api.env === 'development') {
-    api.addRuntimePlugin(() => [
-      winPath(
-        join(api.paths.absTmpPath, 'plugin-clickToComponent/runtime.tsx'),
-      ),
-    ]);
-  }
+  api.addRuntimePlugin(() => [
+    winPath(join(api.paths.absTmpPath, 'plugin-clickToComponent/runtime.tsx')),
+  ]);
 };


### PR DESCRIPTION
`click-to-react-component` 组件虽然做了如下处理，但在生产模式下启用的话其组件仍然会被打包，且默认不会走构建，会导致低版本浏览器兼容问题

``` js
// index.js
export const ClickToComponent =
  process.env.NODE_ENV === 'development' ? Component : () => null

// ContextMenu.js
if (!open) onClose?.()
```
