### PR TITLE
fix(preset-built-in): avoid phantom dependency

### DIFF
--- a/packages/preset-built-in/src/plugins/features/analyze.ts
+++ b/packages/preset-built-in/src/plugins/features/analyze.ts
@@ -1,5 +1,4 @@
-import { BundlerConfigType } from '@umijs/types';
-import { IApi } from 'umi';
+import { BundlerConfigType, IApi } from '@umijs/types';
 
 export default (api: IApi) => {
   api.describe({

--- a/packages/preset-built-in/src/plugins/features/fastRefresh.ts
+++ b/packages/preset-built-in/src/plugins/features/fastRefresh.ts
@@ -1,10 +1,9 @@
-import { BundlerConfigType, IApi, utils } from 'umi';
-
-const { createDebug } = utils;
-
-const debug = createDebug('umi:preset-build-in:fastRefresh');
+import { BundlerConfigType, IApi } from '@umijs/types';
 
 export default (api: IApi) => {
+  const { createDebug } = api.utils;
+  const debug = createDebug('umi:preset-build-in:fastRefresh');
+
   /**
    * enable by default, back up using view rerender
    * ssr can't work with fastRefresh

--- a/packages/preset-built-in/src/plugins/features/forkTSChecker.ts
+++ b/packages/preset-built-in/src/plugins/features/forkTSChecker.ts
@@ -1,7 +1,7 @@
-import { IApi, utils } from 'umi';
+import { IApi } from '@umijs/types';
 
 export default (api: IApi) => {
-  const { deepmerge } = utils;
+  const { deepmerge } = api.utils;
   api.describe({
     key: 'forkTSChecker',
     config: {

--- a/packages/preset-built-in/src/plugins/features/mfsu/mfsu.test.ts
+++ b/packages/preset-built-in/src/plugins/features/mfsu/mfsu.test.ts
@@ -1,6 +1,6 @@
 import { winPath } from '@umijs/utils';
 import { resolve } from 'path';
-import { IApi } from 'umi';
+import { IApi } from '@umijs/types';
 import { getMfsuPath, normalizeReqPath } from './mfsu';
 
 test('functions: get mfsu path', () => {

--- a/packages/preset-built-in/src/plugins/features/mfsu/mfsu.ts
+++ b/packages/preset-built-in/src/plugins/features/mfsu/mfsu.ts
@@ -1,10 +1,9 @@
-import { BundlerConfigType } from '@umijs/types';
+import { BundlerConfigType, IApi } from '@umijs/types';
 import { chalk, createDebug, mkdirp } from '@umijs/utils';
 import assert from 'assert';
 import { existsSync, readFileSync } from 'fs';
 import mime from 'mime';
 import { dirname, join, parse } from 'path';
-import { IApi } from 'umi';
 import webpack from 'webpack';
 import BabelImportRedirectPlugin from './babel-import-redirect-plugin';
 import BabelPluginAutoExport from './babel-plugin-auto-export';


### PR DESCRIPTION
修复 `@umijs/preset-built-in` 对 `umi` 的幽灵依赖，在 Umi 3/4 混用的场景下会有问题