### PR TITLE
refactor(lint): improve message for font-family rule

### DIFF
--- a/examples/lint/src/test.less
+++ b/examples/lint/src/test.less
@@ -1,4 +1,7 @@
 body {
+  font-family: 'PingFangSC';
   font-family: PingFangSC;
+  font-family: PingFangSC, serif;
+  font-family: PingFangSC-Bold;
   unknown: 1;
 }

--- a/examples/lint/src/test.less
+++ b/examples/lint/src/test.less
@@ -1,3 +1,4 @@
 body {
+  font-family: PingFangSC;
   unknown: 1;
 }

--- a/packages/lint/src/config/stylelint/index.ts
+++ b/packages/lint/src/config/stylelint/index.ts
@@ -37,18 +37,8 @@ module.exports = {
     // and it will cause an unexpected font rendering on the devices that have no PingFangSC font
     'declaration-property-value-disallowed-list': [
       {
-        'font-family': [
-          'PingFangSC',
-          "'PingFangSC'",
-          'PingFangSC-Regular',
-          "'PingFangSC-Regular'",
-          'PingFangSC-Medium',
-          "'PingFangSC-Medium'",
-          'PingFangSC-Semibold',
-          "'PingFangSC-Semibold'",
-          'PingFangSC-Bold',
-          "'PingFangSC-Bold'",
-        ],
+        'font-family':
+          '/^(\'|")?PingFangSC(-(Regular|Medium|Semibold|Bold))?\\1$/',
       },
       {
         message:

--- a/packages/lint/src/config/stylelint/index.ts
+++ b/packages/lint/src/config/stylelint/index.ts
@@ -35,20 +35,26 @@ module.exports = {
     // disallowed set single font-family as PingFangSC
     // in most cases, this font-family rule is copied unconsciously from Sketch
     // and it will cause an unexpected font rendering on the devices that have no PingFangSC font
-    'declaration-property-value-disallowed-list': {
-      'font-family': [
-        'PingFangSC',
-        "'PingFangSC'",
-        'PingFangSC-Regular',
-        "'PingFangSC-Regular'",
-        'PingFangSC-Medium',
-        "'PingFangSC-Medium'",
-        'PingFangSC-Semibold',
-        "'PingFangSC-Semibold'",
-        'PingFangSC-Bold',
-        "'PingFangSC-Bold'",
-      ],
-    },
+    'declaration-property-value-disallowed-list': [
+      {
+        'font-family': [
+          'PingFangSC',
+          "'PingFangSC'",
+          'PingFangSC-Regular',
+          "'PingFangSC-Regular'",
+          'PingFangSC-Medium',
+          "'PingFangSC-Medium'",
+          'PingFangSC-Semibold',
+          "'PingFangSC-Semibold'",
+          'PingFangSC-Bold',
+          "'PingFangSC-Bold'",
+        ],
+      },
+      {
+        message:
+          'Unexpected value for property "font-family", which will cause some devices to render the wrong font, please delete this "font-family" css rule, see also: https://github.com/umijs/umi/pull/11001',
+      },
+    ],
   },
   customSyntax: require.resolve('../../../compiled/postcss-less'),
   ignoreFiles: ['node_modules'],


### PR DESCRIPTION
优化 `font-family` Stylelint 规则的错误提示，避免用户看不懂原因，进而增加答疑成本

ref #11001 