### PR TITLE
官方文档中，api.addEntryCode样例代码少了一个引号，导致复制后无法正常使用

### DIFF
--- a/docs/docs/api/plugin-api.md
+++ b/docs/docs/api/plugin-api.md
@@ -276,7 +276,7 @@ api.addBeforeMiddlewares(() => {
 ### addEntryCode
 在入口文件的最后面添加代码（render 后）。传入的 fn 不需要参数，且需要返回一个 string 或者 string 数组。
 ```ts
-api.addEntryCode(() => `console.log('I am after render!)`);
+api.addEntryCode(() => `console.log('I am after render!')`);
 ```
 
 ### addEntryCodeAhead


### PR DESCRIPTION
官方文档中，api.addEntryCode样例代码少了一个引号，导致复制后无法正常使用