### PR TITLE
refactor: 🎨 优化 dva 模型错误展示

### DIFF
--- a/packages/bundler-utils/src/index.ts
+++ b/packages/bundler-utils/src/index.ts
@@ -57,7 +57,7 @@ type Errors = {
   text: string;
 }[];
 
-function prettyPrintEsBuildErrors(
+export function prettyPrintEsBuildErrors(
   errors: Errors = [],
   opts: { content: string; path: string },
 ) {

--- a/packages/plugins/src/utils/modelUtils.ts
+++ b/packages/plugins/src/utils/modelUtils.ts
@@ -1,8 +1,13 @@
+import { prettyPrintEsBuildErrors } from '@umijs/bundler-utils';
 import * as Babel from '@umijs/bundler-utils/compiled/babel/core';
 import * as parser from '@umijs/bundler-utils/compiled/babel/parser';
 import traverse from '@umijs/bundler-utils/compiled/babel/traverse';
 import * as t from '@umijs/bundler-utils/compiled/babel/types';
-import { Loader, transformSync } from '@umijs/bundler-utils/compiled/esbuild';
+import {
+  Loader,
+  transformSync,
+  type TransformResult,
+} from '@umijs/bundler-utils/compiled/esbuild';
 import { readFileSync } from 'fs';
 import { basename, dirname, extname, format, join, relative } from 'path';
 import { IApi } from 'umi';
@@ -176,18 +181,29 @@ export class ModelUtils {
       return true;
     }
 
-    // transform with esbuild first
-    // to reduce unexpected ast problem
-    const loader = extname(file).slice(1) as Loader;
-    const result = transformSync(content, {
-      loader,
-      sourcemap: false,
-      minify: false,
-    });
+    let result: TransformResult | null = null;
+    try {
+      // transform with esbuild first
+      // to reduce unexpected ast problem
+      const ext = extname(file).slice(1);
+      const loader = ext === 'js' ? 'jsx' : (ext as Loader);
+      result = transformSync(content, {
+        loader,
+        sourcemap: false,
+        minify: false,
+        sourcefile: file,
+      });
+    } catch (e: any) {
+      if (e.errors?.length) {
+        prettyPrintEsBuildErrors(e.errors, { path: file, content });
+        delete e.errors;
+      }
+      throw e;
+    }
 
     // transform with babel
     let ret = false;
-    const ast = parser.parse(result.code, {
+    const ast = parser.parse(result!.code, {
       sourceType: 'module',
       sourceFilename: file,
       plugins: [],


### PR DESCRIPTION
升级的应用大量使用 Dva，在 umi 4 中往往检测出问题，优化日志方便排查


## after

```
/Users/umi_playground/git/umi-next/examples/with-dva/models/countx.js:
  13 |   },
  14 |   reducers: {
> 15 |     add(state:any){
     |             ^ Expected ")" but found ":"
  16 |       state.num += 1;
  17 |     },
  18 |   },

fatal - Error: Transform failed with 1 error:
/Users/umi_playground/git/umi-next/examples/with-dva/models/countx.js:15:13: ERROR: Expected ")" but found ":"
    at failureErrorWithLog (/Users/umi_playground/git/umi-next/node_modules/.pnpm/esbuild@0.16.17/node_modules/esbuild/lib/main.js:1604:15)
    at /Users/umi_playground/git/umi-next/node_modules/.pnpm/esbuild@0.16.17/node_modules/esbuild/lib/main.js:837:29
    at responseCallbacks.<computed> (/Users/umi_playground/git/umi-next/node_modules/.pnpm/esbuild@0.16.17/node_modules/esbuild/lib/main.js:701:9)
    at handleIncomingPacket (/Users/umi_playground/git/umi-next/node_modules/.pnpm/esbuild@0.16.17/node_modules/esbuild/lib/main.js:756:9)
    at Socket.readFromStdout (/Users/umi_playground/git/umi-next/node_modules/.pnpm/esbuild@0.16.17/node_modules/esbuild/lib/main.js:677:7)
    at Socket.emit (node:events:520:28)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at Socket.Readable.push (node:internal/streams/readable:228:10)
    at Pipe.onStreamRead (node:internal/stream_base_commons:190:23) {
  warnings: []
}
```

## before

```
fatal - Error: Transform failed with 2 errors:
<stdin>:6:9: ERROR: The JSX syntax extension is not currently enabled
<stdin>:15:13: ERROR: Expected ")" but found ":"
    at failureErrorWithLog (/Users/umi_playground/git/umi-next/node_modules/.pnpm/esbuild@0.16.17/node_modules/esbuild/lib/main.js:1604:15)
    at /Users/umi_playground/git/umi-next/node_modules/.pnpm/esbuild@0.16.17/node_modules/esbuild/lib/main.js:837:29
    at responseCallbacks.<computed> (/Users/umi_playground/git/umi-next/node_modules/.pnpm/esbuild@0.16.17/node_modules/esbuild/lib/main.js:701:9)
    at handleIncomingPacket (/Users/umi_playground/git/umi-next/node_modules/.pnpm/esbuild@0.16.17/node_modules/esbuild/lib/main.js:756:9)
    at Socket.readFromStdout (/Users/umi_playground/git/umi-next/node_modules/.pnpm/esbuild@0.16.17/node_modules/esbuild/lib/main.js:677:7)
    at Socket.emit (node:events:520:28)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at Socket.Readable.push (node:internal/streams/readable:228:10)
    at Pipe.onStreamRead (node:internal/stream_base_commons:190:23) {
  errors: [
    {
      detail: undefined,
      id: '',
      location: [Object],
      notes: [Array],
      pluginName: '',
      text: 'The JSX syntax extension is not currently enabled'
    },
    {
      detail: undefined,
      id: '',
      location: [Object],
      notes: [],
      pluginName: '',
      text: 'Expected ")" but found ":"'
    }
  ],
  warnings: []
}
```
