### PR TITLE
perf(preset-umi): avoid resolve config for lint command

### DIFF
--- a/packages/preset-umi/src/commands/lint.ts
+++ b/packages/preset-umi/src/commands/lint.ts
@@ -5,6 +5,7 @@ export default (api: IApi) => {
   api.registerCommand({
     name: 'lint',
     description: 'lint source code using eslint and stylelint',
+    configResolveMode: 'loose',
     details: `
 umi lint
 


### PR DESCRIPTION
`lint` 命令用不到 Umi 的用户配置文件，将配置解析模式设置为 `loose`，提升命令执行速度