### PR TITLE
fix: s.history.goBack is not a function

### DIFF
--- a/examples/umi-3-compat-mode/layouts/index.tsx
+++ b/examples/umi-3-compat-mode/layouts/index.tsx
@@ -7,7 +7,7 @@ export default (props) => {
       <div>
         <button
           onClick={() => {
-            history.back();
+            props.history.goBack();
           }}
         >
           go back

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -505,8 +505,7 @@ if (process.env.NODE_ENV === 'development') {
     // history.ts
     // only react generates because the preset-vue override causes vite hot updates to fail
     if (api.appData.framework === 'react') {
-      const { historyWithQuery = false, reactRouter5Compat = false } =
-        api.config;
+      const { historyWithQuery, reactRouter5Compat } = api.config;
       const historyPath = historyWithQuery
         ? winPath(dirname(require.resolve('@umijs/history/package.json')))
         : rendererPath;

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -505,7 +505,9 @@ if (process.env.NODE_ENV === 'development') {
     // history.ts
     // only react generates because the preset-vue override causes vite hot updates to fail
     if (api.appData.framework === 'react') {
-      const historyPath = api.config.historyWithQuery
+      const { historyWithQuery = false, reactRouter5Compat = false } =
+        api.config;
+      const historyPath = historyWithQuery
         ? winPath(dirname(require.resolve('@umijs/history/package.json')))
         : rendererPath;
       api.writeTmpFile({
@@ -514,6 +516,7 @@ if (process.env.NODE_ENV === 'development') {
         tplPath: join(TEMPLATES_DIR, 'history.tpl'),
         context: {
           historyPath,
+          reactRouter5Compat,
         },
       });
       api.writeTmpFile({
@@ -522,6 +525,7 @@ if (process.env.NODE_ENV === 'development') {
         tplPath: join(TEMPLATES_DIR, 'historyIntelli.tpl'),
         context: {
           historyPath,
+          reactRouter5Compat,
         },
       });
     }

--- a/packages/preset-umi/templates/history.tpl
+++ b/packages/preset-umi/templates/history.tpl
@@ -24,6 +24,11 @@ export function createHistory(opts: any) {
     replace(to, state) {
       h.replace(patchTo(to, h), state);
     },
+{{#reactRouter5Compat}}
+    goBack(){
+      h.back();
+    },
+{{/reactRouter5Compat}}
     get location() {
       return h.location;
     },
@@ -32,7 +37,7 @@ export function createHistory(opts: any) {
     }
   }
 
-  return h;
+  return history;
 }
 
 // Patch `to` to support basename

--- a/packages/preset-umi/templates/history.tpl
+++ b/packages/preset-umi/templates/history.tpl
@@ -16,6 +16,12 @@ export function createHistory(opts: any) {
     basename = opts.basename;
   }
 
+{{#reactRouter5Compat}}
+  h.goBack = function() {
+    h.back();
+  };
+{{/reactRouter5Compat}}
+
   history = {
     ...h,
     push(to, state) {
@@ -24,11 +30,6 @@ export function createHistory(opts: any) {
     replace(to, state) {
       h.replace(patchTo(to, h), state);
     },
-{{#reactRouter5Compat}}
-    goBack(){
-      h.back();
-    },
-{{/reactRouter5Compat}}
     get location() {
       return h.location;
     },
@@ -37,7 +38,7 @@ export function createHistory(opts: any) {
     }
   }
 
-  return history;
+  return h;
 }
 
 // Patch `to` to support basename

--- a/packages/preset-umi/templates/historyIntelli.tpl
+++ b/packages/preset-umi/templates/historyIntelli.tpl
@@ -71,9 +71,17 @@ type UmiTo = UmiPathname | UmiPath
 
 type UmiPush = (to: UmiTo, state?: any) => void
 type UmiReplace = (to: UmiTo, state?: any) => void
+{{#reactRouter5Compat}}
+type UmiGoBack = () => void
+{{/reactRouter5Compat}}
+
+
 export interface UmiHistory extends History {
   push: UmiPush
   replace: UmiReplace
+{{#reactRouter5Compat}}
+  goBack: UmiGoBack
+{{/reactRouter5Compat}}
 }
 
 // --- type utils ---


### PR DESCRIPTION
![image](https://github.com/umi-contribute/history/assets/11746742/2e9cf223-ee94-4b00-b384-63e80c9736c4)

Uncaught TypeError: s.history.goBack is not a function

开启 `reactRouter5Compat: {}` 配置的时候，旧的 api 应该兼容一下。

https://github.com/umijs/umi/blob/27937cdfbcb6e604917cd1b288f726b4c4f4fe3d/docs/docs/api/api.md?plain=1#L801