### PR TITLE
fix: 🐛 mpa 下文件扫描遗漏 mpa 入口文件的问题

### DIFF
--- a/examples/mpa/pages/foo/index.tsx
+++ b/examples/mpa/pages/foo/index.tsx
@@ -1,7 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 
-export default () => <div>Hello Foo</div>;
-
+export default () => {
+  // for testing hooks in mpa with mfsu
+  const [name] = useState('Foo');
+  return <div>Hello {name}</div>;
+};
 export const config = {
   title: 'fooooooo',
   layout: '@/layouts/foo',

--- a/packages/core/src/service/service.ts
+++ b/packages/core/src/service/service.ts
@@ -55,6 +55,9 @@ export class Service {
       buildResult: BuildResult;
       fileImports?: Record<string, Declaration[]>;
     };
+    mpa?: {
+      entry?: { [key: string]: string }[];
+    };
     [key: string]: any;
   } = {};
   args: yParser.Arguments = { _: [], $0: '' };

--- a/packages/preset-umi/src/features/mpa/mpa.ts
+++ b/packages/preset-umi/src/features/mpa/mpa.ts
@@ -42,7 +42,7 @@ export default (api: IApi) => {
   api.onGenerateFiles(async ({ isFirstTime }) => {
     // Config HMR
     if (!isFirstTime) {
-      api.appData.mpa.entry = await collectEntryWithTimeCount(
+      api.appData.mpa!.entry = await collectEntryWithTimeCount(
         api.paths.absPagesPath,
         api.config.mpa,
         api.userConfig.mountElementId,
@@ -50,7 +50,7 @@ export default (api: IApi) => {
     }
 
     const isReact18 = api.appData.react.version.startsWith('18.');
-    (api.appData.mpa.entry as Entry[]).forEach((entry) => {
+    (api.appData.mpa!.entry as Entry[]).forEach((entry) => {
       const layout = entry.layout || api.config.mpa.layout;
       const layoutImport = layout ? `import Layout from '${layout}';` : '';
       const layoutJSX = layout ? `<Layout><App /></Layout>` : `<App />`;
@@ -89,14 +89,14 @@ ${renderer}
 
   api.modifyEntry((memo) => {
     if ('umi' in memo) delete memo['umi'];
-    (api.appData.mpa.entry as Entry[]).forEach((entry) => {
+    (api.appData.mpa!.entry as Entry[]).forEach((entry) => {
       memo[entry.name] = join(api.paths.absTmpPath, entry.tmpFilePath);
     });
     return memo;
   });
 
   api.chainWebpack((memo) => {
-    (api.appData.mpa.entry as Entry[]).forEach((entry) => {
+    (api.appData.mpa!.entry as Entry[]).forEach((entry) => {
       memo.plugin(`html-${entry.name}`).use(require('html-webpack-plugin'), [
         {
           filename: `${entry.name}.html`,

--- a/packages/preset-umi/src/features/prepare/prepare.ts
+++ b/packages/preset-umi/src/features/prepare/prepare.ts
@@ -69,7 +69,8 @@ export default (api: IApi) => {
       }
       if (!isFirstTime) return;
       logger.info('Preparing...');
-      const entryFile = path.join(api.paths.absTmpPath, 'umi.ts');
+      const umiEntry = path.join(api.paths.absTmpPath, 'umi.ts');
+      const entryPoints = [umiEntry];
       const { build } = await import('./build.js');
       const watch = api.name === 'dev';
       const plugins = await api.applyPlugins({
@@ -79,8 +80,15 @@ export default (api: IApi) => {
       const unwrappedAlias = aliasUtils.parseCircleAlias({
         alias: api.config.alias,
       });
+
+      if (api.userConfig.mpa) {
+        api.appData.mpa?.entry?.forEach(({ tmpFilePath }) => {
+          entryPoints.push(path.join(api.paths.absTmpPath, tmpFilePath));
+        });
+      }
+
       const buildResult = await build({
-        entryPoints: [entryFile],
+        entryPoints,
         watch: watch && {
           async onRebuildSuccess({ result }) {
             const fileImports = await parseProjectImportSpecifiers(result);


### PR DESCRIPTION
close https://github.com/umijs/umi/issues/10765

之前基于文件扫描没有个问题，现在基于 prepare 的 filelist 就需要补全上所有的 entry 文件
