### PR TITLE
feat: bump esbuild -> 0.17.19 , use the new context api

### DIFF
--- a/examples/mfsu-independent-e2e/package.json
+++ b/examples/mfsu-independent-e2e/package.json
@@ -27,7 +27,7 @@
     "babel-loader": "^9.1.2",
     "cross-env": "^7.0.3",
     "cypress": "^12.0.0",
-    "esbuild": "0.16.17",
+    "esbuild": "0.17.19",
     "esbuild-register": "^3.4.2",
     "html-webpack-plugin": "^5.5.0",
     "start-server-and-test": "^1.15.2",

--- a/examples/mfsu-independent/package.json
+++ b/examples/mfsu-independent/package.json
@@ -22,7 +22,7 @@
     "@types/react-dom": "^18.0.10",
     "@umijs/mfsu": "workspace:*",
     "babel-loader": "^9.1.2",
-    "esbuild": "0.16.17",
+    "esbuild": "0.17.19",
     "html-webpack-plugin": "^5.5.0",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",

--- a/packages/bundler-utils/package.json
+++ b/packages/bundler-utils/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@umijs/utils": "workspace:*",
-    "esbuild": "0.16.17",
+    "esbuild": "0.17.19",
     "regenerate": "^1.4.2",
     "regenerate-unicode-properties": "10.1.0",
     "spdy": "^4.0.2"

--- a/packages/bundler-utils/src/esbuild-plugins/index.ts
+++ b/packages/bundler-utils/src/esbuild-plugins/index.ts
@@ -1,0 +1,1 @@
+export { default as esbuildWatchRebuildPlugin } from './watchRebuild';

--- a/packages/bundler-utils/src/esbuild-plugins/watchRebuild.ts
+++ b/packages/bundler-utils/src/esbuild-plugins/watchRebuild.ts
@@ -1,0 +1,55 @@
+import type {
+  BuildFailure,
+  BuildResult,
+  Message,
+  Plugin,
+} from '@umijs/bundler-utils/compiled/esbuild';
+
+//fork from esbuild https://github.com/evanw/esbuild/blob/main/lib/shared/common.ts#L1640
+function failureErrorWithLog(
+  text: string,
+  errors: Message[],
+  warnings: Message[],
+): BuildFailure {
+  let limit = 5;
+  let summary =
+    errors.length < 1
+      ? ''
+      : ` with ${errors.length} error${errors.length < 2 ? '' : 's'}:` +
+        errors
+          .slice(0, limit + 1)
+          .map((e, i) => {
+            if (i === limit) return '\n...';
+            if (!e.location) return `\nerror: ${e.text}`;
+            let { file, line, column } = e.location;
+            let pluginText = e.pluginName ? `[plugin: ${e.pluginName}] ` : '';
+            return `\n${file}:${line}:${column}: ERROR: ${pluginText}${e.text}`;
+          })
+          .join('');
+  let error: any = new Error(`${text}${summary}`);
+  error.errors = errors;
+  error.warnings = warnings;
+  return error;
+}
+
+export default (options: {
+  onRebuild: (error: BuildFailure | null, result: BuildResult | null) => void;
+}): Plugin => ({
+  name: 'watch-rebuild-plugin',
+  setup(build) {
+    let count = 0;
+    build.onEnd((result) => {
+      if (count++ === 0) {
+        return;
+      }
+      if (result.errors.length > 0) {
+        options.onRebuild(
+          failureErrorWithLog('Build failed', result.errors, result.warnings),
+          null,
+        );
+        return;
+      }
+      options.onRebuild(null, result);
+    });
+  },
+});

--- a/packages/bundler-utils/src/index.ts
+++ b/packages/bundler-utils/src/index.ts
@@ -45,6 +45,7 @@ export function isDepPath(path: string) {
   );
 }
 
+export * from './esbuild-plugins';
 export * from './https';
 export * from './proxy';
 export * from './types';

--- a/packages/preset-umi/src/features/apiRoute/dev-server/esbuild.ts
+++ b/packages/preset-umi/src/features/apiRoute/dev-server/esbuild.ts
@@ -1,3 +1,4 @@
+import { esbuildWatchRebuildPlugin } from '@umijs/bundler-utils';
 import esbuild from '@umijs/bundler-utils/compiled/esbuild';
 import { logger } from '@umijs/utils';
 import { join, resolve } from 'path';
@@ -11,7 +12,7 @@ export default async function (api: IApi, apiRoutes: IRoute[]) {
     join(api.paths.absTmpPath, 'api', r.file),
   );
 
