### PR TITLE
refactor(lint): disable color-function-notation stylelint rule

### DIFF
--- a/packages/lint/src/config/stylelint/index.ts
+++ b/packages/lint/src/config/stylelint/index.ts
@@ -29,6 +29,9 @@ module.exports = {
         message: 'Expected class selector to be kebab-case or lowerCamelCase',
       },
     ],
+    // to avoid conflicts with less option { math: always }
+    // ref: https://github.com/less/less-docs/blob/c8b9d33b0b4ec5fe59a4bbda11db202545741228/content/usage/less-options.md#math
+    'color-function-notation': null,
   },
   customSyntax: require.resolve('../../../compiled/postcss-less'),
   ignoreFiles: ['node_modules'],


### PR DESCRIPTION
默认禁用 [`color-function-notation`](https://stylelint.io/user-guide/rules/color-function-notation/) styelint 规则，避免自动 `fix` 导致启用 Less `{ math: 'always' }` 时编译报错