### PR TITLE
chore: remove `umi-` prefix template pkg

### DIFF
--- a/docs/docs/tutorials/getting-started.md
+++ b/docs/docs/tutorials/getting-started.md
@@ -144,11 +144,9 @@ info  - generate files
 ### 从模板创建项目
 
 ```bash
-  # 从 umi-electron-template 创建一个 electron 模板
+  # 从 @umijs/electron-template 创建一个 electron 模板
   pnpm create umi --template electron
 ```
-
-你也可以创建自己的模板，包名格式为 `umi-${name}-template` ，发布至 npm 便可使用 `umi create` 初始化。
 
 ### 参数选项
 

--- a/packages/create-umi/src/template.ts
+++ b/packages/create-umi/src/template.ts
@@ -6,9 +6,7 @@ export enum ERegistry {
   taobao = 'https://registry.npmmirror.com/',
 }
 
-export type UmiTemplate =
-  | `@umijs/${string}-template`
-  | `umi-${string}-template`;
+export type UmiTemplate = `@umijs/${string}-template`;
 
 interface IUnpackTemplateOpts {
   template: UmiTemplate;
@@ -37,26 +35,21 @@ export const unpackTemplate = async (opts: IUnpackTemplateOpts) => {
 
   const nameList: string[] = [];
 
-  const isStartWithUmi =
-    template.startsWith('umi-') || template.startsWith('@umijs/');
+  const isStartWithUmi = template.startsWith('@umijs/');
   if (template.endsWith('-template')) {
     // @umijs/electron-template
-    // umi-electron-template
     if (isStartWithUmi) {
       nameList.push(template);
     } else {
       // electron-template
       nameList.push(`@umijs/${template}`);
-      nameList.push(`umi-${template}`);
     }
   } else if (isStartWithUmi) {
     // @umijs/electron
-    // umi-electron
     nameList.push(`${template}-template`);
   } else {
     // electron
     nameList.push(`@umijs/${template}-template`);
-    nameList.push(`umi-${template}-template`);
   }
 
   for await (const name of nameList) {


### PR DESCRIPTION
删去 `umi-xxx-template` 这种包的初始化。

但我觉得可以不用去，因为可以精确指定 `--template @umijs/electron` or `--template @umijs/electron-template` ，会自动补全 + 查找。