### PR TITLE
fix(prepare): 过滤仅仅 js 文件进行解析

### DIFF
--- a/packages/mfsu/src/dep/getExposeFromContent.ts
+++ b/packages/mfsu/src/dep/getExposeFromContent.ts
@@ -1,4 +1,4 @@
-import { winPath } from '@umijs/utils';
+import { isJavaScriptFile, winPath } from '@umijs/utils';
 import assert from 'assert';
 import { basename } from 'path';
 import { Dep } from './dep';
@@ -42,7 +42,7 @@ export default _;`.trim();
   }
 
   assert(
-    /(js|jsx|mjs|ts|tsx)$/.test(opts.filePath),
+    isJavaScriptFile(opts.filePath),
     `file type not supported for ${basename(opts.filePath)}.`,
   );
   const { exports, isCJS } = await getModuleExports({

--- a/packages/preset-umi/src/features/prepare/prepare.ts
+++ b/packages/preset-umi/src/features/prepare/prepare.ts
@@ -1,6 +1,12 @@
 import type { BuildResult } from '@umijs/bundler-utils/compiled/esbuild';
 import type { Declaration } from '@umijs/es-module-parser';
-import { aliasUtils, importLazy, lodash, logger } from '@umijs/utils';
+import {
+  aliasUtils,
+  importLazy,
+  isJavaScriptFile,
+  lodash,
+  logger,
+} from '@umijs/utils';
 import path from 'path';
 import { addUnWatch } from '../../commands/dev/watch';
 import { IApi, IOnGenerateFiles } from '../../types';
@@ -28,8 +34,9 @@ export default (api: IApi) => {
   }
 
   async function parseProjectImportSpecifiers(br: BuildResult) {
-    const files = Object.keys(br.metafile!.inputs) || [];
-
+    const files = (Object.keys(br.metafile!.inputs) || []).filter(
+      isJavaScriptFile,
+    );
     if (files.length === 0) {
       return {};
     }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -41,6 +41,7 @@ export * from './getCorejsVersion';
 export * from './getDevBanner';
 export * as git from './getFileGitIno';
 export * from './importLazy';
+export * from './isJavaScriptFile';
 export * from './isLocalDev';
 export * from './isMonorepo';
 export * from './isStyleFile';

--- a/packages/utils/src/isJavaScriptFile.ts
+++ b/packages/utils/src/isJavaScriptFile.ts
@@ -1,0 +1,4 @@
+const JS_EXT_REGX = /\.(:?js|jsx|mjs|ts|tsx)$/;
+export function isJavaScriptFile(f: string): boolean {
+  return JS_EXT_REGX.test(f);
+}

--- a/packages/utils/src/isStyleFile.ts
+++ b/packages/utils/src/isStyleFile.ts
@@ -1,5 +1,3 @@
-import { extname } from 'path';
-
 export const AUTO_CSS_MODULE_EXTS = [
   '.css',
   '.less',
@@ -9,12 +7,13 @@ export const AUTO_CSS_MODULE_EXTS = [
   '.styl',
 ];
 
+const STYLE_EXT_REGX = /\.(:?css|less|scss|sass|stylus|styl)$/;
+
 export const isStyleFile = ({
   filename,
-  ext,
 }: {
   filename?: string;
   ext?: string;
 }) => {
-  return filename && AUTO_CSS_MODULE_EXTS.includes(ext || extname(filename));
+  return filename && STYLE_EXT_REGX.test(filename);
 };


### PR DESCRIPTION

1. esbuild 的 meta.inputs 会包含 json 文件，未来可能当有其他类型文件；解析前过滤 js 文件。

2. 顺手优化 isStyleFile

