### PR TITLE
fix(bundler-vite): unexpected assets url if configure publicPath

### DIFF
--- a/packages/bundler-vite/src/build.ts
+++ b/packages/bundler-vite/src/build.ts
@@ -103,11 +103,6 @@ export async function build(opts: IOpts): Promise<void> {
       root: opts.cwd,
       mode: Env.production,
       build: {
-        // generate assets to publicPath dir
-        assetsDir: path.relative(
-          '/',
-          path.join('/', opts.config.publicPath || ''),
-        ),
         rollupOptions: tmpHtmlEntry
           ? // first use entry from options
             {


### PR DESCRIPTION
assetsDir 不能指定成 publicPath  使用默认值
![image](https://user-images.githubusercontent.com/7599351/230814419-ea4916cf-f10a-4c18-9df3-95bd4e307a3d.png)

补齐下背景 从 vite 2 开始  assetsDir 就作为 join 的参数, 如果设置 publicPath 会导致   生成路径包含 publicPath 当指定CDN 的场景会有问题 https://github.com/vitejs/vite/blob/main/packages/vite/src/node/build.ts#L614