### PR TITLE
Feature/lyy umi UI fix 0607

### DIFF
--- a/examples/ant-design-pro/config/config.ts
+++ b/examples/ant-design-pro/config/config.ts
@@ -338,4 +338,5 @@ export default defineConfig({
   codeSplitting: {
     jsStrategy: 'granularChunks',
   },
+  ui: {},
 });

--- a/ui/components/routes/routeChart.tsx
+++ b/ui/components/routes/routeChart.tsx
@@ -98,8 +98,11 @@ export const RouteChart: FC<IProps> = ({ routes, onNodeClick }) => {
     });
 
     graph.node((node) => {
-      const { id, depth } = node;
-      const label = id.split('/').slice(-1)[0];
+      const { depth, id, absPath } = node;
+      // absPath 为空的话就取id, 适配 @@/global-layout
+      const label =
+        ((absPath as string) || '').split('/').slice(-1)[0] ||
+        id.split('/').slice(-1)[0];
       const { color, backgroud } =
         colorList[(depth as number) % colorList.length];
 

--- a/ui/components/routes/routeChart.tsx
+++ b/ui/components/routes/routeChart.tsx
@@ -1,5 +1,6 @@
 import { modeColorMap } from '@/contants';
 import { state as globalState } from '@/models/global';
+import { superLongTextHandle } from '@/utils/g6LongText';
 import { IIRoute } from '@/utils/realizeRoutes';
 import G6 from '@antv/g6';
 import { FC, useEffect } from 'react';
@@ -107,8 +108,9 @@ export const RouteChart: FC<IProps> = ({ routes, onNodeClick }) => {
         style: {
           fill: backgroud,
           stroke: color,
+          fontSize: 12,
         },
-        label,
+        label: superLongTextHandle(label, 96, 12),
         labelCfg: {
           position: 'center',
           offset: 5,

--- a/ui/components/routes/routeChart.tsx
+++ b/ui/components/routes/routeChart.tsx
@@ -98,11 +98,8 @@ export const RouteChart: FC<IProps> = ({ routes, onNodeClick }) => {
     });
 
     graph.node((node) => {
-      const { depth, id, absPath } = node;
-      // absPath 为空的话就取id, 适配 @@/global-layout
-      const label =
-        ((absPath as string) || '').split('/').slice(-1)[0] ||
-        id.split('/').slice(-1)[0];
+      const { depth, absPath } = node;
+      const label = ((absPath as string) || '').split('/').slice(-1)[0] || '/';
       const { color, backgroud } =
         colorList[(depth as number) % colorList.length];
 

--- a/ui/components/routes/routeDrawer.tsx
+++ b/ui/components/routes/routeDrawer.tsx
@@ -70,14 +70,28 @@ export const RouteDrawer: React.FC<{
         mask={false}
       >
         <Wrapper>
+          {info.name ? (
+            <div className="info-item">
+              <h3>Name</h3>
+              <div className="label">{info.absPath}</div>
+            </div>
+          ) : null}
           <div className="info-item">
             <h3>RoutePath</h3>
             <div className="label">{info.absPath}</div>
           </div>
-          <div className="info-item">
-            <h3>FilePath</h3>
-            <div className="label">{info.__absFile || info.file}</div>
-          </div>
+          {info.__absFile || info.file ? (
+            <div className="info-item">
+              <h3>FilePath</h3>
+              <div className="label">{info.__absFile || info.file}</div>
+            </div>
+          ) : null}
+          {info.redirect ? (
+            <div className="info-item">
+              <h3>Redirect</h3>
+              <div className="label">{info.redirect}</div>
+            </div>
+          ) : null}
           <div className="info-item">
             <h3>CodeContent</h3>
             <div className="code-label">

--- a/ui/hooks/useAppData.ts
+++ b/ui/hooks/useAppData.ts
@@ -2,6 +2,8 @@ import type { BuildResult } from '@umijs/bundler-utils/compiled/esbuild';
 import { useQuery } from 'umi';
 
 export interface IRoute {
+  name?: string;
+  redirect?: string;
   path: string;
   id: string;
   parentId?: string;

--- a/ui/layouts/index.tsx
+++ b/ui/layouts/index.tsx
@@ -5,7 +5,6 @@ import { Helmet, Outlet, styled } from 'umi';
 
 const Wrapper = styled.div`
   display: flex;
-  border: 1px solid var(--subtle-color);
   height: 100%;
   aside {
     min-width: 200px;

--- a/ui/utils/g6LongText.ts
+++ b/ui/utils/g6LongText.ts
@@ -1,0 +1,31 @@
+import G6 from '@antv/g6';
+
+// G6换行符处理超长文本
+export const superLongTextHandle = (
+  str: string,
+  maxWidth: number,
+  fontSize: number,
+) => {
+  let currentWidth = 0;
+  let res = str;
+  // 区分汉字和字母
+  const pattern = new RegExp('[\u4E00-\u9FA5]+');
+  str.split('').forEach((letter, i) => {
+    if (currentWidth > maxWidth) return;
+    if (pattern.test(letter)) {
+      // 中文字符
+      currentWidth += fontSize;
+    } else {
+      // 根据字体大小获取单个字母的宽度
+      currentWidth += G6.Util.getLetterWidth(letter, fontSize);
+    }
+    if (currentWidth > maxWidth) {
+      res = `${str.slice(0, i)}\n${superLongTextHandle(
+        str.slice(i),
+        maxWidth,
+        fontSize,
+      )}`;
+    }
+  });
+  return res;
+};

--- a/ui/utils/realizeRoutes.ts
+++ b/ui/utils/realizeRoutes.ts
@@ -5,7 +5,7 @@ export interface IIRoute extends PartialIRoute {
   children: IIRoute[];
 }
 
-export const FAKE_ID = '__FEAKE_LAYOUT__';
+export const FAKE_ID = '__FAKE_LAYOUT__';
 
 // 通过对象引用建立route间关系
 export const realizeRoutes = (routes: IAppData['routes']): IIRoute[] => {
@@ -55,6 +55,8 @@ export const realizeRoutes = (routes: IAppData['routes']): IIRoute[] => {
     return [
       {
         id: FAKE_ID,
+        path: FAKE_ID,
+        absPath: FAKE_ID,
         isLayout: true,
         children: relations,
       },

--- a/ui/utils/realizeRoutes.ts
+++ b/ui/utils/realizeRoutes.ts
@@ -55,8 +55,8 @@ export const realizeRoutes = (routes: IAppData['routes']): IIRoute[] => {
     return [
       {
         id: FAKE_ID,
-        path: FAKE_ID,
-        absPath: FAKE_ID,
+        path: '',
+        absPath: '',
         isLayout: true,
         children: relations,
       },


### PR DESCRIPTION
适配手动声明 routes 导致 id 为数字造成的现实问题，使用 absPath 的结尾来作为 label，如果为空时再取 id，适配 globalLayout
手动声明：
![image](https://github.com/umijs/umi/assets/45666106/f36ce6f0-a535-4aa5-b345-0c5418a68e8c)
自动生成：
![image](https://github.com/umijs/umi/assets/45666106/8719e73a-3d5a-4934-895d-957f92a154d7)

