### PR TITLE
fix: 🐛 关闭 mfus webpack 配置的 的 tscheck 插件

### DIFF
--- a/packages/bundler-webpack/src/dev.ts
+++ b/packages/bundler-webpack/src/dev.ts
@@ -163,7 +163,7 @@ export async function setup(opts: IOpts) {
     rootDir: opts.rootDir,
     env: Env.development,
     entry: opts.entry,
-    userConfig: opts.config,
+    userConfig: { ...opts.config, forkTSChecker: false },
     disableCopy: true,
     hash: true,
     staticPathPrefix: MF_DEP_PREFIX,

--- a/packages/preset-umi/src/commands/dev/depBuildWorker/dev-config.ts
+++ b/packages/preset-umi/src/commands/dev/depBuildWorker/dev-config.ts
@@ -54,7 +54,7 @@ export default (api: IApi) => {
         },
       });
       const opts: any = {
-        config: api.config,
+        config: { ...api.config, forkTSChecker: false },
         pkg: api.pkg,
         cwd: api.cwd,
         rootDir: process.cwd(),


### PR DESCRIPTION
原来会在项目代码 bundle 和依赖代码 bundle 的时候同时搞 tscheck 影响执行效率。