### PR TITLE
docs: use named component export and improve qiankun config

### DIFF
--- a/docs/docs/guides/mpa.md
+++ b/docs/docs/guides/mpa.md
@@ -124,7 +124,9 @@ MPA_FILTER=bar,foo
 默认渲染方式为 react，入口文件只需导出 react 组件，即可进行渲染，无需自行写 `ReactDOM.render` 逻辑。
 
 ```tsx
-export default () => <div>Hello</div>;
+export default function Page() {
+  return <div>Hello</div>
+}
 ```
 
 默认启用 React 18，如果需要 React 17 的渲染方式，请在项目中安装 react 17 的依赖，框架会自动适配 react 版本。

--- a/docs/docs/guides/routes.md
+++ b/docs/docs/guides/routes.md
@@ -373,11 +373,13 @@ export default function() {
 ```jsx
 import { Link } from 'umi';
 
-export default () => (
-  <div>
-    <Link to="/users">Users Page</Link>
-  </div>
-);
+export default function Page() {
+  return (
+    <div>
+      <Link to="/users">Users Page</Link>
+    </div>
+  )
+}
 ```
 
 然后点击 `Users Page` 就会跳转到 `/users` 地址。

--- a/docs/docs/max/data-flow.md
+++ b/docs/docs/max/data-flow.md
@@ -26,7 +26,7 @@ Model 文件允许使用 `.(tsx|ts|jsx|js)` 四种后缀格式，**命名空间�
 
 ```ts
 // src/models/userModel.ts
-export default function Page()  {
+export default function Page() {
   const user = {
     username: 'umi',
   };
@@ -47,7 +47,7 @@ Model 中允许使用其它 `hooks`，以计数器为例：
 // src/models/counterModel.ts
 import { useState, useCallback } from 'react';
 
-export default function Page()  {
+export default function Page() {
   const [counter, setCounter] = useState(0);
 
   const increment = useCallback(() => setCounter((c) => c + 1), []);
@@ -64,7 +64,7 @@ export default function Page()  {
 import { useState } from 'react';
 import { getUser } from '@/services/user';
 
-export default function Page()  {
+export default function Page() {
   const [user, setUser] = useState({});
   const [loading, setLoading] = useState(true);
 
@@ -89,7 +89,7 @@ export default function Page()  {
 import { useRequest } from 'ahooks';
 import { getUser } from '@/services/user';
 
-export default function Page()  {
+export default function Page() {
   const { data: user, loading: loading } = useRequest(async () => {
     const res = await getUser();
     if (res) {
@@ -113,7 +113,7 @@ export default function Page()  {
 // src/components/Username/index.tsx
 import { useModel } from 'umi';
 
-export default function Page()  {
+export default function Page() {
   const { user, loading } = useModel('userModel');
 
   return (
@@ -137,7 +137,7 @@ export default function Page()  {
 // src/components/CounterActions/index.tsx
 import { useModel } from 'umi';
 
-export default function Page()  {
+export default function Page() {
   const { add, minus } = useModel('counterModel', (model) => ({
     add: model.increment,
     minus: model.decrement,
@@ -179,7 +179,7 @@ export async function getInitialState() {
 ```tsx
 import { useModel } from 'umi';
 
-export default function Page()  {
+export default function Page() {
   const { initialState, loading, error, refresh, setInitialState } =
     useModel('@@initialState');
   return <>{initialState}</>;
@@ -215,7 +215,7 @@ export default function Page()  {
 // src/components/AdminInfo/index.tsx
 import { useModel } from 'umi';
 
-export default function Page()  {
+export default function Page() {
   const { user, fetchUser } = useModel('adminModel', (model) => ({
     user: model.admin,
     fetchUser: model.fetchAdmin,

--- a/docs/docs/max/data-flow.md
+++ b/docs/docs/max/data-flow.md
@@ -26,7 +26,7 @@ Model 文件允许使用 `.(tsx|ts|jsx|js)` 四种后缀格式，**命名空间�
 
 ```ts
 // src/models/userModel.ts
-export default () => {
+export default function Page()  {
   const user = {
     username: 'umi',
   };
@@ -47,7 +47,7 @@ Model 中允许使用其它 `hooks`，以计数器为例：
 // src/models/counterModel.ts
 import { useState, useCallback } from 'react';
 
-export default () => {
+export default function Page()  {
   const [counter, setCounter] = useState(0);
 
   const increment = useCallback(() => setCounter((c) => c + 1), []);
@@ -64,7 +64,7 @@ export default () => {
 import { useState } from 'react';
 import { getUser } from '@/services/user';
 
-export default () => {
+export default function Page()  {
   const [user, setUser] = useState({});
   const [loading, setLoading] = useState(true);
 
@@ -89,7 +89,7 @@ export default () => {
 import { useRequest } from 'ahooks';
 import { getUser } from '@/services/user';
 
-export default () => {
+export default function Page()  {
   const { data: user, loading: loading } = useRequest(async () => {
     const res = await getUser();
     if (res) {
@@ -113,7 +113,7 @@ export default () => {
 // src/components/Username/index.tsx
 import { useModel } from 'umi';
 
-export default () => {
+export default function Page()  {
   const { user, loading } = useModel('userModel');
 
   return (
@@ -137,7 +137,7 @@ export default () => {
 // src/components/CounterActions/index.tsx
 import { useModel } from 'umi';
 
-export default () => {
+export default function Page()  {
   const { add, minus } = useModel('counterModel', (model) => ({
     add: model.increment,
     minus: model.decrement,
@@ -179,7 +179,7 @@ export async function getInitialState() {
 ```tsx
 import { useModel } from 'umi';
 
-export default () => {
+export default function Page()  {
   const { initialState, loading, error, refresh, setInitialState } =
     useModel('@@initialState');
   return <>{initialState}</>;
@@ -215,7 +215,7 @@ export default () => {
 // src/components/AdminInfo/index.tsx
 import { useModel } from 'umi';
 
-export default () => {
+export default function Page()  {
   const { user, fetchUser } = useModel('adminModel', (model) => ({
     user: model.admin,
     fetchUser: model.fetchAdmin,

--- a/docs/docs/max/i18n.md
+++ b/docs/docs/max/i18n.md
@@ -69,7 +69,7 @@ export default {
 ```tsx
 import { FormattedMessage } from 'umi';
 
-export default () => {
+export default function Page()  {
   return (
     <div>
       <FormattedMessage id="welcome" />
@@ -96,7 +96,7 @@ export default () => {
 import { Alert } from 'antd';
 import { useIntl } from 'umi';
 
-export default () => {
+export default function Page()  {
   const intl = useIntl();
   const msg = intl.formatMessage({
     id: 'welcome',
@@ -137,7 +137,7 @@ export default {
 ```tsx
 import { FormattedMessage } from 'umi';
 
-export default () => {
+export default function Page()  {
   return (
     <p>
       <FormattedMessage id="user.welcome" values={{ name: '张三' }} />
@@ -151,7 +151,7 @@ export default () => {
 ```tsx
 import { useIntl } from 'umi';
 
-export default () => {
+export default function Page()  {
   const intl = useIntl();
   const msg = intl.formatMessage(
     {
@@ -185,7 +185,7 @@ export default () => {
 ```tsx
 import { SelectLang } from 'umi';
 
-export default () => {
+export default function Page()  {
   return <SelectLang />;
 };
 ```
@@ -244,7 +244,7 @@ export default {
 import { Button } from 'antd';
 import { FormattedMessage } from 'umi';
 
-export default () => {
+export default function Page()  {
   return (
     <Button type="primary">
       <FormattedMessage id="table.submit" />
@@ -269,7 +269,7 @@ export default () => {
 import { Button } from 'antd';
 import { FormattedMessage } from 'umi';
 
-export default () => {
+export default function Page()  {
   return (
     <Button type="primary">
       <FormattedMessage id="table.submit" defaultMessage="SUBMIT TABLE" />
@@ -284,7 +284,7 @@ export default () => {
 import { Button } from 'antd';
 import { useIntl } from 'umi';
 
-export default () => {
+export default function Page()  {
   const intl = useIntl();
   const msg = intl.formatMessage({
     id: 'table.submit',

--- a/docs/docs/max/i18n.md
+++ b/docs/docs/max/i18n.md
@@ -69,7 +69,7 @@ export default {
 ```tsx
 import { FormattedMessage } from 'umi';
 
-export default function Page()  {
+export default function Page() {
   return (
     <div>
       <FormattedMessage id="welcome" />
@@ -96,7 +96,7 @@ export default function Page()  {
 import { Alert } from 'antd';
 import { useIntl } from 'umi';
 
-export default function Page()  {
+export default function Page() {
   const intl = useIntl();
   const msg = intl.formatMessage({
     id: 'welcome',
@@ -137,7 +137,7 @@ export default {
 ```tsx
 import { FormattedMessage } from 'umi';
 
-export default function Page()  {
+export default function Page() {
   return (
     <p>
       <FormattedMessage id="user.welcome" values={{ name: '张三' }} />
@@ -151,7 +151,7 @@ export default function Page()  {
 ```tsx
 import { useIntl } from 'umi';
 
-export default function Page()  {
+export default function Page() {
   const intl = useIntl();
   const msg = intl.formatMessage(
     {
@@ -185,7 +185,7 @@ export default function Page()  {
 ```tsx
 import { SelectLang } from 'umi';
 
-export default function Page()  {
+export default function Page() {
   return <SelectLang />;
 };
 ```
@@ -244,7 +244,7 @@ export default {
 import { Button } from 'antd';
 import { FormattedMessage } from 'umi';
 
-export default function Page()  {
+export default function Page() {
   return (
     <Button type="primary">
       <FormattedMessage id="table.submit" />
@@ -269,7 +269,7 @@ export default function Page()  {
 import { Button } from 'antd';
 import { FormattedMessage } from 'umi';
 
-export default function Page()  {
+export default function Page() {
   return (
     <Button type="primary">
       <FormattedMessage id="table.submit" defaultMessage="SUBMIT TABLE" />
@@ -284,7 +284,7 @@ export default function Page()  {
 import { Button } from 'antd';
 import { useIntl } from 'umi';
 
-export default function Page()  {
+export default function Page() {
   const intl = useIntl();
   const msg = intl.formatMessage({
     id: 'table.submit',

--- a/docs/docs/max/mf.md
+++ b/docs/docs/max/mf.md
@@ -192,7 +192,7 @@ const RemoteCounter = React.lazy(() => {
   return safeMfImport('remoteCounter/Counter', { defualt: () => 'Fallback' });
 });
 
-export default () => {
+export default function Page()  {
   return (
     <Suspense fallback="loading">
       <RemoteCounter />
@@ -230,7 +230,7 @@ const RemoteCounter = safeRemoteComponent<React.FC<{ init?: number }>>({
   loadingElement: 'Loading',
 });
 
-export default () => {
+export default function Page()  {
   return (
     <div>
       <RemoteCounter init={808} />
@@ -299,7 +299,7 @@ const RemoteCounter = safeRemoteComponentWithMfConfig<
   loadingElement: 'raw Loading',
 });
 
-export default () => {
+export default function Page()  {
   return <RemoteCounter />;
 };
 ```

--- a/docs/docs/max/mf.md
+++ b/docs/docs/max/mf.md
@@ -192,7 +192,7 @@ const RemoteCounter = React.lazy(() => {
   return safeMfImport('remoteCounter/Counter', { defualt: () => 'Fallback' });
 });
 
-export default function Page()  {
+export default function Page() {
   return (
     <Suspense fallback="loading">
       <RemoteCounter />
@@ -230,7 +230,7 @@ const RemoteCounter = safeRemoteComponent<React.FC<{ init?: number }>>({
   loadingElement: 'Loading',
 });
 
-export default function Page()  {
+export default function Page() {
   return (
     <div>
       <RemoteCounter init={808} />
@@ -299,7 +299,7 @@ const RemoteCounter = safeRemoteComponentWithMfConfig<
   loadingElement: 'raw Loading',
 });
 
-export default function Page()  {
+export default function Page() {
   return <RemoteCounter />;
 };
 ```

--- a/docs/docs/max/micro-frontend.md
+++ b/docs/docs/max/micro-frontend.md
@@ -174,7 +174,7 @@ export default {
 ```tsx
 import { MicroApp } from 'umi';
 
-export default () => {
+export default function Page() {
   return <MicroApp name="app1" />;
 };
 ```
@@ -186,7 +186,7 @@ export default () => {
 ```tsx
 import { MicroApp } from 'umi';
 
-export default () => {
+export default function Page() {
   return <MicroApp name="app1" base="/prefix/router-path" />
 };
 ```
@@ -205,7 +205,7 @@ export default () => {
 ```tsx
 import { MicroAppWithMemoHistory } from 'umi';
 
-export default () => {
+export default function Page() {
   return <MicroAppWithMemoHistory name="app2" url="/some/page" />;
 };
 ```
@@ -218,7 +218,7 @@ export default () => {
 // 在 app1 中
 import { MicroAppLink } from 'umi';
 
-export default () => {
+export default function Page() {
   return (
     <>
       {/* 跳转链接为 /app2/home */}
@@ -236,7 +236,7 @@ export default () => {
 // 在 app2 中
 import { MicroAppLink } from 'umi';
 
-export default () => {
+export default function Page() {
   return (
     <>
       {/* 跳转链接为 /app1/project/home */}
@@ -254,7 +254,7 @@ export default () => {
 // 在子应用中
 import { MicroAppLink } from 'umi';
 
-export default () => {
+export default function Page() {
   return (
     <>
       {/* 跳转链接为 /table */}
@@ -289,7 +289,7 @@ Qiankun 在 single-spa 的基础上实现了一些额外的生命钩子。按照
 import React, { useRef } from 'react';
 import { MicroApp } from 'umi';
 
-export default () => {
+export default function Page() {
   const microAppRef = useRef();
 
   // 执行此方法时，更新子应用
@@ -380,7 +380,7 @@ export function useQiankunStateForSlave() {
 import React, { useState } from 'react';
 import { MicroApp } from 'umi';
 
-export default () => {
+export default function Page() {
   const [globalState, setGlobalState] = useState<any>({
     slogan: 'Hello MicroFrontend',
   });
@@ -402,7 +402,7 @@ export default () => {
 ```tsx
 import { useModel } from 'umi';
 
-export default () => {
+export default function Page() {
   const masterProps = useModel('@@qiankunStateFromMaster');
   return <div>{JSON.stringify(masterProps)}</div>;
 };
@@ -504,7 +504,7 @@ export default {
 ```tsx
 import { MicroApp } from 'umi';
 
-export default () => {
+export default function Page() {
   return <MicroApp name="app1" autoSetLoading />;
 };
 ```
@@ -538,7 +538,7 @@ export default {
 import CustomLoader from '@/components/CustomLoader';
 import { MicroApp } from 'umi';
 
-export default () => {
+export default function Page() {
   return (
     <MicroApp
       name="app1"
@@ -580,7 +580,7 @@ export default {
 ```tsx
 import { MicroApp } from 'umi';
 
-export default () => {
+export default function Page() {
   return <MicroApp name="app1" autoCaptureError />;
 };
 ```
@@ -589,32 +589,13 @@ export default () => {
 
 如果您没有使用 antd 作为项目组件库，或希望覆盖默认的错误捕获组件样式时，可以设置一个自定义的组件 `errorBoundary` 作为子应用的错误捕获组件。
 
-如果通过路由的模式引入子应用，可以配置如下：
-
-```tsx
-// .umirc.ts
-import CustomErrorBoundary from '../src/components/CustomErrorBoundary';
-
-export default {
-  routes: [
-    {
-      path: '/app1',
-      microApp: 'app1',
-      microAppProps: {
-        errorBoundary: (error) => <CustomErrorBoundary error={error} />,
-      },
-    },
-  ],
-};
-```
-
-如果通过组件的模式引入子应用，直接将 `errorBoundary` 作为参数传入即可：
+通过组件的模式引入子应用，将 `errorBoundary` 作为参数传入即可：
 
 ```tsx
 import CustomErrorBoundary from '@/components/CustomErrorBoundary';
 import { MicroApp } from 'umi';
 
-export default () => {
+export default function Page() {
   return (
     <MicroApp
       name="app1"

--- a/docs/docs/max/request.md
+++ b/docs/docs/max/request.md
@@ -139,7 +139,7 @@ const request: RequestConfig = {
 ```typescript
 import { useRequest } from 'umi';
 
-export default function Page()  {
+export default function Page() {
   const { data, error, loading } = useRequest(() => {
     return services.getUserList('/api/test');
   });

--- a/docs/docs/max/request.md
+++ b/docs/docs/max/request.md
@@ -139,7 +139,7 @@ const request: RequestConfig = {
 ```typescript
 import { useRequest } from 'umi';
 
-export default () => {
+export default function Page()  {
   const { data, error, loading } = useRequest(() => {
     return services.getUserList('/api/test');
   });


### PR DESCRIPTION
1.  经 #10824 反馈发现，现在无法在配置文件里使用 tsx ，序列化写文件的过程中函数都会被清除掉，故删除 qiankun 在配置文件中使用 `errorBoundary` 的部分。

2. 所有匿名函数改为具名函数，防止误导导致 react refresh 不生效。