### PR TITLE
feat(ssr): support useServerInsertedHTML

### DIFF
--- a/examples/ssr-demo/src/pages/index.tsx
+++ b/examples/ssr-demo/src/pages/index.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { Link, useClientLoaderData, useServerLoaderData } from 'umi';
+import {
+  Link,
+  useClientLoaderData,
+  useServerInsertedHTML,
+  useServerLoaderData,
+} from 'umi';
 import Button from '../components/Button';
 // @ts-ignore
 import bigImage from './big_image.jpg';
@@ -14,6 +19,11 @@ import umiLogo from './umi.png';
 export default function HomePage() {
   const clientLoaderData = useClientLoaderData();
   const serverLoaderData = useServerLoaderData();
+
+  useServerInsertedHTML(() => {
+    return <div>inserted html</div>;
+  });
+
   return (
     <div>
       <h1 className="title">Hello~</h1>

--- a/packages/preset-umi/src/features/ssr/ssr.ts
+++ b/packages/preset-umi/src/features/ssr/ssr.ts
@@ -71,6 +71,30 @@ export default (api: IApi) => {
 export { React };
 `,
     });
+
+    api.writeTmpFile({
+      noPluginDir: true,
+      path: 'core/serverInsertedHTMLContext.ts',
+      content: `
+// Use React.createContext to avoid errors from the RSC checks because
+// it can't be imported directly in Server Components:
+import React from 'react'
+
+export type ServerInsertedHTMLHook = (callbacks: () => React.ReactNode) => void;
+// More info: https://github.com/vercel/next.js/pull/40686
+export const ServerInsertedHTMLContext =
+  React.createContext<ServerInsertedHTMLHook | null>(null as any);
+
+// copy form https://github.com/vercel/next.js/blob/fa076a3a69c9ccf63c9d1e53e7b681aa6dc23db7/packages/next/src/shared/lib/server-inserted-html.tsx#L13
+export function useServerInsertedHTML(callback: () => React.ReactNode): void {
+  const addInsertedServerHTMLCallback = React.useContext(ServerInsertedHTMLContext);
+  // Should have no effects on client where there's no flush effects provider
+  if (addInsertedServerHTMLCallback) {
+    addInsertedServerHTMLCallback(callback);
+  }
+}
+`,
+    });
   });
 
   api.onBeforeCompiler(async ({ opts }) => {

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -617,6 +617,11 @@ if (process.env.NODE_ENV === 'development') {
           exports.push(`export { TestBrowser } from './testBrowser';`);
         }
       }
+      if (api.config.ssr && api.appData.framework === 'react') {
+        exports.push(
+          `export { useServerInsertedHTML } from './core/serverInsertedHTMLContext';`,
+        );
+      }
       // plugins
       exports.push('// plugins');
       const allPlugins = readdirSync(api.paths.absTmpPath).filter((file) =>

--- a/packages/preset-umi/templates/server.tpl
+++ b/packages/preset-umi/templates/server.tpl
@@ -6,10 +6,17 @@ import { PluginManager } from '{{{ umiPluginPath }}}';
 import createRequestHandler, { createMarkupGenerator } from '{{{ umiServerPath }}}';
 
 let helmetContext;
+let ServerInsertedHTMLContext;
 
 try {
   helmetContext = require('./core/helmetContext').context;
 } catch { /* means `helmet: false`, do noting */ }
+
+
+try {
+  ServerInsertedHTMLContext = require('./core/serverInsertedHTMLContext').ServerInsertedHTMLContext;
+} catch { /* means `helmet: false`, do noting */ }
+
 
 const routesWithServerLoader = {
 {{#routesWithServerLoader}}
@@ -50,6 +57,7 @@ const createOpts = {
   getClientRootComponent,
   helmetContext,
   createHistory,
+  ServerInsertedHTMLContext,
 };
 const requestHandler = createRequestHandler(createOpts);
 

--- a/packages/preset-umi/templates/server.tpl
+++ b/packages/preset-umi/templates/server.tpl
@@ -6,16 +6,13 @@ import { PluginManager } from '{{{ umiPluginPath }}}';
 import createRequestHandler, { createMarkupGenerator } from '{{{ umiServerPath }}}';
 
 let helmetContext;
-let ServerInsertedHTMLContext;
 
 try {
   helmetContext = require('./core/helmetContext').context;
 } catch { /* means `helmet: false`, do noting */ }
 
 
-try {
-  ServerInsertedHTMLContext = require('./core/serverInsertedHTMLContext').ServerInsertedHTMLContext;
-} catch {}
+const ServerInsertedHTMLContext = require('./core/serverInsertedHTMLContext').ServerInsertedHTMLContext;
 
 
 const routesWithServerLoader = {

--- a/packages/preset-umi/templates/server.tpl
+++ b/packages/preset-umi/templates/server.tpl
@@ -15,7 +15,7 @@ try {
 
 try {
   ServerInsertedHTMLContext = require('./core/serverInsertedHTMLContext').ServerInsertedHTMLContext;
-} catch { /* means `helmet: false`, do noting */ }
+} catch {}
 
 
 const routesWithServerLoader = {

--- a/packages/preset-umi/templates/server.tpl
+++ b/packages/preset-umi/templates/server.tpl
@@ -2,6 +2,7 @@ import { getClientRootComponent } from '{{{ serverRendererPath }}}';
 import { getRoutes } from './core/route';
 import { createHistory as createClientHistory } from './core/history';
 import { getPlugins as getClientPlugins } from './core/plugin';
+import { ServerInsertedHTMLContext } from './core/serverInsertedHTMLContext';
 import { PluginManager } from '{{{ umiPluginPath }}}';
 import createRequestHandler, { createMarkupGenerator } from '{{{ umiServerPath }}}';
 
@@ -10,10 +11,6 @@ let helmetContext;
 try {
   helmetContext = require('./core/helmetContext').context;
 } catch { /* means `helmet: false`, do noting */ }
-
-
-const ServerInsertedHTMLContext = require('./core/serverInsertedHTMLContext').ServerInsertedHTMLContext;
-
 
 const routesWithServerLoader = {
 {{#routesWithServerLoader}}

--- a/packages/renderer-react/src/server.tsx
+++ b/packages/renderer-react/src/server.tsx
@@ -63,6 +63,7 @@ export async function getClientRootComponent(opts: {
 function Html({ children, loaderData, manifest }: any) {
   // TODO: 处理 head 标签，比如 favicon.ico 的一致性
   // TODO: root 支持配置
+
   return (
     <html lang="en">
       <head>
@@ -78,6 +79,7 @@ function Html({ children, loaderData, manifest }: any) {
             __html: `<b>Enable JavaScript to run this app.</b>`,
           }}
         />
+
         <div id="root">{children}</div>
         <script
           dangerouslySetInnerHTML={{


### PR DESCRIPTION
之后  antd  的 css in js ssr  就可以这样写了
```tsx
'use client';
import React from 'react';
import { useServerInsertedHTML } from 'umi';
import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';

const cache = createCache();

export default function StyledComponentsRegistry({
  children,
}: {
  children: React.ReactNode;
}) {
  useServerInsertedHTML(() => {
    const styleText = extractStyle(cache, true);
    return (
      <style
        dangerouslySetInnerHTML={{
          __html: styleText,
        }}
      />
    );
  });

  if (typeof window !== 'undefined') return <>{children}</>;

  return <StyleProvider cache={cache}>{children}</StyleProvider>;
}
```