### PR TITLE
chore: 🐛 调整 dev server onBeforeMiddleware 调用顺序

### DIFF
--- a/packages/bundler-webpack/src/server/server.ts
+++ b/packages/bundler-webpack/src/server/server.ts
@@ -64,13 +64,13 @@ export async function createServer(opts: IOpts): Promise<any> {
     }
   });
 
-  // before middlewares
-  (opts.beforeMiddlewares || []).forEach((m) => app.use(m));
-
   // Provides the ability to execute custom middleware prior to all other middleware internally within the server.
   if (opts.onBeforeMiddleware) {
     opts.onBeforeMiddleware(app);
   }
+
+  // before middlewares
+  (opts.beforeMiddlewares || []).forEach((m) => app.use(m));
 
   // webpack dev middleware
   const configs = Array.isArray(webpackConfig)


### PR DESCRIPTION
让 onBeforeMiddleware 真正优先于内置的 Middleware

使用的场景：需要给构建产物的 http 响应增加特殊的 http 头，需要在后面的 static 中间件之前配置好。