### PR TITLE
fix: icon spin prop warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install pnpm (node 14)
         if: ${{ matrix.node-version == '14.x' }}
-        run: npm install -g @pnpm/exe@8.1.0
+        run: npm install -g @pnpm/exe@8.6.0
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/examples/max/pages/index.tsx
+++ b/examples/max/pages/index.tsx
@@ -50,7 +50,7 @@ export default function HomePage() {
       <h2> Icons</h2>
       <div>
         {includedIcons.map((i) => {
-          return <Icon icon={i} className={i} key={i} />;
+          return <Icon spin icon={i} className={i} key={i} />;
         })}
         <Icon icon="local:logo/foo/smile" />
         <Icon icon="local:logo/heart-Upper-CASE" />

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "umi-scripts": "workspace:*",
     "zx": "^7.1.1"
   },
-  "packageManager": "pnpm@8.1.0",
+  "packageManager": "pnpm@8.6.0",
   "engines": {
     "node": ">=14",
     "pnpm": ">=8"

--- a/packages/preset-umi/src/features/icons/icons.ts
+++ b/packages/preset-umi/src/features/icons/icons.ts
@@ -319,7 +319,7 @@ interface IUmiIconProps extends React.SVGAttributes<SVGElement> {
 }
 
 export const Icon = React.forwardRef<HTMLSpanElement, IUmiIconProps>((props, ref) => {
-  const { icon, hover, style, className = '' , rotate, flip, ...extraProps } = props;
+  const { icon, hover, style, className = '' , rotate, spin, flip, ...extraProps } = props;
   const iconName = normalizeIconName(alias[icon] || icon);
   const Component = iconsMap[iconName];
   if (!Component) {
@@ -327,7 +327,7 @@ export const Icon = React.forwardRef<HTMLSpanElement, IUmiIconProps>((props, ref
     return null;
   }
   const HoverComponent = hover ? iconsMap[normalizeIconName(alias[hover] || hover)] : null;
-  const cls = props.spin ? 'umiIconLoadingCircle' : undefined;
+  const cls = spin ? 'umiIconLoadingCircle' : undefined;
   const svgStyle = {};
   const transform: string[] = [];
   if (rotate) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false
 
 overrides:
   browserslist: 4.21.5


### PR DESCRIPTION
fix #11256

修复 Icon 组件的 spin 属性透传下去导致非预期的警告问题