### PR TITLE
fix(tsconfig): wrong tmpPath dir in production mode

### DIFF
--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -42,7 +42,7 @@ export default (api: IApi) => {
     // tsconfig.json
     const frameworkName = api.service.frameworkName;
     const srcPrefix = api.appData.hasSrcDir ? 'src/' : '';
-    const umiTempDir = `${srcPrefix}.${frameworkName}`;
+    const umiTempDir = `${srcPrefix}${basename(api.paths.absTmpPath)}`;
     const baseUrl = api.appData.hasSrcDir ? '../../' : '../';
     const isTs5 = api.appData.typescript.tsVersion?.startsWith('5');
     const isTslibInstalled = !!api.appData.typescript.tslibVersion;


### PR DESCRIPTION
The alias for `@@` in umi tsconfig was wrong in production mode.

```bash
├── src
│   ├── .umi
│   │   ├── tsconfig.json
│   ├── .umi-production
│   │   ├── tsconfig.json
```

.umi/tsconfig.json
```json
"@@/*": [
    "src/.umi/*"
]
```

.umi-production/tsconfig.json
```json
"@@/*": [
    "src/.umi-production/*"
]
```