### PR TITLE
feat: support loading only suspense for ssr

### DIFF
--- a/packages/preset-umi/src/features/ssr/ssr.ts
+++ b/packages/preset-umi/src/features/ssr/ssr.ts
@@ -155,4 +155,6 @@ export default function handler(request, response) {
     };
     return config;
   });
+
+  api.addRuntimePluginKey(() => ['modifyServerRenderOpts']);
 };

--- a/packages/preset-umi/src/features/suspense/suspense.ts
+++ b/packages/preset-umi/src/features/suspense/suspense.ts
@@ -1,0 +1,37 @@
+import type { IApi } from '../../types';
+
+/**
+ * plugin for replace React Suspense with custom suspense
+ * to avoid hydration error when page re-render in runtime
+ * only for dumi static site now
+ */
+export default (api: IApi) => {
+  api.describe({
+    enableBy() {
+      // FIXME: enable condition before merge
+      // return Boolean(api.appData._useLoadingOnlySuspense);
+      return true;
+    },
+  });
+
+  api.writeTmpFile({
+    noPluginDir: true,
+    path: 'core/suspense.ts',
+    content: `
+import React, { Suspense } from 'react';
+
+const LoadingOnlySuspense: typeof Suspense = (props) => {
+  // TODO: implement
+  return props.children;
+}
+
+export function modifyClientRenderOpts(memo: any) {
+  memo.suspenseComponent = LoadingOnlySuspense;
+
+  return memo;
+}
+    `,
+  });
+
+  api.addRuntimePlugin(() => ['@@/core/suspense.ts']);
+};

--- a/packages/preset-umi/src/features/suspense/suspense.ts
+++ b/packages/preset-umi/src/features/suspense/suspense.ts
@@ -31,6 +31,12 @@ export default (api: IApi) => {
 
     return memo;
   }
