### PR TITLE
fix: phantom dep problem for utils and babel-preset

### DIFF
--- a/packages/babel-preset-umi/package.json
+++ b/packages/babel-preset-umi/package.json
@@ -47,6 +47,7 @@
     "@umijs/babel-plugin-auto-css-modules": "3.3.14",
     "@umijs/babel-plugin-import-to-await-require": "3.3.14",
     "@umijs/babel-plugin-lock-core-js-3": "3.3.14",
+    "@umijs/utils": "3.3.14",
     "babel-plugin-dynamic-import-node": "2.3.3",
     "babel-plugin-import": "^1.13.1",
     "babel-plugin-named-asset-import": "0.3.7",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -43,6 +43,7 @@
     "@types/signale": "1.4.1",
     "@types/yargs": "15.0.12",
     "@types/yargs-parser": "15.0.0",
+    "@umijs/babel-preset-umi": "3.3.14",
     "address": "1.1.2",
     "chalk": "4.1.0",
     "cheerio": "1.0.0-rc.3",


### PR DESCRIPTION
修复 Umi 3.3.x 中 @umijs/utils 和 @umijs/babel-preset-umi 的幽灵依赖问题

背景：Smallfish 仍然基于 3.3.x，其组件库方案在集成 dumi 2 的时候会出现依赖错位的问题