### PR TITLE
feat: support modify babel deco plugin opts

### DIFF
--- a/packages/babel-preset-umi/src/index.ts
+++ b/packages/babel-preset-umi/src/index.ts
@@ -16,6 +16,7 @@ interface IOpts {
   stripExports: { exports: string[] };
   classPropertiesLoose: any;
   pluginStyledComponents: any;
+  pluginDecorators: any;
 }
 
 export default (_context: any, opts: IOpts) => {
@@ -75,11 +76,14 @@ export default (_context: any, opts: IOpts) => {
       // TC39 Proposals
       // class-static-block
       // decorators
-      [
+      opts.pluginDecorators !== false && [
         require.resolve(
           '@umijs/bundler-utils/compiled/babel/plugin-proposal-decorators',
         ),
-        { legacy: true },
+        {
+          legacy: true,
+          ...opts.pluginDecorators,
+        },
       ],
       // Enable loose mode to use assignment instead of defineProperty
       // Note:


### PR DESCRIPTION
resolve #11103

#### 背景

目前几个信息如下：

1. ecma 官配 deco 虽然已经正式出台，但功能是超级阉割版，与 TS deco 相比十分逊色。

2. 目前 esbuild 对此持观望态度，没有实施计划（ https://github.com/evanw/esbuild/issues/3045#issuecomment-1501238674 、https://github.com/evanw/esbuild/issues/104 ）

3. 目前 swc 对此只是有了实施，但未开放 api （ https://github.com/swc-project/swc/issues/7193 、 https://github.com/swc-project/swc/discussions/5053#discussioncomment-5543835 ）

#### 做法

所以我们先把 deco 配置项放出来，但不做过多的假定。
