### PR TITLE
fix(deps): unicode regex compile failed since babel bundle

### DIFF
--- a/packages/deps/package.json
+++ b/packages/deps/package.json
@@ -43,6 +43,7 @@
     "esbuild": "0.12.15",
     "jest-worker": "24.9.0",
     "prettier": "2.2.1",
+    "regenerate": "1.4.2",
     "regenerate-unicode-properties": "10.0.1"
   },
   "devDependencies": {

--- a/packages/deps/taskfile.js
+++ b/packages/deps/taskfile.js
@@ -18,6 +18,9 @@ const externals = {
   'react': 'react',
   // @umijs/babel-plugin-import-to-await-require 依赖 @umijs/utils，后续考虑删除依赖
   '@umijs/utils': '@umijs/utils',
+  // babel 正则插件动态 require 了 regenerate-unicode-properties，其产物单独依赖 regenerate
+  // 如果其他依赖不对 regenerate 做 external，会导致 regenerate 多实例引发编译失败
+  'regenerate': 'regenerate',
 
   // webpack
   'node-libs-browser': 'node-libs-browser',

--- a/yarn.lock
+++ b/yarn.lock
@@ -15605,7 +15605,7 @@ regenerate-unicode-properties@^8.2.0:
   dependencies:
     regenerate "^1.4.0"
 
-regenerate@^1.4.0, regenerate@^1.4.2:
+regenerate@1.4.2, regenerate@^1.4.0, regenerate@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==


### PR DESCRIPTION
修复 Umi 3 babel 在编译 unicode 正则时报错的问题，原因和解法同 https://github.com/umijs/umi/pull/8846

**注意：由于 Umi 3 的 ncc 重新打包产物 diff 非常巨大，为了避免引发其他问题，实际产物是手动修正的**