### PR TITLE
fix: build 时报错找不到 uno.css

### DIFF
--- a/packages/plugins/src/unocss.ts
+++ b/packages/plugins/src/unocss.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process';
+import { exec, execSync } from 'child_process';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { IApi } from 'umi';
@@ -31,19 +31,22 @@ export default (api: IApi) => {
 
     const generatedPath = join(api.paths.absTmpPath, outputPath);
     const binPath = join(api.cwd, 'node_modules/.bin/unocss');
-    const watchDirs = api.config.unocss.watch;
+    const watchDirs = api.config.unocss.watch.join(' ');
 
     /** 透过子进程建立 unocss 服务，将生成的 css 写入 generatedPath */
-    const unocss = exec(
-      `${binPath} ${watchDirs.join(' ')} --out-file ${generatedPath} ${
-        api.env === 'development' ? '--watch' : ''
-      }`,
-      { cwd: api.cwd },
-    );
-
-    unocss.on('error', (m: any) => {
-      api.logger.error('unocss service encounter an error: ' + m);
-    });
+    const isDev = api.env === 'development';
+    const command = `${binPath} ${watchDirs} --out-file ${generatedPath} ${
+      isDev ? '--watch' : ''
+    }`;
+    if (isDev) {
+      const unocss = exec(command, { cwd: api.cwd });
+      unocss.on('error', (m: any) => {
+        api.logger.error('unocss service encounter an error: ' + m);
+      });
+    } else {
+      // build 时 需要等待 unocss 生成文件后才能继续走编译流程
+      execSync(command, { cwd: api.cwd });
+    }
   });
 
   /** 将生成的 css 文件加入到 import 中 */


### PR DESCRIPTION
在部分大仓库下，由于`uno cli`可能处理稍微久点才能生成`css`。

导致进入了`webpack`编译流程还没有`uno.css`文件，从而中断编译流程。

报错如下：
<img width="1726" alt="image" src="https://user-images.githubusercontent.com/23382699/227190121-b531c608-fd0e-43b6-9658-84f6d2875514.png">

---
修改为在`build`时候同步等待`uno cli`执行完成
