### PR TITLE
fix: use absolute path to types reference

### DIFF
--- a/packages/plugins/src/layout.ts
+++ b/packages/plugins/src/layout.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { IApi, RUNTIME_TYPE_FILE_NAME } from 'umi';
-import { lodash, Mustache, winPath } from 'umi/plugin-utils';
+import { lodash, Mustache, NpmClientEnum, winPath } from 'umi/plugin-utils';
 import { resolveProjectDep } from './utils/resolveProjectDep';
 import { withTmpPath } from './utils/withTmpPath';
 
@@ -24,6 +24,8 @@ const getAllIcons = () => {
     {},
   );
 };
+
+const ANT_PRO_COMPONENT = '@ant-design/pro-components';
 
 export default (api: IApi) => {
   let antdVersion = '4.0.0';
@@ -53,7 +55,7 @@ export default (api: IApi) => {
    */
   const depList = [
     '@alipay/tech-ui',
-    '@ant-design/pro-components',
+    ANT_PRO_COMPONENT,
     '@ant-design/pro-layout',
   ];
 
@@ -83,10 +85,11 @@ export default (api: IApi) => {
       return join(cwd, 'node_modules', pkgHasDep);
     }
     // 如果项目中没有去找插件依赖的
-    return dirname(require.resolve('@ant-design/pro-components/package.json'));
+    return dirname(require.resolve(`${ANT_PRO_COMPONENT}/package.json`));
   };
 
   const pkgPath = winPath(getPkgPath());
+  const resolvedPkgPath = pkgPath || ANT_PRO_COMPONENT;
 
   api.modifyAppData((memo) => {
     const version = require(`${pkgPath}/package.json`).version;
@@ -108,9 +111,15 @@ export default (api: IApi) => {
     return memo;
   });
 
+  // use absolute path to types references in `npm/yarn` will cause case problems.
+  // https://github.com/umijs/umi/discussions/10947
+  const isFlattedDepsDir = [NpmClientEnum.npm, NpmClientEnum.yarn].includes(
+    api.appData.npmClient,
+  );
+
   api.onGenerateFiles(() => {
     const PKG_TYPE_REFERENCE = `/// <reference types="${
-      pkgPath || '@ant-design/pro-components'
+      isFlattedDepsDir ? ANT_PRO_COMPONENT : resolvedPkgPath
     }" />`;
     const hasInitialStatePlugin = api.config.initialState;
     // Layout.tsx
@@ -123,7 +132,7 @@ import type { IRoute } from 'umi';
 import React, { useMemo } from 'react';
 import {
   ProLayout,
-} from "${pkgPath || '@ant-design/pro-components'}";
+} from "${resolvedPkgPath}";
 import './Layout.less';
 import Logo from './Logo';
 import Exception from './Exception';
@@ -316,9 +325,7 @@ const { formatMessage } = useIntl();
       path: 'types.d.ts',
       content: `
     ${PKG_TYPE_REFERENCE}
-    import type { ProLayoutProps, HeaderProps } from "${
-      pkgPath || '@ant-design/pro-components'
-    }";
+    import type { ProLayoutProps, HeaderProps } from "${resolvedPkgPath}";
     ${
       hasInitialStatePlugin
         ? `import type InitialStateType from '@@/plugin-initialState/@@initialState';


### PR DESCRIPTION
经反馈，使用绝对路径的 ts types 引用，在使用 npm / yarn 的时候有大小写问题，所以我们跳过这些包管理器的绝对路径解析，因为他们有幽灵依赖，可以直接解析到。

from #10947