-  await esbuild.build({
+  const ctx = await esbuild.context({
     format: 'cjs',
     platform: 'node',
     bundle: true,
@@ -20,17 +21,19 @@ export default async function (api: IApi, apiRoutes: IRoute[]) {
       resolve(api.paths.absTmpPath, 'api/_middlewares.ts'),
     ],
     outdir: resolve(api.paths.cwd, OUTPUT_PATH),
-    plugins: [esbuildIgnorePathPrefixPlugin()],
-    watch: {
-      onRebuild(error) {
-        if (error) logger.error('Compile api routes failed: ', error);
-
-        // Reload API route modules
-        Object.keys(require.cache).forEach((modulePath) => {
-          if (modulePath.startsWith(join(api.paths.cwd, OUTPUT_PATH)))
-            delete require.cache[modulePath];
-        });
-      },
-    },
+    plugins: [
+      esbuildIgnorePathPrefixPlugin(),
+      esbuildWatchRebuildPlugin({
+        onRebuild(error) {
+          if (error) logger.error('Compile api routes failed: ', error);
+          // Reload API route modules
+          Object.keys(require.cache).forEach((modulePath) => {
+            if (modulePath.startsWith(join(api.paths.cwd, OUTPUT_PATH)))
+              delete require.cache[modulePath];
+          });
+        },
+      }),
+    ],
   });
+  await ctx.watch();
 }

--- a/packages/preset-umi/src/features/prepare/build.ts
+++ b/packages/preset-umi/src/features/prepare/build.ts
@@ -1,4 +1,5 @@
-import esbuild from '@umijs/bundler-utils/compiled/esbuild';
+import { esbuildWatchRebuildPlugin } from '@umijs/bundler-utils';
+import esbuild, { BuildOptions } from '@umijs/bundler-utils/compiled/esbuild';
 import { logger } from '@umijs/utils';
 import path from 'path';
 import { esbuildAliasPlugin } from './esbuildPlugins/esbuildAliasPlugin';
@@ -17,7 +18,7 @@ export async function build(opts: {
 }) {
   const outdir = path.join(path.dirname(opts.entryPoints[0]), 'out');
   const alias = opts.config?.alias || {};
-  return await esbuild.build({
+  const buildOptions: BuildOptions = {
     // 需要指定 absWorkingDir 兼容 APP_ROOT 的情况
     absWorkingDir: opts.config.cwd,
     format: 'esm',
@@ -30,17 +31,6 @@ export async function build(opts: {
       '.jsx': 'tsx',
       '.ts': 'ts',
       '.tsx': 'tsx',
-    },
-    watch: !!opts.watch && {
-      onRebuild(err, result) {
-        if (err) {
-          logger.error(`[icons] build failed: ${err}`);
-        } else {
-          if (opts.watch) {
-            opts.watch.onRebuildSuccess({ result: result! });
-          }
-        }
-      },
     },
     // do I need this?
     // incremental: true,
@@ -59,7 +49,24 @@ export async function build(opts: {
       // if we resolve externals first, we will get { external: true }
       esbuildExternalPlugin({ alias }),
       esbuildAliasPlugin({ alias }),
+      esbuildWatchRebuildPlugin({
+        onRebuild(err, result) {
+          if (err) {
+            logger.error(`[icons] build failed: ${err}`);
+          } else {
+            if (opts.watch) {
+              opts.watch.onRebuildSuccess({ result: result! });
+            }
+          }
+        },
+      }),
       ...(opts.plugins || []),
     ],
-  });
+  };
+  if (opts.watch) {
+    const ctx = await esbuild.context(buildOptions);
+    return await ctx.watch();
+  } else {
+    return await esbuild.build(buildOptions);
+  }
 }

--- a/packages/preset-umi/src/features/ssr/builder/builder.ts
+++ b/packages/preset-umi/src/features/ssr/builder/builder.ts
@@ -1,4 +1,5 @@
-import esbuild from '@umijs/bundler-utils/compiled/esbuild';
+import { esbuildWatchRebuildPlugin } from '@umijs/bundler-utils';
+import esbuild, { BuildOptions } from '@umijs/bundler-utils/compiled/esbuild';
 import { aliasUtils, isMonorepo, logger } from '@umijs/utils';
 import { resolve } from 'path';
 import { IApi } from '../../../types';
@@ -27,7 +28,7 @@ export async function build(opts: { api: IApi; watch?: boolean }) {
   // currently esbuild not support circle alias
   const alias = aliasUtils.parseCircleAlias({ alias: api.config.alias });
 
-  await esbuild.build({
+  const buildOptions: BuildOptions = {
     alias,
     format: 'cjs',
     platform: 'node',
@@ -35,17 +36,6 @@ export async function build(opts: { api: IApi; watch?: boolean }) {
     bundle: true,
     logLevel: 'silent',
     inject: [resolve(api.paths.absTmpPath, 'ssr/react-shim.js')],
-    watch: watch
-      ? {
-          onRebuild(err) {
-            logger.event('[SSR] Rebuilt');
-            delete require.cache[absServerBuildPath(api)];
-            if (err) {
-              logger.error(err);
-            }
-          },
-        }
-      : false,
     loader,
     entryPoints: [resolve(api.paths.absTmpPath, 'umi.server.ts')],
     plugins: [
@@ -54,10 +44,25 @@ export async function build(opts: { api: IApi; watch?: boolean }) {
       cssLoader({ cwd: api.cwd }),
       svgLoader({ cwd: api.cwd }),
       assetsLoader({ cwd: api.cwd }),
+      esbuildWatchRebuildPlugin({
+        onRebuild(err) {
+          logger.event('[SSR] Rebuilt');
+          delete require.cache[absServerBuildPath(api)];
+          if (err) {
+            logger.error(err);
+          }
+        },
+      }),
     ],
     outfile: absServerBuildPath(api),
     external: getExternal(),
-  });
+  };
+  if (watch) {
+    const ctx = await esbuild.context(buildOptions);
+    await ctx.watch();
+  } else {
+    await esbuild.build(buildOptions);
+  }
   const diff = new Date().getTime() - now;
   logger.info(`[SSR] Compiled in ${diff}ms`);
 }

--- a/packages/preset-umi/src/features/ssr/builder/less-loader.ts
+++ b/packages/preset-umi/src/features/ssr/builder/less-loader.ts
@@ -18,9 +18,7 @@ export const lessLoader = (opts: {
         const filePath = join(args.resolveDir, args.path);
         return {
           path: filePath,
-          watchFiles: !!build.initialOptions.watch
-            ? [filePath, ...getLessImports(filePath)]
-            : undefined,
+          watchFiles: [filePath, ...getLessImports(filePath)],
         };
       });
 

--- a/packages/preset-umi/src/utils/routeExportExtractor.ts
+++ b/packages/preset-umi/src/utils/routeExportExtractor.ts
@@ -1,4 +1,4 @@
-import esbuild from '@umijs/bundler-utils/compiled/esbuild';
+import esbuild, { BuildOptions } from '@umijs/bundler-utils/compiled/esbuild';
 import { join, resolve } from 'path';
 import type { IApi } from 'umi';
 
@@ -74,12 +74,11 @@ async function setupExportExtractBuilder(
   opts: IRouteExportExtractorSetupBuilderOpts,
 ) {
   const { api, entryFile, outFile } = opts;
-  await esbuild.build({
+  const buildOptions: BuildOptions = {
     format: 'esm',
     platform: 'browser',
     target: 'esnext',
     loader,
-    watch: api.env === 'development' && {},
     bundle: true,
     logLevel: 'error',
     entryPoints: [join(api.paths.absTmpPath, entryFile)],
@@ -107,7 +106,13 @@ async function setupExportExtractBuilder(
         },
       },
     ],
-  });
+  };
+  if (api.env === 'development') {
+    const ctx = await esbuild.context(buildOptions);
+    return await ctx.watch();
+  } else {
+    return await esbuild.build(buildOptions);
+  }
 }
 
 const loader: { [ext: string]: esbuild.Loader } = {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -26,7 +26,7 @@
     "@umijs/bundler-utils": "workspace:*",
     "@umijs/utils": "workspace:*",
     "babel-jest": "^29.4.3",
-    "esbuild": "0.16.17",
+    "esbuild": "0.17.19",
     "identity-obj-proxy": "3.0.0",
     "isomorphic-unfetch": "4.0.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -874,14 +874,14 @@ importers:
         specifier: ^9.1.2
         version: 9.1.2(@babel/core@7.21.0)(webpack@5.75.0)
       esbuild:
-        specifier: 0.16.17
-        version: 0.16.17
+        specifier: 0.17.19
+        version: 0.17.19
       html-webpack-plugin:
         specifier: ^5.5.0
         version: 5.5.0(webpack@5.75.0)
       webpack:
         specifier: ^5.75.0
-        version: 5.75.0(esbuild@0.16.17)(uglify-js@3.17.4)(webpack-cli@5.0.1)
+        version: 5.75.0(esbuild@0.17.19)(uglify-js@3.17.4)(webpack-cli@5.0.1)
       webpack-cli:
         specifier: ^5.0.1
         version: 5.0.1(webpack-dev-server@4.11.1)(webpack@5.75.0)
@@ -935,11 +935,11 @@ importers:
         specifier: ^12.0.0
         version: 12.6.0
       esbuild:
-        specifier: 0.16.17
-        version: 0.16.17
+        specifier: 0.17.19
+        version: 0.17.19
       esbuild-register:
         specifier: ^3.4.2
-        version: 3.4.2(esbuild@0.16.17)
+        version: 3.4.2(esbuild@0.17.19)
       html-webpack-plugin:
         specifier: ^5.5.0
         version: 5.5.0(webpack@5.75.0)
@@ -948,7 +948,7 @@ importers:
         version: 1.15.2
       webpack:
         specifier: ^5.75.0
-        version: 5.75.0(esbuild@0.16.17)(uglify-js@3.17.4)(webpack-cli@5.0.1)
+        version: 5.75.0(esbuild@0.17.19)(uglify-js@3.17.4)(webpack-cli@5.0.1)
       webpack-cli:
         specifier: ^5.0.1
         version: 5.0.1(webpack-dev-server@4.11.1)(webpack@5.75.0)
@@ -1695,8 +1695,8 @@ importers:
         specifier: workspace:*
         version: link:../utils
       esbuild:
-        specifier: 0.16.17
-        version: 0.16.17
+        specifier: 0.17.19
+        version: 0.17.19
       regenerate:
         specifier: ^1.4.2
         version: 1.4.2
@@ -2558,8 +2558,8 @@ importers:
         specifier: ^29.4.3
         version: 29.4.3(@babel/core@7.21.0)
       esbuild:
-        specifier: 0.16.17
-        version: 0.16.17
+        specifier: 0.17.19
+        version: 0.17.19
       identity-obj-proxy:
         specifier: 3.0.0
         version: 3.0.0
@@ -9732,8 +9732,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/android-arm64@0.17.12:
-    resolution: {integrity: sha512-WQ9p5oiXXYJ33F2EkE3r0FRDFVpEdcDiwNX3u7Xaibxfx6vQE0Sb8ytrfQsA5WO6kDn6mDfKLh6KrPBjvkk7xA==}
+  /@esbuild/android-arm64@0.17.19:
+    resolution: {integrity: sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -9756,8 +9756,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/android-arm@0.17.12:
-    resolution: {integrity: sha512-E/sgkvwoIfj4aMAPL2e35VnUJspzVYl7+M1B2cqeubdBhADV4uPon0KCc8p2G+LqSJ6i8ocYPCqY3A4GGq0zkQ==}
+  /@esbuild/android-arm@0.17.19:
+    resolution: {integrity: sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -9772,8 +9772,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/android-x64@0.17.12:
-    resolution: {integrity: sha512-m4OsaCr5gT+se25rFPHKQXARMyAehHTQAz4XX1Vk3d27VtqiX0ALMBPoXZsGaB6JYryCLfgGwUslMqTfqeLU0w==}
+  /@esbuild/android-x64@0.17.19:
+    resolution: {integrity: sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -9788,8 +9788,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.17.12:
-    resolution: {integrity: sha512-O3GCZghRIx+RAN0NDPhyyhRgwa19MoKlzGonIb5hgTj78krqp9XZbYCvFr9N1eUxg0ZQEpiiZ4QvsOQwBpP+lg==}
+  /@esbuild/darwin-arm64@0.17.19:
+    resolution: {integrity: sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -9804,8 +9804,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/darwin-x64@0.17.12:
-    resolution: {integrity: sha512-5D48jM3tW27h1qjaD9UNRuN+4v0zvksqZSPZqeSWggfMlsVdAhH3pwSfQIFJwcs9QJ9BRibPS4ViZgs3d2wsCA==}
+  /@esbuild/darwin-x64@0.17.19:
+    resolution: {integrity: sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -9820,8 +9820,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.17.12:
-    resolution: {integrity: sha512-OWvHzmLNTdF1erSvrfoEBGlN94IE6vCEaGEkEH29uo/VoONqPnoDFfShi41Ew+yKimx4vrmmAJEGNoyyP+OgOQ==}
+  /@esbuild/freebsd-arm64@0.17.19:
+    resolution: {integrity: sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -9836,8 +9836,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/freebsd-x64@0.17.12:
-    resolution: {integrity: sha512-A0Xg5CZv8MU9xh4a+7NUpi5VHBKh1RaGJKqjxe4KG87X+mTjDE6ZvlJqpWoeJxgfXHT7IMP9tDFu7IZ03OtJAw==}
+  /@esbuild/freebsd-x64@0.17.19:
+    resolution: {integrity: sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -9852,8 +9852,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-arm64@0.17.12:
-    resolution: {integrity: sha512-cK3AjkEc+8v8YG02hYLQIQlOznW+v9N+OI9BAFuyqkfQFR+DnDLhEM5N8QRxAUz99cJTo1rLNXqRrvY15gbQUg==}
+  /@esbuild/linux-arm64@0.17.19:
+    resolution: {integrity: sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -9868,8 +9868,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-arm@0.17.12:
-    resolution: {integrity: sha512-WsHyJ7b7vzHdJ1fv67Yf++2dz3D726oO3QCu8iNYik4fb5YuuReOI9OtA+n7Mk0xyQivNTPbl181s+5oZ38gyA==}
+  /@esbuild/linux-arm@0.17.19:
+    resolution: {integrity: sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -9884,8 +9884,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-ia32@0.17.12:
-    resolution: {integrity: sha512-jdOBXJqcgHlah/nYHnj3Hrnl9l63RjtQ4vn9+bohjQPI2QafASB5MtHAoEv0JQHVb/xYQTFOeuHnNYE1zF7tYw==}
+  /@esbuild/linux-ia32@0.17.19:
+    resolution: {integrity: sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -9908,8 +9908,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-loong64@0.17.12:
-    resolution: {integrity: sha512-GTOEtj8h9qPKXCyiBBnHconSCV9LwFyx/gv3Phw0pa25qPYjVuuGZ4Dk14bGCfGX3qKF0+ceeQvwmtI+aYBbVA==}
+  /@esbuild/linux-loong64@0.17.19:
+    resolution: {integrity: sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -9924,8 +9924,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.17.12:
-    resolution: {integrity: sha512-o8CIhfBwKcxmEENOH9RwmUejs5jFiNoDw7YgS0EJTF6kgPgcqLFjgoc5kDey5cMHRVCIWc6kK2ShUePOcc7RbA==}
+  /@esbuild/linux-mips64el@0.17.19:
+    resolution: {integrity: sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -9940,8 +9940,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-ppc64@0.17.12:
-    resolution: {integrity: sha512-biMLH6NR/GR4z+ap0oJYb877LdBpGac8KfZoEnDiBKd7MD/xt8eaw1SFfYRUeMVx519kVkAOL2GExdFmYnZx3A==}
+  /@esbuild/linux-ppc64@0.17.19:
+    resolution: {integrity: sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -9956,8 +9956,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.17.12:
-    resolution: {integrity: sha512-jkphYUiO38wZGeWlfIBMB72auOllNA2sLfiZPGDtOBb1ELN8lmqBrlMiucgL8awBw1zBXN69PmZM6g4yTX84TA==}
+  /@esbuild/linux-riscv64@0.17.19:
+    resolution: {integrity: sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -9972,8 +9972,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-s390x@0.17.12:
-    resolution: {integrity: sha512-j3ucLdeY9HBcvODhCY4b+Ds3hWGO8t+SAidtmWu/ukfLLG/oYDMaA+dnugTVAg5fnUOGNbIYL9TOjhWgQB8W5g==}
+  /@esbuild/linux-s390x@0.17.19:
+    resolution: {integrity: sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -9988,8 +9988,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-x64@0.17.12:
-    resolution: {integrity: sha512-uo5JL3cgaEGotaqSaJdRfFNSCUJOIliKLnDGWaVCgIKkHxwhYMm95pfMbWZ9l7GeW9kDg0tSxcy9NYdEtjwwmA==}
+  /@esbuild/linux-x64@0.17.19:
+    resolution: {integrity: sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -10004,8 +10004,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/netbsd-x64@0.17.12:
-    resolution: {integrity: sha512-DNdoRg8JX+gGsbqt2gPgkgb00mqOgOO27KnrWZtdABl6yWTST30aibGJ6geBq3WM2TIeW6COs5AScnC7GwtGPg==}
+  /@esbuild/netbsd-x64@0.17.19:
+    resolution: {integrity: sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -10020,8 +10020,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/openbsd-x64@0.17.12:
-    resolution: {integrity: sha512-aVsENlr7B64w8I1lhHShND5o8cW6sB9n9MUtLumFlPhG3elhNWtE7M1TFpj3m7lT3sKQUMkGFjTQBrvDDO1YWA==}
+  /@esbuild/openbsd-x64@0.17.19:
+    resolution: {integrity: sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -10036,8 +10036,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/sunos-x64@0.17.12:
-    resolution: {integrity: sha512-qbHGVQdKSwi0JQJuZznS4SyY27tYXYF0mrgthbxXrZI3AHKuRvU+Eqbg/F0rmLDpW/jkIZBlCO1XfHUBMNJ1pg==}
+  /@esbuild/sunos-x64@0.17.19:
+    resolution: {integrity: sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -10052,8 +10052,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/win32-arm64@0.17.12:
-    resolution: {integrity: sha512-zsCp8Ql+96xXTVTmm6ffvoTSZSV2B/LzzkUXAY33F/76EajNw1m+jZ9zPfNJlJ3Rh4EzOszNDHsmG/fZOhtqDg==}
+  /@esbuild/win32-arm64@0.17.19:
+    resolution: {integrity: sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -10068,8 +10068,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/win32-ia32@0.17.12:
-    resolution: {integrity: sha512-FfrFjR4id7wcFYOdqbDfDET3tjxCozUgbqdkOABsSFzoZGFC92UK7mg4JKRc/B3NNEf1s2WHxJ7VfTdVDPN3ng==}
+  /@esbuild/win32-ia32@0.17.19:
+    resolution: {integrity: sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -10084,8 +10084,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/win32-x64@0.17.12:
-    resolution: {integrity: sha512-JOOxw49BVZx2/5tW3FqkdjSD/5gXYeVGPDcB0lvap0gLQshkh1Nyel1QazC+wNxus3xPlsYAgqU1BUmrmCvWtw==}
+  /@esbuild/win32-x64@0.17.19:
+    resolution: {integrity: sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -15772,7 +15772,7 @@ packages:
       webpack:
         optional: true
     dependencies:
-      webpack: 5.75.0(esbuild@0.16.17)(uglify-js@3.17.4)(webpack-cli@5.0.1)
+      webpack: 5.75.0(esbuild@0.17.19)(uglify-js@3.17.4)(webpack-cli@5.0.1)
       webpack-cli: 5.0.1(webpack-dev-server@4.11.1)(webpack@5.75.0)
 
   /@webpack-cli/info@2.0.1(webpack-cli@5.0.1)(webpack@5.75.0):
@@ -15785,7 +15785,7 @@ packages:
       webpack:
         optional: true
     dependencies:
-      webpack: 5.75.0(esbuild@0.16.17)(uglify-js@3.17.4)(webpack-cli@5.0.1)
+      webpack: 5.75.0(esbuild@0.17.19)(uglify-js@3.17.4)(webpack-cli@5.0.1)
       webpack-cli: 5.0.1(webpack-dev-server@4.11.1)(webpack@5.75.0)
 
   /@webpack-cli/serve@2.0.1(webpack-cli@5.0.1)(webpack-dev-server@4.11.1)(webpack@5.75.0):
@@ -15801,7 +15801,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack: 5.75.0(esbuild@0.16.17)(uglify-js@3.17.4)(webpack-cli@5.0.1)
+      webpack: 5.75.0(esbuild@0.17.19)(uglify-js@3.17.4)(webpack-cli@5.0.1)
       webpack-cli: 5.0.1(webpack-dev-server@4.11.1)(webpack@5.75.0)
       webpack-dev-server: 4.11.1(webpack-cli@5.0.1)(webpack@5.75.0)
 
@@ -17228,7 +17228,7 @@ packages:
       '@babel/core': 7.21.0
       find-cache-dir: 3.3.2
       schema-utils: 4.0.0
-      webpack: 5.75.0(esbuild@0.16.17)(uglify-js@3.17.4)(webpack-cli@5.0.1)
+      webpack: 5.75.0(esbuild@0.17.19)(uglify-js@3.17.4)(webpack-cli@5.0.1)
     dev: true
 
   /babel-plugin-dynamic-import-node@2.3.3:
@@ -21315,13 +21315,13 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-register@3.4.2(esbuild@0.16.17):
+  /esbuild-register@3.4.2(esbuild@0.17.19):
     resolution: {integrity: sha512-kG/XyTDyz6+YDuyfB9ZoSIOOmgyFCH+xPRtsCa8W85HLRV5Csp+o3jWVbOSHgSLfyLc5DmP+KFDNwty4mEjC+Q==}
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
-      esbuild: 0.16.17
+      esbuild: 0.17.19
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -21468,12 +21468,14 @@ packages:
 
   /esbuild@0.11.23:
     resolution: {integrity: sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q==}
+    hasBin: true
     requiresBuild: true
     dev: false
 
   /esbuild@0.14.36:
     resolution: {integrity: sha512-HhFHPiRXGYOCRlrhpiVDYKcFJRdO0sBElZ668M4lh2ER0YgnkLxECuFe7uWCf23FrcLc59Pqr7dHkTqmRPDHmw==}
     engines: {node: '>=12'}
+    hasBin: true
     requiresBuild: true
     optionalDependencies:
       esbuild-android-64: 0.14.36
@@ -21501,6 +21503,7 @@ packages:
   /esbuild@0.14.49:
     resolution: {integrity: sha512-/TlVHhOaq7Yz8N1OJrjqM3Auzo5wjvHFLk+T8pIue+fhnhIMpfAzsG6PLVMbFveVxqD2WOp3QHei+52IMUNmCw==}
     engines: {node: '>=12'}
+    hasBin: true
     requiresBuild: true
     optionalDependencies:
       esbuild-android-64: 0.14.49
@@ -21528,6 +21531,7 @@ packages:
   /esbuild@0.14.51:
     resolution: {integrity: sha512-+CvnDitD7Q5sT7F+FM65sWkF8wJRf+j9fPcprxYV4j+ohmzVj2W7caUqH2s5kCaCJAfcAICjSlKhDCcvDpU7nw==}
     engines: {node: '>=12'}
+    hasBin: true
     requiresBuild: true
     optionalDependencies:
       esbuild-android-64: 0.14.51
@@ -21555,6 +21559,7 @@ packages:
   /esbuild@0.15.18:
     resolution: {integrity: sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==}
     engines: {node: '>=12'}
+    hasBin: true
     requiresBuild: true
     optionalDependencies:
       '@esbuild/android-arm': 0.15.18
@@ -21583,6 +21588,7 @@ packages:
   /esbuild@0.16.17:
     resolution: {integrity: sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==}
     engines: {node: '>=12'}
+    hasBin: true
     requiresBuild: true
     optionalDependencies:
       '@esbuild/android-arm': 0.16.17
@@ -21608,34 +21614,34 @@ packages:
       '@esbuild/win32-ia32': 0.16.17
       '@esbuild/win32-x64': 0.16.17
 
-  /esbuild@0.17.12:
-    resolution: {integrity: sha512-bX/zHl7Gn2CpQwcMtRogTTBf9l1nl+H6R8nUbjk+RuKqAE3+8FDulLA+pHvX7aA7Xe07Iwa+CWvy9I8Y2qqPKQ==}
+  /esbuild@0.17.19:
+    resolution: {integrity: sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==}
     engines: {node: '>=12'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@esbuild/android-arm': 0.17.12
-      '@esbuild/android-arm64': 0.17.12
-      '@esbuild/android-x64': 0.17.12
-      '@esbuild/darwin-arm64': 0.17.12
-      '@esbuild/darwin-x64': 0.17.12
-      '@esbuild/freebsd-arm64': 0.17.12
-      '@esbuild/freebsd-x64': 0.17.12
-      '@esbuild/linux-arm': 0.17.12
-      '@esbuild/linux-arm64': 0.17.12
-      '@esbuild/linux-ia32': 0.17.12
-      '@esbuild/linux-loong64': 0.17.12
-      '@esbuild/linux-mips64el': 0.17.12
-      '@esbuild/linux-ppc64': 0.17.12
-      '@esbuild/linux-riscv64': 0.17.12
-      '@esbuild/linux-s390x': 0.17.12
-      '@esbuild/linux-x64': 0.17.12
-      '@esbuild/netbsd-x64': 0.17.12
-      '@esbuild/openbsd-x64': 0.17.12
-      '@esbuild/sunos-x64': 0.17.12
-      '@esbuild/win32-arm64': 0.17.12
-      '@esbuild/win32-ia32': 0.17.12
-      '@esbuild/win32-x64': 0.17.12
+      '@esbuild/android-arm': 0.17.19
+      '@esbuild/android-arm64': 0.17.19
+      '@esbuild/android-x64': 0.17.19
+      '@esbuild/darwin-arm64': 0.17.19
+      '@esbuild/darwin-x64': 0.17.19
+      '@esbuild/freebsd-arm64': 0.17.19
+      '@esbuild/freebsd-x64': 0.17.19
+      '@esbuild/linux-arm': 0.17.19
+      '@esbuild/linux-arm64': 0.17.19
+      '@esbuild/linux-ia32': 0.17.19
+      '@esbuild/linux-loong64': 0.17.19
+      '@esbuild/linux-mips64el': 0.17.19
+      '@esbuild/linux-ppc64': 0.17.19
+      '@esbuild/linux-riscv64': 0.17.19
+      '@esbuild/linux-s390x': 0.17.19
+      '@esbuild/linux-x64': 0.17.19
+      '@esbuild/netbsd-x64': 0.17.19
+      '@esbuild/openbsd-x64': 0.17.19
+      '@esbuild/sunos-x64': 0.17.19
+      '@esbuild/win32-arm64': 0.17.19
+      '@esbuild/win32-ia32': 0.17.19
+      '@esbuild/win32-x64': 0.17.19
 
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -24175,7 +24181,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.75.0(esbuild@0.16.17)(uglify-js@3.17.4)(webpack-cli@5.0.1)
+      webpack: 5.75.0(esbuild@0.17.19)(uglify-js@3.17.4)(webpack-cli@5.0.1)
 
   /htmlparser2@3.10.1:
     resolution: {integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==}
@@ -38291,7 +38297,7 @@ packages:
       uglify-js: 3.17.4
       webpack: 5.76.1(@swc/core@1.3.24)(uglify-js@3.17.4)
 
-  /terser-webpack-plugin@5.3.6(esbuild@0.16.17)(uglify-js@3.17.4)(webpack@5.75.0):
+  /terser-webpack-plugin@5.3.6(esbuild@0.17.19)(uglify-js@3.17.4)(webpack@5.75.0):
     resolution: {integrity: sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -38310,13 +38316,13 @@ packages:
         optional: true
     dependencies:
       '@jridgewell/trace-mapping': 0.3.15
-      esbuild: 0.16.17
+      esbuild: 0.17.19
       jest-worker: 27.5.1
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
       terser: 5.16.1
       uglify-js: 3.17.4
-      webpack: 5.75.0(esbuild@0.16.17)(uglify-js@3.17.4)(webpack-cli@5.0.1)
+      webpack: 5.75.0(esbuild@0.17.19)(uglify-js@3.17.4)(webpack-cli@5.0.1)
 
   /terser@5.16.1:
     resolution: {integrity: sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==}
@@ -39923,7 +39929,7 @@ packages:
         optional: true
     dependencies:
       '@types/node': 18.11.18
-      esbuild: 0.17.12
+      esbuild: 0.17.19
       less: 4.1.3
       postcss: 8.4.21
       rollup: 3.20.7
@@ -40205,7 +40211,7 @@ packages:
       import-local: 3.1.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.75.0(esbuild@0.16.17)(uglify-js@3.17.4)(webpack-cli@5.0.1)
+      webpack: 5.75.0(esbuild@0.17.19)(uglify-js@3.17.4)(webpack-cli@5.0.1)
       webpack-dev-server: 4.11.1(webpack-cli@5.0.1)(webpack@5.75.0)
       webpack-merge: 5.8.0
 
@@ -40223,7 +40229,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.0.0
-      webpack: 5.75.0(esbuild@0.16.17)(uglify-js@3.17.4)(webpack-cli@5.0.1)
+      webpack: 5.75.0(esbuild@0.17.19)(uglify-js@3.17.4)(webpack-cli@5.0.1)
 
   /webpack-dev-middleware@6.0.1(webpack@5.76.1):
     resolution: {integrity: sha512-PZPZ6jFinmqVPJZbisfggDiC+2EeGZ1ZByyMP5sOFJcPPWSexalISz+cvm+j+oYPT7FIJyxT76esjnw9DhE5sw==}
@@ -40282,7 +40288,7 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.75.0(esbuild@0.16.17)(uglify-js@3.17.4)(webpack-cli@5.0.1)
+      webpack: 5.75.0(esbuild@0.17.19)(uglify-js@3.17.4)(webpack-cli@5.0.1)
       webpack-cli: 5.0.1(webpack-dev-server@4.11.1)(webpack@5.75.0)
       webpack-dev-middleware: 5.3.3(webpack@5.75.0)
       ws: 8.12.0
@@ -40329,7 +40335,7 @@ packages:
     resolution: {integrity: sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==}
     dev: true
 
-  /webpack@5.75.0(esbuild@0.16.17)(uglify-js@3.17.4)(webpack-cli@5.0.1):
+  /webpack@5.75.0(esbuild@0.17.19)(uglify-js@3.17.4)(webpack-cli@5.0.1):
     resolution: {integrity: sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -40360,7 +40366,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.6(esbuild@0.16.17)(uglify-js@3.17.4)(webpack@5.75.0)
+      terser-webpack-plugin: 5.3.6(esbuild@0.17.19)(uglify-js@3.17.4)(webpack@5.75.0)
       watchpack: 2.4.0
       webpack-cli: 5.0.1(webpack-dev-server@4.11.1)(webpack@5.75.0)
       webpack-sources: 3.2.3


### PR DESCRIPTION
1.采用新的esbuild context api
2.提取原有的watch onRebuild选项为单独的插件，用法与参数与原有一致

ref https://github.com/umijs/umi/issues/10305