+
+  export function modifyServerRenderOpts(memo: any) {
+    memo.suspenseComponent = LoadingOnlySuspense;
+
+    return memo;
+  }
       `,
     });
   });

--- a/packages/preset-umi/src/features/suspense/suspense.ts
+++ b/packages/preset-umi/src/features/suspense/suspense.ts
@@ -14,23 +14,25 @@ export default (api: IApi) => {
     },
   });
 
-  api.writeTmpFile({
-    noPluginDir: true,
-    path: 'core/suspense.ts',
-    content: `
-import React, { Suspense } from 'react';
+  api.onGenerateFiles(() => {
+    api.writeTmpFile({
+      noPluginDir: true,
+      path: 'core/suspense.ts',
+      content: `
+  import React, { Suspense } from 'react';
 
-const LoadingOnlySuspense: typeof Suspense = (props) => {
-  // TODO: implement
-  return props.children;
-}
+  const LoadingOnlySuspense: typeof Suspense = (props) => {
+    // TODO: implement
+    return props.children;
+  }
 
-export function modifyClientRenderOpts(memo: any) {
-  memo.suspenseComponent = LoadingOnlySuspense;
+  export function modifyClientRenderOpts(memo: any) {
+    memo.suspenseComponent = LoadingOnlySuspense;
 
-  return memo;
-}
-    `,
+    return memo;
+  }
+      `,
+    });
   });
 
   api.addRuntimePlugin(() => ['@@/core/suspense.ts']);

--- a/packages/preset-umi/src/index.ts
+++ b/packages/preset-umi/src/index.ts
@@ -32,6 +32,7 @@ export default () => {
       require.resolve('./features/polyfill/publicPathPolyfill'),
       require.resolve('./features/prepare/prepare'),
       require.resolve('./features/routePrefetch/routePrefetch'),
+      require.resolve('./features/suspense/suspense'),
       require.resolve('./features/terminal/terminal'),
 
       // 1. generate tmp files

--- a/packages/preset-umi/templates/server.tpl
+++ b/packages/preset-umi/templates/server.tpl
@@ -50,8 +50,7 @@ const createOpts = {
   getClientRootComponent,
   helmetContext,
   createHistory,
-  },
-});
+};
 const requestHandler = createRequestHandler(createOpts);
 
 export const _markupGenerator = createMarkupGenerator(createOpts);

--- a/packages/preset-umi/templates/server.tpl
+++ b/packages/preset-umi/templates/server.tpl
@@ -50,7 +50,8 @@ const createOpts = {
   getClientRootComponent,
   helmetContext,
   createHistory,
-};
+  },
+});
 const requestHandler = createRequestHandler(createOpts);
 
 export const _markupGenerator = createMarkupGenerator(createOpts);

--- a/packages/renderer-react/src/browser.tsx
+++ b/packages/renderer-react/src/browser.tsx
@@ -140,6 +140,12 @@ export type RenderClientOpts = {
    * 应用渲染完成的回调函数
    */
   callback?: () => void;
+  /**
+   * 自定义 Suspense 组件
+   */
+  suspenseComponent?: Parameters<
+    typeof createClientRoutes
+  >[0]['suspenseComponent'];
 };
 /**
  * umi max 所需要的所有插件列表，用于获取provide
@@ -170,6 +176,7 @@ const getBrowser = (
     routeComponents: opts.routeComponents,
     loadingComponent: opts.loadingComponent,
     reactRouter5Compat: opts.reactRouter5Compat,
+    suspenseComponent: opts.suspenseComponent,
   });
   opts.pluginManager.applyPlugins({
     key: 'patchClientRoutes',

--- a/packages/renderer-react/src/server.tsx
+++ b/packages/renderer-react/src/server.tsx
@@ -13,12 +13,16 @@ export async function getClientRootComponent(opts: {
   location: string;
   loaderData: { [routeKey: string]: any };
   manifest: any;
+  suspenseComponent?: Parameters<
+    typeof createClientRoutes
+  >[0]['suspenseComponent'];
 }) {
   const basename = '/';
   const components = { ...opts.routeComponents };
   const clientRoutes = createClientRoutes({
     routesById: opts.routes,
     routeComponents: components,
+    suspenseComponent: opts.suspenseComponent,
   });
   let rootContainer = (
     <StaticRouter basename={basename} location={opts.location}>

--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -72,14 +72,18 @@ function createJSXGenerator(opts: CreateRequestHandlerOptions) {
 
     const manifest =
       typeof opts.manifest === 'function' ? opts.manifest() : opts.manifest;
-    const context = {
-      routes,
-      routeComponents,
-      pluginManager,
-      location: url,
-      manifest,
-      loaderData,
-    };
+    const context = PluginManager.applyPlugins({
+      type: 'modify',
+      key: 'modifyServerRenderOpts',
+      initialValue: {
+        routes,
+        routeComponents,
+        pluginManager,
+        location: url,
+        manifest,
+        loaderData,
+      },
+    });
 
     return {
       element: (await opts.getClientRootComponent(context)) as ReactElement,


### PR DESCRIPTION
## 背景

SSR 预渲染场景（例如使用 dumi 的 Ant Design 官网）中，路由级的 `Suspense` 倘若在注水过程中触发 re-render，则会导致注水失败、抛出错误并重新加载整个应用，最终给浏览者带来糟糕的体验。

关联 issue：https://github.com/ant-design/ant-design/issues/41563

## 方案

支持将原生的 `Suspense` 替换成自定义的 `Suspense`，该组件可以只做 Loading 效果，不实现原生 `Suspense` 的注水和异常处理。

子任务：
- [x] renderer-react 支持传入自定义的 `suspenseComponent` 参数
- [x] preset-umi 增加 suspense 插件，通过 `modifyClientRenderOpts` 设置自定义的 `Suspense` 组件
- [ ] 实现 `Suspense` 组件，cc @MadCcc 

## 讨论点
- [ ] 是否要把该插件的开启方式从私有 flag 变成与 `ssr` + `exportStatic` 配置项关联？