### PR TITLE
feat(Server): allow devServer be configured *not* to use http2 when in https mode

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -363,10 +363,16 @@ if (false) {
 
 - port，端口号，默认 `8000`
 - host，默认 `0.0.0.0`
-- https，是否启用 https server，同时也会开启 HTTP/2
+- https，是否启用 https server
 - writeToDisk，生成 `assets` 到文件系统
 
 启用 port 和 host 也可以通过环境变量 PORT 和 HOST 临时指定。
+
+关于 https 配置项。
+
+- 可以通过 `https: true` 或 `https: {}` 开启，使用 umi 内置的证书，http/2 也会开启。
+- 如果不希望使用 http/2，可以通过 `https: { http2: false }` 关闭。(使用 HTTP 2.0 在 Chrome 或 Edge 浏览器中中有偶然出现 `ERR_HTTP2_PROTOCOL_ERROR`报错，如有遇到，建议使用此配置)
+- 如果希望使用自定义证书，可以通过 `https: { cert: '...', key: '...' }` 配置， key 和 cert 指定文件路径。
 
 ## devtool
 

--- a/docs/config/README.zh-CN.md
+++ b/docs/config/README.zh-CN.md
@@ -362,10 +362,16 @@ if (false) {
 
 - port，端口号，默认 `8000`
 - host，默认 `0.0.0.0`
-- https，是否启用 https server，同时也会开启 HTTP/2
+- https，是否启用 https server
 - writeToDisk，生成 `assets` 到文件系统
 
 启用 port 和 host 也可以通过环境变量 PORT 和 HOST 临时指定。
+
+关于 https 配置项。
+
+- 可以通过 `https: true` 或 `https: {}` 开启，使用 umi 内置的证书，http/2 也会开启。
+- 如果不希望使用 http/2，可以通过 `https: { http2: false }` 关闭。(使用 HTTP 2.0 在 Chrome 或 Edge 浏览器中中有偶然出现 `ERR_HTTP2_PROTOCOL_ERROR`报错，如有遇到，建议使用此配置)
+- 如果希望使用自定义证书，可以通过 `https: { cert: '...', key: '...' }` 配置， key 和 cert 指定文件路径。
 
 ## devtool
 

--- a/packages/bundler-webpack/src/getConfig/getConfig.webpack5.test.ts
+++ b/packages/bundler-webpack/src/getConfig/getConfig.webpack5.test.ts
@@ -19,9 +19,9 @@ test('nodePolyfill', async () => {
   const providePlugins = config.plugins?.filter(
     (plugin) => plugin instanceof defaultWebpack.ProvidePlugin,
   );
-  expect(providePlugins.length).toBeGreaterThan(0);
+  expect(providePlugins?.length).toBeGreaterThan(0);
 
-  const nodePolyfillPlugin: any = providePlugins.find(
+  const nodePolyfillPlugin: any = providePlugins?.find(
     (plugin) => (plugin as any)?.definitions?.Buffer,
   );
 
@@ -45,7 +45,7 @@ test('disable nodePolyfill', async () => {
   const providePlugins = config.plugins?.filter(
     (plugin) => plugin instanceof defaultWebpack.ProvidePlugin,
   );
-  const nodePolyfillPlugin: any = providePlugins.find(
+  const nodePolyfillPlugin: any = providePlugins?.find(
     (plugin) => (plugin as any)?.definitions?.Buffer,
   );
 

--- a/packages/preset-built-in/src/plugins/features/devServer.ts
+++ b/packages/preset-built-in/src/plugins/features/devServer.ts
@@ -15,6 +15,7 @@ export default (api: IApi) => {
                 .object({
                   key: joi.string(),
                   cert: joi.string(),
+                  http2: joi.boolean(),
                 })
                 .unknown(),
               joi.boolean(),

--- a/packages/server/src/Server/utils.test.ts
+++ b/packages/server/src/Server/utils.test.ts
@@ -65,6 +65,24 @@ describe('ServerUtils', () => {
         key: join(__dirname, 'cert', 'key.pem'),
         cert: join(__dirname, 'cert', 'cert.pem'),
       });
+
+      expect(
+        getCredentials({
+          https: {},
+        }),
+      ).toEqual({
+        key: join(__dirname, 'cert', 'key.pem'),
+        cert: join(__dirname, 'cert', 'cert.pem'),
+      });
+
+      expect(
+        getCredentials({
+          https: { http2: false },
+        }),
+      ).toEqual({
+        key: join(__dirname, 'cert', 'key.pem'),
+        cert: join(__dirname, 'cert', 'cert.pem'),
+      });
     });
   });
 });

--- a/packages/server/src/Server/utils.test.ts
+++ b/packages/server/src/Server/utils.test.ts
@@ -80,6 +80,7 @@ describe('ServerUtils', () => {
           https: { http2: false },
         }),
       ).toEqual({
+        http2: false,
         key: join(__dirname, 'cert', 'key.pem'),
         cert: join(__dirname, 'cert', 'cert.pem'),
       });

--- a/packages/server/src/Server/utils.ts
+++ b/packages/server/src/Server/utils.ts
@@ -6,16 +6,33 @@ import { IHttps, IServerOpts } from './Server';
 
 const logger = new Logger('@umijs/server:utils');
 
-export const getCredentials = (opts: IServerOpts): IHttps => {
-  const { https } = opts;
-  const defautlServerOptions: IHttps = {
+function useDefaultKeyCertOptions(httpsOptions: IServerOpts['https']): IHttps {
+  const defaultKeyCertOptions: IHttps = {
     key: join(__dirname, 'cert', 'key.pem'),
     cert: join(__dirname, 'cert', 'cert.pem'),
   };
-  // custom cert using https: { key: '', cert: '' }
-  const serverOptions = (
-    https === true ? defautlServerOptions : https
-  ) as IHttps;
+
+  if (httpsOptions === true) {
+    return defaultKeyCertOptions;
+  }
+  if (typeof httpsOptions === 'object') {
+    const keys = Object.keys(httpsOptions) as Array<keyof typeof httpsOptions>;
+    if (keys.length === 0) {
+      return defaultKeyCertOptions;
+    }
+    if (keys.length === 1 && keys[0] === 'http2') {
+      return defaultKeyCertOptions;
+    }
+    return httpsOptions;
+  }
+  return {};
+}
+
+export const getCredentials = (opts: IServerOpts): IHttps => {
+  const { https } = opts;
+
+  const serverOptions = useDefaultKeyCertOptions(https);
+
   if (!serverOptions?.key || !serverOptions?.cert) {
     const err = new Error(
       `Both options.https.key and options.https.cert are required.`,

--- a/packages/server/src/Server/utils.ts
+++ b/packages/server/src/Server/utils.ts
@@ -16,14 +16,7 @@ function useDefaultKeyCertOptions(httpsOptions: IServerOpts['https']): IHttps {
     return defaultKeyCertOptions;
   }
   if (typeof httpsOptions === 'object') {
-    const keys = Object.keys(httpsOptions) as Array<keyof typeof httpsOptions>;
-    if (keys.length === 0) {
-      return defaultKeyCertOptions;
-    }
-    if (keys.length === 1 && keys[0] === 'http2') {
-      return defaultKeyCertOptions;
-    }
-    return httpsOptions;
+    return { ...defaultKeyCertOptions, ...httpsOptions };
   }
   return {};
 }


### PR DESCRIPTION
This PR implements the same functionality as #10693 but in umi3.