### PR TITLE
chore(webpack): 将所有打包资源添加可配置的前缀  staticPathPrefix

### DIFF
--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -118,9 +118,15 @@ export async function getConfig(opts: IOpts): Promise<Configuration> {
   const disableCompress = process.env.COMPRESS === 'none';
   config.output
     .path(absOutputPath)
-    .filename(useHash ? `[name].[contenthash:8].js` : `[name].js`)
+    .filename(
+      useHash
+        ? `${applyOpts.staticPathPrefix}[name].[contenthash:8].js`
+        : `${applyOpts.staticPathPrefix}[name].js`,
+    )
     .chunkFilename(
-      useHash ? `[name].[contenthash:8].async.js` : `[name].async.js`,
+      useHash
+        ? `${applyOpts.staticPathPrefix}[name].[contenthash:8].async.js`
+        : `${applyOpts.staticPathPrefix}[name].async.js`,
     )
     .publicPath(userConfig.publicPath || 'auto')
     .pathinfo(isDev || disableCompress)

--- a/packages/bundler-webpack/src/config/miniCSSExtractPlugin.ts
+++ b/packages/bundler-webpack/src/config/miniCSSExtractPlugin.ts
@@ -9,19 +9,20 @@ interface IOpts {
   cwd: string;
   env: Env;
   useHash: boolean;
+  staticPathPrefix: string;
 }
 
 export async function addMiniCSSExtractPlugin(opts: IOpts) {
-  const { config, userConfig, useHash } = opts;
+  const { config, userConfig, useHash, staticPathPrefix } = opts;
   const hash = useHash ? '.[contenthash:8]' : '';
   if (!userConfig.styleLoader) {
     config.plugin('mini-css-extract-plugin').use(MiniCSSExtractPlugin, [
       {
-        filename: `[name]${hash}.css`,
+        filename: `${staticPathPrefix}[name]${hash}.css`,
         chunkFilename: opts.userConfig.ssr
           ? // TODO: FIXME
-            `umi${hash}.css`
-          : `[name]${hash}.chunk.css`,
+            `${staticPathPrefix}umi${hash}.css`
+          : `${staticPathPrefix}[name]${hash}.chunk.css`,
         ignoreOrder: true,
       },
     ]);


### PR DESCRIPTION
将所有经 webpack 处理的 css/js 添加前缀可配置化的前缀 `staticPathPrefix`，方便项目上线部署时统一对 staticPathPrefix 目录下的资源添加 `Long Term Cache`，如以下 nginx 的配置。

```
location /static {
        expires 1y;
}
```

以下是对 `examples/ant-design-pro` 的构建结果。（而以前都在 dist 目录下，不是能够很方便地与 index.html 等区分开来，不好配 Cache-Control）

``` bash
✔ Webpack
  Compiled successfully in 46.15s

info  - Memory Usage: 851.06 MB (RSS: 2260.04 MB)

info  - File sizes after gzip:

  1.15 MB    dist/ts.worker.js
  863.19 kB  dist/static/umi.2f40946e.js
  335.18 kB  dist/static/p__dashboard__monitor__index.7d98669a.async.js
  266.05 kB  dist/static/shared-rHc4btX5bbNVapvifq2kZ98B-Tw_.3a78f672.async.js
  233.6 kB   dist/css.worker.js
  199.42 kB  dist/static/mapbox-gl-lib.0fd22ba8.async.js
  182.23 kB  dist/html.worker.js
  114.35 kB  dist/json.worker.js
  78.24 kB   dist/editor.worker.js
  70.34 kB   dist/static/umi.e5e17c8f.css
  55.49 kB   dist/static/framework.772dca84.js
  41.12 kB   dist/static/l7regl-lib.8d73e9c7.async.js
  28.72 kB   dist/static/acorn-lib.055583a9.async.js
  6.72 kB    dist/static/p__dashboard__analysis__index.dc56bc76.async.js
  6.13 kB    dist/static/p__account__center__index.5e6fb4dc.async.js
  5.24 kB    dist/static/p__list__search__articles__index.5ccce672.async.js
  4.64 kB    dist/static/p__account__settings__index.b4d566d7.async.js
  4.34 kB    dist/static/p__user__Login__index.76f476d3.async.js
  4.07 kB    dist/static/p__list__search__applications__index.f3dc4766.async.js
  4 kB       dist/static/shared-4Q364lF608qmcbs9fCWKttflZQ_.3cbe16cf.async.js
  3.76 kB    dist/static/p__list__search__projects__index.a139837c.async.js
  3.48 kB    dist/static/p__profile__advanced__index.74010ab9.async.js
  3.15 kB    dist/static/t__plugin-layout__Layout.57810692.async.js
  2.86 kB    dist/static/p__list__basic-list__index.e8645b26.async.js
  2.83 kB    dist/static/p__list__table-list__index.b79a10ed.async.js
  2.78 kB    dist/static/p__dashboard__workplace__index.dcb02b34.async.js
  2.16 kB    dist/static/p__form__advanced-form__index.7eb7c632.async.js
  2.06 kB    dist/static/p__user__register__index.2a1ef821.async.js
  1.82 kB    dist/static/p__form__step-form__index.82cea3ca.async.js
  1.68 kB    dist/static/p__dashboard__analysis__index.88220c2f.chunk.css
  1.57 kB    dist/static/p__result__success__index.59bc6c08.async.js
  1.49 kB    dist/static/p__form__basic-form__index.5afae86b.async.js
  1.45 kB    dist/static/p__profile__basic__index.9c7eb45f.async.js
  1.38 kB    dist/static/p__list__card-list__index.7e0572bd.async.js
  1.13 kB    dist/static/p__account__center__index.81e8f277.chunk.css
  1.07 kB    dist/static/p__dashboard__workplace__index.ba4f77af.chunk.css
  975 B      dist/static/p__list__search__projects__index.3f7b5bbe.chunk.css
  890 B      dist/static/p__list__search__articles__index.4562f56c.chunk.css
  835 B      dist/static/p__list__search__applications__index.edd7aea6.chunk.css
  788 B      dist/static/p__account__settings__index.91a8409f.chunk.css
  725 B      dist/static/p__list__basic-list__index.4d7ecb50.chunk.css
  673 B      dist/static/p__result__fail__index.3b5c17ba.async.js
  641 B      dist/static/p__list__card-list__index.1d7ffb85.chunk.css
  635 B      dist/static/p__user__register-result__index.3bc3f1e4.async.js
  619 B      dist/static/p__list__search__index.15ac4dd2.async.js
  459 B      dist/static/p__dashboard__monitor__index.10a083c4.chunk.css
  440 B      dist/static/p__form__advanced-form__index.eb87fefc.chunk.css
  437 B      dist/static/p__user__Login__index.86f291d1.chunk.css
  367 B      dist/static/t__plugin-layout__Layout.74b4118c.chunk.css
  345 B      dist/static/p__profile__advanced__index.35b75b5c.chunk.css
  345 B      dist/static/p__user__register__index.3aa7b5e1.chunk.css
  313 B      dist/static/p__exception__403__index.ffb4fc6b.async.js
  312 B      dist/static/p__exception__404__index.746c9289.async.js
  310 B      dist/static/p__exception__500__index.95367012.async.js
  308 B      dist/static/p__404.9ea70a79.async.js
  227 B      dist/static/782.d37cdfb9.async.js
  222 B      dist/static/layouts__index.18a35ed3.async.js
  198 B      dist/static/p__user__register-result__index.2b23e4da.chunk.css
  147 B      dist/static/p__result__success__index.9ff4f370.chunk.css
  119 B      dist/static/p__result__fail__index.b54243f5.chunk.css
  109 B      dist/static/p__form__step-form__index.5733b827.chunk.css
  91 B       dist/static/p__profile__basic__index.0df6d4dc.chunk.css
  69 B       dist/static/p__form__basic-form__index.43136fee.chunk.css
```