### PR TITLE
fix: enable require config cache

### DIFF
--- a/packages/core/src/service/service.ts
+++ b/packages/core/src/service/service.ts
@@ -431,16 +431,12 @@ export class Service {
     const resolveMode = this.commands[this.name].configResolveMode;
     const config = await this.applyPlugins({
       key: 'modifyConfig',
-      // why clone deep?
-      // user may change the config in modifyConfig
-      // e.g. memo.alias = xxx
-      initialValue: lodash.cloneDeep(
+      initialValue:
         resolveMode === 'strict'
           ? this.configManager!.getConfig({
               schemas: this.configSchemas,
             }).config
           : this.configManager!.getUserConfig().config,
-      ),
       args: { paths: this.paths },
     });
     const defaultConfig = await this.applyPlugins({


### PR DESCRIPTION
fix #11226

目前由于不同的 stage ，都会读取配置，但有的阶段需要 schema 校验有的不需要，这会导致多次读取、运行配置。

为了解多次运行，思路是缓存一下。