### PR TITLE
feat(ui): 插件接入支持 qiankun 模式

### DIFF
--- a/ui/.umirc.ts
+++ b/ui/.umirc.ts
@@ -3,6 +3,7 @@ export default {
     '@umijs/plugins/dist/valtio',
     '@umijs/plugins/dist/styled-components',
     '@umijs/plugins/dist/react-query',
+    '@umijs/plugins/dist/qiankun',
   ],
   publicPath: '/__umi_ui/entry/',
   base: '/__umi_ui/entry',
@@ -27,5 +28,8 @@ export default {
       'local:sun',
       'local:moon',
     ],
+  },
+  qiankun: {
+    master: {},
   },
 };

--- a/ui/components/PluginContainer.tsx
+++ b/ui/components/PluginContainer.tsx
@@ -1,3 +1,8 @@
 export const PluginContainer = (props: { url: string; name: string }) => {
-  return <iframe style={{ width: '100%', height: '100%' }} src={props.url} />;
+  return (
+    <iframe
+      style={{ width: '100%', height: '100%', border: 0 }}
+      src={props.url}
+    />
+  );
 };

--- a/ui/hooks/useAppData.ts
+++ b/ui/hooks/useAppData.ts
@@ -111,6 +111,8 @@ export interface IAppData {
         url: string;
         icon: string;
         name: string;
+        renderType?: string; // 可以选择配置 qiankun，默认 iframe
+        meta?: any; // 配置乾坤后可以传递的props，比如 yuyanId?
       }[];
       [key: string]: any;
     }[];

--- a/ui/layouts/index.tsx
+++ b/ui/layouts/index.tsx
@@ -5,7 +5,6 @@ import { Helmet, Outlet, styled } from 'umi';
 
 const Wrapper = styled.div`
   display: flex;
-  border: 1px solid var(--subtle-color);
   height: 100%;
   aside {
     min-width: 200px;

--- a/ui/models/global.ts
+++ b/ui/models/global.ts
@@ -41,6 +41,6 @@ export const actions = {
     const mode = state.mode === 'light' ? 'dark' : 'light';
     state.mode = mode;
     // 是否需要 localstorage 保存上次选择 mode
-    document.querySelector('html').classList.toggle('dark');
+    document.querySelector('html')!.classList.toggle('dark');
   },
 };


### PR DESCRIPTION
ui 自定义页面接入支持 qiankun 模式，url 为静态资源 (需要 sirv 起服务) 和 链接均可
![image](https://github.com/umijs/umi/assets/45666106/dfbe4d18-d3ca-4de2-83b3-160375f3c5a8)

![image](https://github.com/umijs/umi/assets/45666106/886741a7-0fcb-45f9-9d5b-24711055d41e)

