### PR TITLE
fix: 🐛 dep 文件路径过长 生产 hash ，保留 200 个字符方便查看按照文件名查找文件

### DIFF
--- a/packages/mfsu/src/dep/dep.ts
+++ b/packages/mfsu/src/dep/dep.ts
@@ -1,5 +1,6 @@
 import { chalk, logger, pkgUp, winPath } from '@umijs/utils';
 import assert from 'assert';
+import { createHash } from 'crypto';
 import { readFileSync } from 'fs';
 import { dirname, isAbsolute, join } from 'path';
 import { MF_VA_PREFIX } from '../constants';
@@ -29,10 +30,23 @@ export class Dep {
     this.version = opts.version;
     this.cwd = opts.cwd;
     this.shortFile = this.file;
-    this.normalizedFile = this.shortFile.replace(/\//g, '_').replace(/:/g, '_');
+    this.normalizedFile = this.normalizePath(this.shortFile);
     this.filePath = `${MF_VA_PREFIX}${this.normalizedFile}.js`;
     this.excludeNodeNatives = opts.excludeNodeNatives!;
     this.importer = opts.importer;
+  }
+
+  private normalizePath(p: string): string {
+    const longPath = p.replace(/\//g, '_').replace(/:/g, '_');
+
+    if (longPath.length <= 200) {
+      return longPath;
+    }
+
+    const hash = createHash('md5').update(longPath).digest('hex').slice(0, 16);
+    const post = longPath.slice(-200);
+
+    return `${hash}_${post}`;
   }
 
   async buildExposeContent() {

--- a/packages/mfsu/src/dep/dep.ts
+++ b/packages/mfsu/src/dep/dep.ts
@@ -37,7 +37,12 @@ export class Dep {
   }
 
   private normalizePath(p: string): string {
-    const longPath = p.replace(/\//g, '_').replace(/:/g, '_');
+    let longPath = p;
+
+    if (longPath.startsWith(this.cwd)) {
+      longPath = longPath.slice(this.cwd.length);
+    }
+    longPath = longPath.replace(/\//g, '_').replace(/:/g, '_');
 
     if (longPath.length <= 200) {
       return longPath;


### PR DESCRIPTION
close https://github.com/umijs/umi/issues/10893 
close https://github.com/umijs/umi/issues/10868
close https://github.com/umijs/umi/issues/10973 