### PR TITLE
feat(lint): disallow unexpected font-family from sketch

### DIFF
--- a/packages/lint/src/config/stylelint/index.ts
+++ b/packages/lint/src/config/stylelint/index.ts
@@ -32,6 +32,23 @@ module.exports = {
     // to avoid conflicts with less option { math: always }
     // ref: https://github.com/less/less-docs/blob/c8b9d33b0b4ec5fe59a4bbda11db202545741228/content/usage/less-options.md#math
     'color-function-notation': null,
+    // disallowed set single font-family as PingFangSC
+    // in most cases, this font-family rule is copied unconsciously from Sketch
+    // and it will cause an unexpected font rendering on the devices that have no PingFangSC font
+    'declaration-property-value-disallowed-list': {
+      'font-family': [
+        'PingFangSC',
+        "'PingFangSC'",
+        'PingFangSC-Regular',
+        "'PingFangSC-Regular'",
+        'PingFangSC-Medium',
+        "'PingFangSC-Medium'",
+        'PingFangSC-Semibold',
+        "'PingFangSC-Semibold'",
+        'PingFangSC-Bold',
+        "'PingFangSC-Bold'",
+      ],
+    },
   },
   customSyntax: require.resolve('../../../compiled/postcss-less'),
   ignoreFiles: ['node_modules'],


### PR DESCRIPTION
禁止意外的 `font-family` 配置，通常是来源于从 Sketch 中复制的 CSS 样式，单一的 `font-family` 会导致在没有该字体的设备上渲染异常

cc @afc163 