### PR TITLE
feat(plugin-qiankun): qiankun 本地研发支持设置 appName

### DIFF
--- a/packages/plugins/src/qiankun/slave.ts
+++ b/packages/plugins/src/qiankun/slave.ts
@@ -32,7 +32,7 @@ function handleOriginalHtml(
   microAppEntry: string,
   originalHtml: string,
 ) {
-  const appName = api.pkg.name;
+  const appName = api.config.qiankun?.slave?.appName || api.pkg.name;
   assert(
     appName,
     '[@umijs/plugin-qiankun]: You should have name in package.json',


### PR DESCRIPTION
- 因为存在 qiankun 应用 appName 与 pkg.name 对不上的情况，所以允许用户自行指定 appName