### PR TITLE
feat: locales的语言文件编写支持对象引入的方式

### DIFF
--- a/examples/max/cypress/e2e/smoke.cy.ts
+++ b/examples/max/cypress/e2e/smoke.cy.ts
@@ -47,11 +47,30 @@ describe('Basic Test', () => {
     cy.get('li.ant-pro-base-menu-menu-item').contains('dva');
   });
 
-  it('can change local', () => {
+  it('can change Chinese locale render page', () => {
     cy.get('.ant-dropdown-trigger').find('i.anticon').click();
 
     cy.contains('简体中文').click();
     cy.get('li.ant-pro-base-menu-menu-item').contains('首页');
+    cy.get('section#locales div.hello').should('have.text', '你好');
+    cy.get('section#locales h1').should('have.text', '世界！');
+    cy.get('section#locales div.user-welcome').should(
+      'have.text',
+      '你好, 朋友',
+    );
+  });
+
+  it('can change English locale render page', () => {
+    cy.get('.ant-dropdown-trigger').find('i.anticon').click();
+
+    cy.contains('English').click();
+    cy.get('li.ant-pro-base-menu-menu-item').contains('Index');
+    cy.get('section#locales div.hello').should('have.text', 'Hello');
+    cy.get('section#locales h1').should('have.text', 'World!');
+    cy.get('section#locales div.user-welcome').should(
+      'have.text',
+      'hello, friend',
+    );
   });
 
   it('tailwind css', () => {

--- a/examples/max/locales/en-US.js
+++ b/examples/max/locales/en-US.js
@@ -3,4 +3,7 @@ export default {
   World: 'World!',
   'site.title': 'Index',
   'about.title': 'About',
+  user:{
+    welcome: 'hello, friend',
+  },
 };

--- a/examples/max/locales/zh-CN.js
+++ b/examples/max/locales/zh-CN.js
@@ -3,4 +3,7 @@ export default {
   World: '世界！',
   'site.title': '首页',
   'about.title': '关于',
+  user:{
+    welcome: '你好, 朋友',
+  }
 };

--- a/examples/max/pages/index.tsx
+++ b/examples/max/pages/index.tsx
@@ -25,14 +25,21 @@ export default function HomePage() {
   const access = useAccess();
   console.log('access', access);
   const intl = useIntl();
+
   return (
     <div>
       <h2 className={styles.myText}>index page</h2>
       <Button type="primary">Button</Button>
       <Input />
       <DatePicker />
-      <div>{intl.formatMessage({ id: 'HELLO' })}</div>
-      <FormattedMessage id="World" />
+      {/* 中英文语言切换 */}
+      <section id="locales">
+        <div className="hello">{intl.formatMessage({ id: 'HELLO' })}</div>
+        <FormattedMessage id="World" />
+        <div className="user-welcome">
+          {intl.formatMessage({ id: 'user.welcome' })}
+        </div>
+      </section>
       <Button
         type="primary"
         onClick={() => {

--- a/packages/plugins/templates/locale/localeExports.tpl
+++ b/packages/plugins/templates/locale/localeExports.tpl
@@ -51,11 +51,30 @@ import lang_{{lang}}{{country}}{{index}} from "{{{path}}}";
 {{/paths}}
 {{/LocaleList}}
 
+const flattenMessages=(
+  nestedMessages: Record<string, any>,
+  prefix = '',
+) => {
+  return Object.keys(nestedMessages).reduce(
+    (messages: Record<string, any>, key) => {
+      const value = nestedMessages[key];
+      const prefixedKey = prefix ? `${prefix}.${key}` : key;
+      if (typeof value === 'string') {
+        messages[prefixedKey] = value;
+      } else {
+        Object.assign(messages, flattenMessages(value, prefixedKey));
+      }
+      return messages;
+    },
+    {},
+  );
+}
+
 export const localeInfo: {[key: string]: any} = {
   {{#LocaleList}}
   '{{name}}': {
     messages: {
-      {{#paths}}...lang_{{lang}}{{country}}{{index}},{{/paths}}
+      {{#paths}}...flattenMessages(lang_{{lang}}{{country}}{{index}}),{{/paths}}
     },
     locale: '{{locale}}',
     {{#Antd}}antd: {


### PR DESCRIPTION
### 问题描述
 locales的语言文件编写支持对象引入的方式。这个写法主要是为了配合umi的官方文档上编写的demo。文档上是支持使用对象编写，但是实际查看源码后发现不支持。
个人觉得支持对象的方式，前缀可以不用在每次定义字符串名称时重复写多次，即使使用“.”隔开也显得很长和冗余。特别是对于前缀不止一个的情况下会更友好。

在locales/zh-CN.js文件中支持对象嵌套的写法
```
// 编辑如下
export default {
  "user.welcome": '嗨,朋友',
  user:{
    welcome: '你好, 朋友',
  }
};
```
```
// 使用如下：
 <FormattedMessage id="user.welcome" />
 <div>{intl.formatMessage({ id: 'user.welcome' })}</div>

```
注意："user.welcome"和 对象嵌套的写法效果一致，后者会覆盖前者。并且使用方式一样，都是通过id值为"user.welcome"。

### 关联issue
closes #11208 

