### PR TITLE
fix(locale): 修复 locale 空配置时 antd 缺失部分内容的情况

### DIFF
--- a/packages/plugins/src/locale.ts
+++ b/packages/plugins/src/locale.ts
@@ -146,7 +146,7 @@ export default (api: IApi) => {
 
     let DefaultAntdLocales: string[] = [];
     // set antd default locale
-    if (!antdLocales.length && api.config.locale?.antd) {
+    if (!antdLocales.length && antd) {
       const [lang, country = ''] = defaultLocale.split(baseSeparator);
       DefaultAntdLocales = lodash.uniq(
         await addAntdLocales({


### PR DESCRIPTION
当仅配置 `locale: {}` 时，会得到：
![image](https://user-images.githubusercontent.com/46307343/225380620-52829dbe-9d28-4ba2-a3dd-130ef30f574f.png)
