### PR TITLE
[WIP] feat: add useAntdConfig and useAntdConfigSetter

### DIFF
--- a/docs/docs/max/antd.md
+++ b/docs/docs/max/antd.md
@@ -130,6 +130,51 @@ export const antd: RuntimeAntdConfig = (memo) => {
 };
 ```
 
+### 动态切换主题
+
+**注意：该功能仅 antd v5 可用**
+
+当存在主题相关的配置时开启
+
+```tsx
+import { Layout, Space, Switch, version } from 'antd';
+import { useAntdConfig, useAntdConfigSetter } from 'umi';
+
+export default function Page() {
+  const setAntdConfig = useAntdConfigSetter();
+  const antdConfig = useAntdConfig();
+  return (
+    <Layout>
+      <h1>with antd@{version}</h1>
+      <Space>
+        isDarkTheme
+        <Switch
+          checked={antdConfig?.dark}
+          onChange={() => {
+            setAntdConfig({
+              dark: !antdConfig?.dark,
+            });
+          }}
+        ></Switch>
+      </Space>
+      <Space>
+        isCompactTheme
+        <Switch
+          checked={antdConfig?.compact}
+          onChange={() => {
+            setAntdConfig({
+              compact: !antdConfig?.compact,
+            });
+          }}
+        ></Switch>
+      </Space>
+    </Layout>
+  );
+}
+```
+
+使用 `setAntdConfig` 可以动态修改 [antd@5 ConfigProvider](https://ant.design/components/config-provider-cn) 组件支持的所有属性和两个主题模式 `dark: boolean`、`compact: boolean` 
+
 ## FAQ
 
 ### 如何使用 antd 的其他版本？

--- a/examples/with-antd-5/.umirc.ts
+++ b/examples/with-antd-5/.umirc.ts
@@ -11,6 +11,9 @@ export default {
         colorPrimary: '#1DA57A',
       },
     },
+    dark: true,
+    compact: true,
+    import: true,
     /**
      * antd@5.1.0 ~ 5.2.3 仅支持 appConfig: {}, 来启用 <App /> 组件;
      * antd@5.3.0 及以上才支持 appConfig: { // ... } 来添加更多 App 配置项;

--- a/examples/with-antd-5/.umirc.ts
+++ b/examples/with-antd-5/.umirc.ts
@@ -11,7 +11,7 @@ export default {
         colorPrimary: '#1DA57A',
       },
     },
-    dark: true,
+    dark: false,
     compact: true,
     import: true,
     /**

--- a/examples/with-antd-5/app.ts
+++ b/examples/with-antd-5/app.ts
@@ -1,12 +1,10 @@
-import { theme } from 'antd';
 import { RuntimeAntdConfig } from 'umi';
-const { darkAlgorithm, compactAlgorithm } = theme;
 
 export const antd: RuntimeAntdConfig = (memo) => {
   memo.appConfig ??= {};
   memo.appConfig.message ??= {};
   memo.appConfig.message.duration = 5;
-  memo.theme ??= {};
-  memo.theme.algorithm = [darkAlgorithm, compactAlgorithm];
+  // .umirc.ts 中配置了 dark = false
+  memo.dark = true;
   return memo;
 };

--- a/examples/with-antd-5/app.ts
+++ b/examples/with-antd-5/app.ts
@@ -1,9 +1,12 @@
+import { theme } from 'antd';
 import { RuntimeAntdConfig } from 'umi';
+const { darkAlgorithm, compactAlgorithm } = theme;
 
 export const antd: RuntimeAntdConfig = (memo) => {
   memo.appConfig ??= {};
   memo.appConfig.message ??= {};
   memo.appConfig.message.duration = 5;
-
+  memo.theme ??= {};
+  memo.theme.algorithm = [darkAlgorithm, compactAlgorithm];
   return memo;
 };

--- a/examples/with-antd-5/pages/index.tsx
+++ b/examples/with-antd-5/pages/index.tsx
@@ -1,8 +1,18 @@
-import { App, Button, Layout, Space, version } from 'antd';
+import { App, Button, Layout, Space, Switch, theme, version } from 'antd';
 import React, { useState } from 'react';
-import { getLocale, setLocale, useIntl } from 'umi';
+import {
+  getLocale,
+  setLocale,
+  useAntdConfig,
+  useAntdConfigSetter,
+  useIntl,
+} from 'umi';
 
+const { defaultAlgorithm } = theme;
 export default function Page() {
+  const setAntdConfig = useAntdConfigSetter();
+  const antdConfig = useAntdConfig();
+  console.log(antdConfig);
   const [isZh, setIsZh] = useState(true);
   // 若要使用 useApp hook，须先在 antd 插件中配置 appConfig
   const { message, modal } = App.useApp();
@@ -44,6 +54,28 @@ export default function Page() {
         >
           {msg}
         </Button>
+      </Space>
+      <Space>
+        isDarkTheme
+        <Switch
+          checked={antdConfig?.dark}
+          onChange={() => {
+            setAntdConfig({
+              dark: !antdConfig?.dark,
+            });
+          }}
+        ></Switch>
+      </Space>
+      <Space>
+        isCompactTheme
+        <Switch
+          checked={antdConfig?.compact}
+          onChange={() => {
+            setAntdConfig({
+              compact: !antdConfig?.compact,
+            });
+          }}
+        ></Switch>
       </Space>
     </Layout>
   );

--- a/examples/with-antd-5/pages/index.tsx
+++ b/examples/with-antd-5/pages/index.tsx
@@ -1,4 +1,4 @@
-import { App, Button, Space, version } from 'antd';
+import { App, Button, Layout, Space, version } from 'antd';
 import React, { useState } from 'react';
 import { getLocale, setLocale, useIntl } from 'umi';
 
@@ -25,7 +25,8 @@ export default function Page() {
   };
 
   return (
-    <>
+    <Layout>
+      {Math.random()}
       <h1>with antd@{version}</h1>
       <Space>
         <Button onClick={sayHai}>Say Hai</Button>
@@ -34,14 +35,16 @@ export default function Page() {
         </Button>
       </Space>
       locale:{locale}
-      <Button
-        onClick={() => {
-          setIsZh(!isZh);
-          setLocale(isZh ? 'en-US' : 'zh-CN', false);
-        }}
-      >
-        {msg}
-      </Button>
-    </>
+      <Space>
+        <Button
+          onClick={() => {
+            setIsZh(!isZh);
+            setLocale(isZh ? 'en-US' : 'zh-CN', false);
+          }}
+        >
+          {msg}
+        </Button>
+      </Space>
+    </Layout>
   );
 }

--- a/packages/plugins/src/antd.ts
+++ b/packages/plugins/src/antd.ts
@@ -139,6 +139,11 @@ export default (api: IApi) => {
         antd.configProvider.theme || {},
         antd.theme,
       );
+      if (antd.configProvider.theme.algorithm) {
+        api.logger.error(
+          `When configure 'algorithm' in the configuration file, an exception occurs. Please configure 'algorithm' in the runtime configuration instead. https://github.com/umijs/umi/issues/11156`,
+        );
+      }
     }
 
     if (antd.appConfig) {

--- a/packages/plugins/templates/antd/runtime.ts.tpl
+++ b/packages/plugins/templates/antd/runtime.ts.tpl
@@ -1,17 +1,62 @@
 import React from 'react';
 import {
-  Modal,
 {{#configProvider}}
   ConfigProvider,
 {{/configProvider}}
 {{#appConfig}}
   App,
 {{/appConfig}}
+{{^isAntd5}}
+  Modal,
   message,
   notification,
+{{/isAntd5}}
+{{#isAntd5}}
+  theme
+{{/isAntd5}}
 } from 'antd';
 import { ApplyPluginsType } from 'umi';
 import { getPluginManager } from '../core/plugin';
+{{#isAntd5}}
+import { AntdContext, AntdContextSetter } from './context';
+
+const { darkAlgorithm, compactAlgorithm, defaultAlgorithm } = theme;
+
+const AntdProvider = ({ container, config }) => {
+  const [antdConfig, setConfig] = React.useState(config);
+  const setAntdConfig = (data) => {
+    const mergeConfig = {
+      ...antdConfig,
+      ...data,
+      theme: {
+        ...(antdConfig?.theme || {}),
+        ...(data?.theme || {}),
+      },
+    };
+    // set theme model
+    if ('dark' in data || 'compact' in data) {
+      mergeConfig.theme.algorithm = [
+        mergeConfig?.dark ? darkAlgorithm : defaultAlgorithm,
+        mergeConfig?.compact && compactAlgorithm,
+      ].filter(Boolean);
+    }
+    setConfig(mergeConfig);
+  };
+  if (antdConfig.iconPrefixCls) {
+    // Icons in message need to set iconPrefixCls via ConfigProvider.config()
+    ConfigProvider.config({
+      iconPrefixCls: antdConfig.iconPrefixCls,
+    });
+  }
+  return (
+    <AntdContextSetter.Provider value={setAntdConfig}>
+      <AntdContext.Provider value={antdConfig}>
+        <ConfigProvider {...antdConfig}>{container}</ConfigProvider>
+      </AntdContext.Provider>
+    </AntdContextSetter.Provider>
+  );
+};
+{{/isAntd5}}
 
 let cacheAntdConfig = null;
 
@@ -27,6 +72,10 @@ const getAntdConfig = () => {
   {{#appConfig}}
         appConfig: {{{appConfig}}},
   {{/appConfig}}
+{{#isAntd5}}
+        dark: {{dark}},
+        compact: {{compact}},
+{{/isAntd5}}
       },
     });
   }
@@ -34,12 +83,27 @@ const getAntdConfig = () => {
 }
 
 export function rootContainer(rawContainer) {
-  const {
-    appConfig,
-    ...finalConfigProvider
-  } = getAntdConfig();
-  let container = rawContainer;
 {{#configProvider}}
+const {
+  appConfig,
+  ...finalConfigProvider
+} = getAntdConfig();
+if (finalConfigProvider.iconPrefixCls) {
+  // Icons in message need to set iconPrefixCls via ConfigProvider.config()
+  ConfigProvider.config({
+    iconPrefixCls: finalConfigProvider.iconPrefixCls,
+  });
+};
+
+{{#isAntd5}}
+  // init algorithm
+  finalConfigProvider.theme ??= {};
+  finalConfigProvider.theme.algorithm = [
+    finalConfigProvider?.dark ? darkAlgorithm : defaultAlgorithm,
+    finalConfigProvider?.compact && compactAlgorithm,
+  ].filter(Boolean);
+  return <AntdProvider config={finalConfigProvider} container={rawContainer} />;;
+{{/isAntd5}}
 
 {{^isAntd5}}
   // It is only necessary in Ant Design version 4.x
@@ -54,17 +118,11 @@ export function rootContainer(rawContainer) {
       prefixCls: `${finalConfigProvider.prefixCls}-notification`
     });
   }
+  return <ConfigProvider {...finalConfigProvider}>{rawContainer}</ConfigProvider>;
 {{/isAntd5}}
-  if (finalConfigProvider.iconPrefixCls) {
-    // Icons in message need to set iconPrefixCls via ConfigProvider.config()
-    ConfigProvider.config({
-      iconPrefixCls: finalConfigProvider.iconPrefixCls,
-    });
-  };
-  container = <ConfigProvider {...finalConfigProvider}>{container}</ConfigProvider>;
 {{/configProvider}}
 
-  return container;
+  return rawContainer;
 }
 
 {{#appConfig}}

--- a/packages/plugins/templates/antd/runtime.ts.tpl
+++ b/packages/plugins/templates/antd/runtime.ts.tpl
@@ -40,6 +40,9 @@ export function rootContainer(rawContainer) {
   } = getAntdConfig();
   let container = rawContainer;
 {{#configProvider}}
+
+{{^isAntd5}}
+  // It is only necessary in Ant Design version 4.x
   if (finalConfigProvider.prefixCls) {
     Modal.config({
       rootPrefixCls: finalConfigProvider.prefixCls
@@ -51,7 +54,7 @@ export function rootContainer(rawContainer) {
       prefixCls: `${finalConfigProvider.prefixCls}-notification`
     });
   }
-
+{{/isAntd5}}
   if (finalConfigProvider.iconPrefixCls) {
     // Icons in message need to set iconPrefixCls via ConfigProvider.config()
     ConfigProvider.config({


### PR DESCRIPTION
1、当用户使用到不支持的配置时，给出警告。
Closes: #10231 #10745

2、增加 useAntdConfig 和 useAntdConfigSetter api 用于动态修改 ConfigProvider 的配置
![Untitled](https://github.com/umijs/umi/assets/11746742/c21c0fd0-941e-4848-8e21-7aab5b87e713)

3、禁止在 config 中配置 algorithm
Closes: https://github.com/umijs/umi/issues/11156