### PR TITLE
fix: momentlocal lose when use addLocale

### DIFF
--- a/examples/config-locale/.umirc.ts
+++ b/examples/config-locale/.umirc.ts
@@ -1,0 +1,25 @@
+export default {
+  plugins: ['@umijs/plugins/dist/antd', '@umijs/plugins/dist/locale'],
+  locale: {
+    title: true,
+    default: 'zh-CN',
+    antd: true,
+  },
+  antd: {
+    // valid for antd5.0 only
+    theme: {
+      token: {
+        colorPrimary: '#1DA57A',
+      },
+    },
+    /**
+     * antd@5.1.0 ~ 5.2.3 仅支持 appConfig: {}, 来启用 <App /> 组件;
+     * antd@5.3.0 及以上才支持 appConfig: { // ... } 来添加更多 App 配置项;
+     */
+    appConfig: {
+      message: {
+        maxCount: 3,
+      },
+    },
+  },
+};

--- a/examples/config-locale/locales/en-US.js
+++ b/examples/config-locale/locales/en-US.js
@@ -1,0 +1,3 @@
+export default {
+  HELLO: 'Hello',
+};

--- a/examples/config-locale/locales/zh-CN.js
+++ b/examples/config-locale/locales/zh-CN.js
@@ -1,0 +1,3 @@
+export default {
+  HELLO: '你好',
+};

--- a/examples/config-locale/package.json
+++ b/examples/config-locale/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@example/config-locale",
+  "private": true,
+  "scripts": {
+    "build": "umi build",
+    "dev": "umi dev",
+    "setup": "umi setup",
+    "start": "npm run dev"
+  },
+  "dependencies": {
+    "@umijs/plugins": "workspace:*",
+    "antd": "^5.3.0",
+    "umi": "workspace:*"
+  }
+}

--- a/examples/config-locale/pages/index.tsx
+++ b/examples/config-locale/pages/index.tsx
@@ -1,0 +1,45 @@
+import { Button, QRCode, Space, version } from 'antd';
+import React, { useState } from 'react';
+import { addLocale, getLocale, setLocale, useIntl } from 'umi';
+
+export default function Page() {
+  const [isZh, setIsZh] = useState(true);
+  const locale = getLocale();
+  const addWelComeMessage = () => {
+    addLocale('zh-CN', {
+      welcome: '欢迎！',
+    });
+  };
+  const intl = useIntl();
+  const msg = intl.formatMessage({
+    id: 'HELLO',
+  });
+  const welcome = intl.formatMessage({
+    id: 'welcome',
+  });
+  return (
+    <>
+      <h1>with antd@{version}</h1>
+      <QRCode
+        value="https://ant.design/"
+        status="expired"
+        onRefresh={() => console.log('refresh')}
+      />
+      <Space>
+        <Button type="primary" onClick={addWelComeMessage}>
+          追加中文 locale
+        </Button>
+      </Space>
+      locale:{locale}
+      <Button
+        onClick={() => {
+          setIsZh(!isZh);
+          setLocale(isZh ? 'en-US' : 'zh-CN', false);
+        }}
+      >
+        {msg}
+      </Button>
+      {welcome}
+    </>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   "packageManager": "pnpm@8.6.0",
   "engines": {
     "node": ">=14",
-    "pnpm": ">=8"
+    "pnpm": ">=8.6.0"
   },
   "//why-overrides-browserslist": "See scripts/bundleDeps.ts",
   "pnpm": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   "packageManager": "pnpm@8.6.0",
   "engines": {
     "node": ">=14",
-    "pnpm": ">=8.6.0"
+    "pnpm": "^8.6.2"
   },
   "//why-overrides-browserslist": "See scripts/bundleDeps.ts",
   "pnpm": {

--- a/packages/plugins/templates/locale/localeExports.tpl
+++ b/packages/plugins/templates/locale/localeExports.tpl
@@ -90,8 +90,8 @@ export const addLocale = (
     ? Object.assign({}, localeInfo[name].messages, messages)
     : messages;
 
-
-  const { momentLocale, antd } = extraLocales || {};
+  // 用户只是追加 messages 时，extraLocales 可选
+  const { momentLocale = localeInfo[name]?.momentLocale, antd = localeInfo[name]?.antd } = extraLocales || {};
   const locale = name.split('{{BaseSeparator}}')?.join('-')
   localeInfo[name] = {
     messages: mergeMessages,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: false
@@ -554,6 +554,18 @@ importers:
       express:
         specifier: 4.18.2
         version: 4.18.2
+      umi:
+        specifier: workspace:*
+        version: link:../../packages/umi
+
+  examples/config-locale:
+    dependencies:
+      '@umijs/plugins':
+        specifier: workspace:*
+        version: link:../../packages/plugins
+      antd:
+        specifier: ^5.3.0
+        version: 5.6.0(react-dom@18.1.0)(react@18.1.0)
       umi:
         specifier: workspace:*
         version: link:../../packages/umi
@@ -1961,7 +1973,7 @@ importers:
         version: 10.4.13(postcss@8.4.21)
       babel-loader:
         specifier: 9.1.2
-        version: 9.1.2(@babel/core@7.21.0)(webpack@5.75.0)
+        version: 9.1.2(webpack@5.76.1)
       compression:
         specifier: 1.7.4
         version: 1.7.4
@@ -2094,7 +2106,7 @@ importers:
         version: link:../babel-preset-umi
       eslint-plugin-jest:
         specifier: 27.2.1
-        version: 27.2.1(@typescript-eslint/eslint-plugin@5.48.1)(eslint@8.35.0)(jest@29.4.3)(typescript@4.9.4)
+        version: 27.2.1(@typescript-eslint/eslint-plugin@5.48.1)(jest@29.4.3)(typescript@4.9.4)
       eslint-plugin-react:
         specifier: 7.32.2
         version: 7.32.2(eslint@8.35.0)
@@ -2106,7 +2118,7 @@ importers:
         version: 8.4.21
       postcss-syntax:
         specifier: 0.36.2
-        version: 0.36.2(postcss-html@0.36.0)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@7.0.39)
+        version: 0.36.2(postcss-less@6.0.0)(postcss@8.4.21)
       stylelint-config-standard:
         specifier: 25.0.0
         version: 25.0.0
@@ -2174,7 +2186,7 @@ importers:
         version: 1.0.1
       webpack:
         specifier: 5.76.1
-        version: 5.76.1(@swc/core@1.3.24)(uglify-js@3.17.4)
+        version: 5.76.1(uglify-js@3.17.4)
       webpack-virtual-modules:
         specifier: 0.5.0
         version: 0.5.0
@@ -2480,7 +2492,7 @@ importers:
         version: 3.0.1(vue@3.2.45)
       '@vue/babel-plugin-jsx':
         specifier: 1.1.1
-        version: 1.1.1(@babel/core@7.21.0)
+        version: 1.1.1
       vue:
         specifier: 3.2.45
         version: 3.2.45
@@ -2974,7 +2986,7 @@ packages:
       '@emotion/unitless': 0.7.5
       classnames: 2.3.2
       csstype: 3.1.0
-      rc-util: 5.30.0(react-dom@17.0.2)(react@17.0.2)
+      rc-util: 5.33.0(react-dom@17.0.2)(react@17.0.2)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       stylis: 4.1.4
@@ -2995,7 +3007,29 @@ packages:
       '@emotion/unitless': 0.7.5
       classnames: 2.3.2
       csstype: 3.1.0
-      rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
+      react: 18.1.0
+      react-dom: 18.1.0(react@18.1.0)
+      stylis: 4.1.4
+    dev: false
+
+  /@ant-design/cssinjs@1.10.1(react-dom@18.1.0)(react@18.1.0):
+    resolution: {integrity: sha512-PSoJS8RMzn95ZRg007dJGr6AU0Zim/O+tTN0xmXmh9CkIl4y3wuOr2Zhehaj7s130wPSYDVvahf3DKT50w/Zhw==}
+    peerDependencies:
+      react: '>=16.0.0'
+      react-dom: '>=16.0.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@emotion/hash': 0.8.0
+      '@emotion/unitless': 0.7.5
+      classnames: 2.3.2
+      csstype: 3.1.0
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
       stylis: 4.1.4
@@ -3173,7 +3207,7 @@ packages:
       '@ant-design/icons-svg': 4.2.1
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
-      rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
     dev: false
@@ -5039,7 +5073,7 @@ packages:
       classnames: 2.3.1
       mana-syringe: 0.2.2
       moment: 2.29.4
-      rc-field-form: 1.31.0(react-dom@18.1.0)(react@18.1.0)
+      rc-field-form: 1.32.1(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-color: 2.17.1(react@18.1.0)
       react-dom: 18.1.0(react@18.1.0)
@@ -5660,6 +5694,21 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       regexpu-core: 5.2.2
     dev: true
+
+  /@babel/helper-define-polyfill-provider@0.3.3:
+    resolution: {integrity: sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==}
+    peerDependencies:
+      '@babel/core': ^7.4.0-0
+    dependencies:
+      '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.21.4)
+      '@babel/helper-plugin-utils': 7.20.2
+      debug: 4.3.4(supports-color@8.1.1)
+      lodash.debounce: 4.0.8
+      resolve: 1.22.1
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.20.12):
     resolution: {integrity: sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==}
@@ -8236,6 +8285,22 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
+  /@babel/plugin-transform-runtime@7.21.0:
+    resolution: {integrity: sha512-ReY6pxwSzEU0b3r2/T/VhqMKg/AkceBT19X0UptA3/tYi5Pe2eXgEUH+NNMC5nok6c6XQz5tyVTUpuezRfSMSg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
+      babel-plugin-polyfill-corejs2: 0.3.3
+      babel-plugin-polyfill-corejs3: 0.6.0
+      babel-plugin-polyfill-regenerator: 0.4.1
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/plugin-transform-runtime@7.21.0(@babel/core@7.21.0):
     resolution: {integrity: sha512-ReY6pxwSzEU0b3r2/T/VhqMKg/AkceBT19X0UptA3/tYi5Pe2eXgEUH+NNMC5nok6c6XQz5tyVTUpuezRfSMSg==}
     engines: {node: '>=6.9.0'}
@@ -8251,6 +8316,7 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/plugin-transform-runtime@7.4.4(@babel/core@7.4.5):
     resolution: {integrity: sha512-aMVojEjPszvau3NRg+TIH14ynZLvPewH4xhlCW1w6A3rkxTS1m4uwzRclYR9oS+rl/dr+kT+pzbfHuAWP/lc7Q==}
@@ -12035,7 +12101,26 @@ packages:
       '@babel/runtime': 7.21.0
       '@ctrl/tinycolor': 3.6.0
       classnames: 2.3.2
-      rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
+      react: 18.1.0
+      react-dom: 18.1.0(react@18.1.0)
+    dev: false
+
+  /@rc-component/color-picker@1.2.0(react-dom@18.1.0)(react@18.1.0):
+    resolution: {integrity: sha512-IitJ6RWGHs7btI1AqzGPrehr5bueWLGDUyMKwDwvFunfSDo/o8g/95kUG55vC5EYLM0ZJ3SDfw45OrW5KAx3oA==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@ctrl/tinycolor': 3.6.0
+      classnames: 2.3.2
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
     dev: false
@@ -12052,7 +12137,7 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.21.0
-      rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
 
@@ -12076,7 +12161,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
-      rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
 
@@ -12094,7 +12179,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
-      rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
 
@@ -12112,9 +12197,28 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
-      rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
+
+  /@rc-component/portal@1.1.1(react-dom@18.1.0)(react@18.1.0):
+    resolution: {integrity: sha512-m8w3dFXX0H6UkJ4wtfrSwhe2/6M08uz24HHrF8pWfAXPwA9hwCuTE5per/C86KwNLouRpwFGcr7LfpHaa1F38g==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      classnames: 2.3.2
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
+      react: 18.1.0
+      react-dom: 18.1.0(react@18.1.0)
+    dev: false
 
   /@rc-component/tour@1.8.0(react-dom@18.1.0)(react@18.1.0):
     resolution: {integrity: sha512-rrRGioHTLQlGca27G2+lw7QpRb3uuMYCUIJjj31/B44VCJS0P2tqYhOgtzvWQmaLMlWH3ZlpzotkKX13NT4XEA==}
@@ -12177,7 +12281,7 @@ packages:
       rc-align: 4.0.12(react-dom@18.1.0)(react@18.1.0)
       rc-motion: 2.7.3(react-dom@18.1.0)(react@18.1.0)
       rc-resize-observer: 1.3.1(react-dom@18.1.0)(react@18.1.0)
-      rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
 
@@ -12519,7 +12623,7 @@ packages:
     dependencies:
       '@babel/core': 7.21.0
       postcss: 8.4.21
-      postcss-syntax: 0.36.2(postcss-html@0.36.0)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@7.0.39)
+      postcss-syntax: 0.36.2(postcss-less@6.0.0)(postcss@8.4.21)
     transitivePeerDependencies:
       - supports-color
 
@@ -13804,6 +13908,34 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@typescript-eslint/eslint-plugin@5.48.1(@typescript-eslint/parser@5.48.1)(typescript@4.9.4):
+    resolution: {integrity: sha512-9nY5K1Rp2ppmpb9s9S2aBiF3xo5uExCehMDmYmmFqqyxgenbHJ3qbarcLt4ITgaD6r/2ypdlcFRdcuVPnks+fQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.48.1(eslint@8.35.0)(typescript@4.9.4)
+      '@typescript-eslint/scope-manager': 5.48.1
+      '@typescript-eslint/type-utils': 5.48.1(eslint@8.35.0)(typescript@4.9.4)
+      '@typescript-eslint/utils': 5.48.1(eslint@8.35.0)(typescript@4.9.4)
+      debug: 4.3.4(supports-color@8.1.1)
+      ignore: 5.2.0
+      natural-compare-lite: 1.4.0
+      regexpp: 3.2.0
+      semver: 7.3.8
+      tsutils: 3.21.0(typescript@4.9.4)
+      typescript: 4.9.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@typescript-eslint/experimental-utils@4.33.0(eslint@7.32.0)(typescript@4.9.4):
     resolution: {integrity: sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -14619,7 +14751,7 @@ packages:
       eslint-plugin-react: 7.29.4(eslint@8.35.0)
       eslint-plugin-react-hooks: 4.5.0(eslint@8.35.0)
       postcss: 8.4.21
-      postcss-syntax: 0.36.2(postcss-html@0.36.0)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@7.0.39)
+      postcss-syntax: 0.36.2(postcss-less@6.0.0)(postcss@8.4.21)
       stylelint-config-standard: 25.0.0
     transitivePeerDependencies:
       - eslint
@@ -14647,7 +14779,7 @@ packages:
       eslint-plugin-react: 7.32.2(eslint@8.35.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.35.0)
       postcss: 8.4.21
-      postcss-syntax: 0.36.2(postcss-html@0.36.0)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@7.0.39)
+      postcss-syntax: 0.36.2(postcss-less@6.0.0)(postcss@8.4.21)
       stylelint-config-standard: 25.0.0
     transitivePeerDependencies:
       - eslint
@@ -15082,7 +15214,7 @@ packages:
       '@jest/types': 27.5.1
       '@umijs/bundler-utils': 4.0.57
       '@umijs/utils': 4.0.57
-      babel-jest: 29.4.3(@babel/core@7.21.0)
+      babel-jest: 29.4.3
       esbuild: 0.16.17
       identity-obj-proxy: 3.0.0
       isomorphic-unfetch: 4.0.2
@@ -15551,6 +15683,23 @@ packages:
 
   /@vue/babel-helper-vue-transform-on@1.0.2:
     resolution: {integrity: sha512-hz4R8tS5jMn8lDq6iD+yWL6XNB699pGIVLk7WSJnn1dbpjaazsjZQkieJoRX6gW5zpYSCFqQ7jUquPNY65tQYA==}
+    dev: false
+
+  /@vue/babel-plugin-jsx@1.1.1:
+    resolution: {integrity: sha512-j2uVfZjnB5+zkcbc/zsOc0fSNGCMMjaEXP52wdwdIfn0qjFfEYpYZBFKFg+HHnQeJCVrjOeO0YxgaL7DMrym9w==}
+    dependencies:
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.4.5)
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.21.2
+      '@babel/types': 7.21.2
+      '@vue/babel-helper-vue-transform-on': 1.0.2
+      camelcase: 6.3.0
+      html-tags: 3.2.0
+      svg-tags: 1.0.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
     dev: false
 
   /@vue/babel-plugin-jsx@1.1.1(@babel/core@7.21.0):
@@ -16759,6 +16908,73 @@ packages:
       - moment
     dev: false
 
+  /antd@5.6.0(react-dom@18.1.0)(react@18.1.0):
+    resolution: {integrity: sha512-VW8c3pOsSxjIdpn/fyicaXHNjG0lYKb2xzi4pLwmYuChUl6P92S5MfrhB00XQY4TWgsfBucdgX8XSoiLCTRTCg==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@ant-design/colors': 7.0.0
+      '@ant-design/cssinjs': 1.10.1(react-dom@18.1.0)(react@18.1.0)
+      '@ant-design/icons': 5.1.0(react-dom@18.1.0)(react@18.1.0)
+      '@ant-design/react-slick': 1.0.0(react@18.1.0)
+      '@babel/runtime': 7.21.0
+      '@ctrl/tinycolor': 3.6.0
+      '@rc-component/color-picker': 1.2.0(react-dom@18.1.0)(react@18.1.0)
+      '@rc-component/mutate-observer': 1.0.0(react-dom@18.1.0)(react@18.1.0)
+      '@rc-component/tour': 1.8.0(react-dom@18.1.0)(react@18.1.0)
+      '@rc-component/trigger': 1.13.0(react-dom@18.1.0)(react@18.1.0)
+      classnames: 2.3.2
+      copy-to-clipboard: 3.3.1
+      dayjs: 1.11.7
+      qrcode.react: 3.1.0(react@18.1.0)
+      rc-cascader: 3.12.0(react-dom@18.1.0)(react@18.1.0)
+      rc-checkbox: 3.0.0(react-dom@18.1.0)(react@18.1.0)
+      rc-collapse: 3.7.0(react-dom@18.1.0)(react@18.1.0)
+      rc-dialog: 9.1.0(react-dom@18.1.0)(react@18.1.0)
+      rc-drawer: 6.2.0(react-dom@18.1.0)(react@18.1.0)
+      rc-dropdown: 4.1.0(react-dom@18.1.0)(react@18.1.0)
+      rc-field-form: 1.32.1(react-dom@18.1.0)(react@18.1.0)
+      rc-image: 5.17.1(react-dom@18.1.0)(react@18.1.0)
+      rc-input: 1.0.4(react-dom@18.1.0)(react@18.1.0)
+      rc-input-number: 7.4.2(react-dom@18.1.0)(react@18.1.0)
+      rc-mentions: 2.3.0(react-dom@18.1.0)(react@18.1.0)
+      rc-menu: 9.9.2(react-dom@18.1.0)(react@18.1.0)
+      rc-motion: 2.7.3(react-dom@18.1.0)(react@18.1.0)
+      rc-notification: 5.0.4(react-dom@18.1.0)(react@18.1.0)
+      rc-pagination: 3.5.0(react-dom@18.1.0)(react@18.1.0)
+      rc-picker: 3.8.1(dayjs@1.11.7)(react-dom@18.1.0)(react@18.1.0)
+      rc-progress: 3.4.1(react-dom@18.1.0)(react@18.1.0)
+      rc-rate: 2.12.0(react-dom@18.1.0)(react@18.1.0)
+      rc-resize-observer: 1.3.1(react-dom@18.1.0)(react@18.1.0)
+      rc-segmented: 2.2.2(react-dom@18.1.0)(react@18.1.0)
+      rc-select: 14.5.0(react-dom@18.1.0)(react@18.1.0)
+      rc-slider: 10.1.1(react-dom@18.1.0)(react@18.1.0)
+      rc-steps: 6.0.0(react-dom@18.1.0)(react@18.1.0)
+      rc-switch: 4.1.0(react-dom@18.1.0)(react@18.1.0)
+      rc-table: 7.32.1(react-dom@18.1.0)(react@18.1.0)
+      rc-tabs: 12.7.1(react-dom@18.1.0)(react@18.1.0)
+      rc-textarea: 1.2.2(react-dom@18.1.0)(react@18.1.0)
+      rc-tooltip: 6.0.1(react-dom@18.1.0)(react@18.1.0)
+      rc-tree: 5.7.4(react-dom@18.1.0)(react@18.1.0)
+      rc-tree-select: 5.9.0(react-dom@18.1.0)(react@18.1.0)
+      rc-upload: 4.3.4(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
+      react: 18.1.0
+      react-dom: 18.1.0(react@18.1.0)
+      scroll-into-view-if-needed: 3.0.6
+      throttle-debounce: 5.0.0
+    transitivePeerDependencies:
+      - date-fns
+      - luxon
+      - moment
+    dev: false
+
   /antd@5.6.0-alpha.0(moment@2.29.4)(react-dom@18.1.0)(react@18.1.0):
     resolution: {integrity: sha512-zdvRSPiP4NHqAzmKNoCwLPWCO865fAEkSvhIlRPG6fvdGERtZ9xrcjaMul35Uoy5ruqVFeBc/BkLZ1x/M4bZhA==}
     peerDependencies:
@@ -17205,6 +17421,23 @@ packages:
       - supports-color
     dev: true
 
+  /babel-jest@29.4.3:
+    resolution: {integrity: sha512-o45Wyn32svZE+LnMVWv/Z4x0SwtLbh4FyGcYtR20kIWd+rdrDZ9Fzq8Ml3MYLD+mZvEdzCjZsCnYZ2jpJyQ+Nw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@babel/core': ^7.8.0
+    dependencies:
+      '@jest/transform': 29.4.3
+      '@types/babel__core': 7.20.0
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.4.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /babel-jest@29.4.3(@babel/core@7.21.0):
     resolution: {integrity: sha512-o45Wyn32svZE+LnMVWv/Z4x0SwtLbh4FyGcYtR20kIWd+rdrDZ9Fzq8Ml3MYLD+mZvEdzCjZsCnYZ2jpJyQ+Nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -17236,6 +17469,21 @@ packages:
       find-cache-dir: 3.3.2
       schema-utils: 4.0.0
       webpack: 5.75.0(esbuild@0.17.19)(uglify-js@3.17.4)(webpack-cli@5.0.1)
+    dev: true
+
+  /babel-loader@9.1.2(webpack@5.76.1):
+    resolution: {integrity: sha512-mN14niXW43tddohGl8HPu5yfQq70iUThvFL/4QzESA7GcZoC0eVOhvWdQ8+3UlSjaDE9MVtsW9mxDY07W7VpVA==}
+    engines: {node: '>= 14.15.0'}
+    peerDependencies:
+      '@babel/core': ^7.12.0
+      webpack: '>=5'
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+    dependencies:
+      find-cache-dir: 3.3.2
+      schema-utils: 4.0.0
+      webpack: 5.76.1(@swc/core@1.3.24)(uglify-js@3.17.4)
     dev: true
 
   /babel-plugin-dynamic-import-node@2.3.3:
@@ -17318,6 +17566,18 @@ packages:
       resolve: 1.22.1
     dev: true
 
+  /babel-plugin-polyfill-corejs2@0.3.3:
+    resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/compat-data': 7.21.4
+      '@babel/helper-define-polyfill-provider': 0.3.3
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.20.12):
     resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
     peerDependencies:
@@ -17343,6 +17603,17 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /babel-plugin-polyfill-corejs3@0.6.0:
+    resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/helper-define-polyfill-provider': 0.3.3
+      core-js-compat: 3.27.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /babel-plugin-polyfill-corejs3@0.6.0(@babel/core@7.20.12):
     resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
     peerDependencies:
@@ -17365,6 +17636,16 @@ packages:
       core-js-compat: 3.27.1
     transitivePeerDependencies:
       - supports-color
+
+  /babel-plugin-polyfill-regenerator@0.4.1:
+    resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/helper-define-polyfill-provider': 0.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /babel-plugin-polyfill-regenerator@0.4.1(@babel/core@7.20.12):
     resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
@@ -17442,6 +17723,25 @@ packages:
       '@babel/helper-module-imports': 7.18.6
     dev: false
 
+  /babel-preset-current-node-syntax@1.0.1:
+    resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.4.5)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.21.0)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.20.12)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.21.0)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.4.5)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.20.12)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.4.5)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.20.12)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.4.5)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.4.5)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.4.5)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.20.12)
+    dev: true
+
   /babel-preset-current-node-syntax@1.0.1(@babel/core@7.21.0):
     resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
     peerDependencies:
@@ -17470,6 +17770,16 @@ packages:
       '@babel/core': 7.21.0
       babel-plugin-jest-hoist: 26.6.2
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.21.0)
+    dev: true
+
+  /babel-preset-jest@29.4.3:
+    resolution: {integrity: sha512-gWx6COtSuma6n9bw+8/F+2PCXrIgxV/D1TJFnp6OyBK2cxPWg0K9p/sriNYeifKjpUkMViWQ09DSWtzJQRETsw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      babel-plugin-jest-hoist: 29.4.3
+      babel-preset-current-node-syntax: 1.0.1
     dev: true
 
   /babel-preset-jest@29.4.3(@babel/core@7.21.0):
@@ -17635,7 +17945,7 @@ packages:
       '@antv/g2plot': 2.3.39
       '@antv/util': 2.0.17
       '@babel/plugin-transform-modules-commonjs': 7.21.2(@babel/core@7.4.5)
-      '@babel/plugin-transform-runtime': 7.21.0(@babel/core@7.21.0)
+      '@babel/plugin-transform-runtime': 7.21.0
       '@juggle/resize-observer': 3.4.0
       babel-plugin-transform-replace-object-assign: 2.0.0
       d3-color: 3.1.0
@@ -20220,6 +20530,7 @@ packages:
     dependencies:
       domelementtype: 2.3.0
       entities: 2.2.0
+    dev: true
 
   /dom-serializer@1.4.1:
     resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
@@ -20243,6 +20554,7 @@ packages:
 
   /domelementtype@1.3.1:
     resolution: {integrity: sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==}
+    dev: true
 
   /domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
@@ -20258,6 +20570,7 @@ packages:
     resolution: {integrity: sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==}
     dependencies:
       domelementtype: 1.3.1
+    dev: true
 
   /domhandler@4.3.1:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
@@ -20270,6 +20583,7 @@ packages:
     dependencies:
       dom-serializer: 0.2.2
       domelementtype: 1.3.1
+    dev: true
 
   /domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -20542,6 +20856,7 @@ packages:
 
   /entities@1.1.2:
     resolution: {integrity: sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==}
+    dev: true
 
   /entities@2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
@@ -21799,6 +22114,30 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+    dev: true
+
+  /eslint-plugin-jest@27.2.1(@typescript-eslint/eslint-plugin@5.48.1)(jest@29.4.3)(typescript@4.9.4):
+    resolution: {integrity: sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^5.0.0
+      eslint: ^7.0.0 || ^8.0.0
+      jest: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+      eslint:
+        optional: true
+      jest:
+        optional: true
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.48.1(@typescript-eslint/parser@5.48.1)(typescript@4.9.4)
+      '@typescript-eslint/utils': 5.48.1(eslint@8.35.0)(typescript@4.9.4)
+      jest: 29.4.3(@types/node@18.11.18)(ts-node@10.9.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: false
 
   /eslint-plugin-promise@6.1.1(eslint@7.32.0):
     resolution: {integrity: sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==}
@@ -24199,6 +24538,7 @@ packages:
       entities: 1.1.2
       inherits: 2.0.4
       readable-stream: 3.6.0
+    dev: true
 
   /htmlparser2@6.1.0:
     resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
@@ -29767,6 +30107,7 @@ packages:
 
   /picocolors@0.2.1:
     resolution: {integrity: sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==}
+    dev: true
 
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
@@ -30298,6 +30639,7 @@ packages:
       htmlparser2: 3.10.1
       postcss: 7.0.39
       postcss-syntax: 0.36.2(postcss-html@0.36.0)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@7.0.39)
+    dev: true
 
   /postcss-image-set-function@4.0.6(postcss@8.4.21):
     resolution: {integrity: sha512-KfdC6vg53GC+vPd2+HYzsZ6obmPqOk6HY09kttU19+Gj1nC3S3XBVEXDHxkhxTohgZqzbUb94bKXvKDnYWBm/A==}
@@ -30365,6 +30707,7 @@ packages:
     engines: {node: '>=6.14.4'}
     dependencies:
       postcss: 7.0.39
+    dev: true
 
   /postcss-less@4.0.1:
     resolution: {integrity: sha512-C92S4sHlbDpefJ2QQJjrucCcypq3+KZPstjfuvgOCNnGx0tF9h8hXgAlOIATGAxMXZXaF+nVp+/Mi8pCAWdSmw==}
@@ -30383,7 +30726,6 @@ packages:
         optional: true
     dependencies:
       postcss: 8.4.21
-    dev: true
 
   /postcss-load-config@3.1.4(postcss@8.4.21)(ts-node@10.9.1):
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
@@ -30921,6 +31263,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       postcss: 7.0.39
+    dev: true
 
   /postcss-selector-not@5.0.0(postcss@8.4.21):
     resolution: {integrity: sha512-/2K3A4TCP9orP4TNS7u3tGdRFVKqz/E6pX3aGnriPG0jU78of8wsUcqE4QAhWEU0d+WnMSF93Ah3F//vUtK+iQ==}
@@ -30993,6 +31336,33 @@ packages:
       postcss-html: 0.36.0(postcss-syntax@0.36.2)(postcss@7.0.39)
       postcss-less: 3.1.4
       postcss-scss: 2.1.1
+    dev: true
+
+  /postcss-syntax@0.36.2(postcss-less@6.0.0)(postcss@8.4.21):
+    resolution: {integrity: sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==}
+    peerDependencies:
+      postcss: '>=5.0.0'
+      postcss-html: '*'
+      postcss-jsx: '*'
+      postcss-less: '*'
+      postcss-markdown: '*'
+      postcss-scss: '*'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      postcss-html:
+        optional: true
+      postcss-jsx:
+        optional: true
+      postcss-less:
+        optional: true
+      postcss-markdown:
+        optional: true
+      postcss-scss:
+        optional: true
+    dependencies:
+      postcss: 8.4.21
+      postcss-less: 6.0.0(postcss@8.4.21)
 
   /postcss-unique-selectors@5.1.1(postcss@8.4.21):
     resolution: {integrity: sha512-5JiODlELrz8L2HwxfPnhOWZYWDxVHWL83ufOv84NrcgipI7TaeRsatAhK4Tr2/ZiYldpK/wBvw5BD3qfaK96GA==}
@@ -31026,6 +31396,7 @@ packages:
     dependencies:
       picocolors: 0.2.1
       source-map: 0.6.1
+    dev: true
 
   /postcss@8.4.14:
     resolution: {integrity: sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==}
@@ -31571,7 +31942,7 @@ packages:
       classnames: 2.3.2
       dom-align: 1.12.3
       lodash: 4.17.21
-      rc-util: 5.30.0(react-dom@17.0.2)(react@17.0.2)
+      rc-util: 5.33.0(react-dom@17.0.2)(react@17.0.2)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       resize-observer-polyfill: 1.5.1
@@ -31591,7 +31962,7 @@ packages:
       classnames: 2.3.2
       dom-align: 1.12.3
       lodash: 4.17.21
-      rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
       resize-observer-polyfill: 1.5.1
@@ -31632,8 +32003,8 @@ packages:
       array-tree-filter: 2.1.0
       classnames: 2.3.2
       rc-select: 14.5.0(react-dom@18.1.0)(react@18.1.0)
-      rc-tree: 5.7.0(react-dom@18.1.0)(react@18.1.0)
-      rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      rc-tree: 5.7.4(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
     dev: false
@@ -31886,6 +32257,25 @@ packages:
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
 
+  /rc-collapse@3.7.0(react-dom@18.1.0)(react@18.1.0):
+    resolution: {integrity: sha512-Cir1c89cENiK5wryd9ut+XltrIfx/+KH1/63uJIVjuXkgfrIvIy6W1fYGgEYtttbHW2fEfxg1s31W+Vm98fSRw==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      classnames: 2.3.2
+      rc-motion: 2.7.3(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
+      react: 18.1.0
+      react-dom: 18.1.0(react@18.1.0)
+    dev: false
+
   /rc-dialog@8.8.2(react-dom@18.1.0)(react@18.1.0):
     resolution: {integrity: sha512-n1waqBDDKqCCcPCDGycahfawF00WqgtXTXUwxrLStUpfQAo7nzkAvTq9voT78X2qN83UYvrMg1TWCuTueBp+sg==}
     peerDependencies:
@@ -32074,6 +32464,26 @@ packages:
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
 
+  /rc-drawer@6.2.0(react-dom@18.1.0)(react@18.1.0):
+    resolution: {integrity: sha512-spPkZ3WvP0U0vy5dyzSwlUJ/+vLFtjP/cTwSwejhQRoDBaexSZHsBhELoCZcEggI7LQ7typmtG30lAue2HEhvA==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@rc-component/portal': 1.1.1(react-dom@18.1.0)(react@18.1.0)
+      classnames: 2.3.2
+      rc-motion: 2.7.3(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
+      react: 18.1.0
+      react-dom: 18.1.0(react@18.1.0)
+    dev: false
+
   /rc-dropdown@3.5.2(react-dom@18.1.0)(react@18.1.0):
     resolution: {integrity: sha512-Ty4LsXjkspZuFJSRx3blCLLCDicXM5qds6F1odgEa+jcjC+OJKHQGnvE4FqtoljPaqWm4wG78pbgXH6Ddh2DkA==}
     peerDependencies:
@@ -32143,7 +32553,7 @@ packages:
       '@babel/runtime': 7.21.0
       '@rc-component/trigger': 1.13.0(react-dom@18.1.0)(react@18.1.0)
       classnames: 2.3.2
-      rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
     dev: false
@@ -32236,7 +32646,26 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       async-validator: 4.2.5
-      rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
+      react: 18.1.0
+      react-dom: 18.1.0(react@18.1.0)
+    dev: false
+
+  /rc-field-form@1.32.1(react-dom@18.1.0)(react@18.1.0):
+    resolution: {integrity: sha512-q2kxLRD4s4QuAcgWcTgTnzEyJfCQ8xhwrk1gjntKWaIBv46qJmDkAtBX/HIkYT2s7ksE2jphELhvv5tRlvrbsQ==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      async-validator: 4.2.5
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
     dev: false
@@ -32299,6 +32728,27 @@ packages:
       rc-dialog: 9.1.0(react-dom@18.1.0)(react@18.1.0)
       rc-motion: 2.7.3(react-dom@18.1.0)(react@18.1.0)
       rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      react: 18.1.0
+      react-dom: 18.1.0(react@18.1.0)
+    dev: false
+
+  /rc-image@5.17.1(react-dom@18.1.0)(react@18.1.0):
+    resolution: {integrity: sha512-oR4eviLyQxd/5A7pn843w2/Z1wuBA27L2lS4agq0sjl2z97ssNIVEzRzgwgB0ZxVZG/qSu9Glit2Zgzb/n+blQ==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@rc-component/portal': 1.1.0(react-dom@18.1.0)(react@18.1.0)
+      classnames: 2.3.2
+      rc-dialog: 9.1.0(react-dom@18.1.0)(react@18.1.0)
+      rc-motion: 2.7.3(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
     dev: false
@@ -32718,6 +33168,28 @@ packages:
       react-dom: 18.1.0(react@18.1.0)
     dev: false
 
+  /rc-mentions@2.3.0(react-dom@18.1.0)(react@18.1.0):
+    resolution: {integrity: sha512-gNpsSKsBHSXvyAA1ZowVTqXSWUIw7+OI9wmjL87KcYURvtm9nDo8R0KtOc2f1PT7q9McUpFzhm6AvQdIly0aRA==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@rc-component/trigger': 1.13.0(react-dom@18.1.0)(react@18.1.0)
+      classnames: 2.3.2
+      rc-input: 1.0.4(react-dom@18.1.0)(react@18.1.0)
+      rc-menu: 9.9.2(react-dom@18.1.0)(react@18.1.0)
+      rc-textarea: 1.2.2(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
+      react: 18.1.0
+      react-dom: 18.1.0(react@18.1.0)
+    dev: false
+
   /rc-menu@9.5.5(react-dom@18.1.0)(react@18.1.0):
     resolution: {integrity: sha512-wj2y2BAKwSMyWXO3RBf9sNN5V+DFWxFl45Ma6qQEHA5nwwh7p07bNgc6AAJc+L1+LAz+rWz3AU8PYyT17hMHCw==}
     peerDependencies:
@@ -32865,6 +33337,27 @@ packages:
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
 
+  /rc-menu@9.9.2(react-dom@18.1.0)(react@18.1.0):
+    resolution: {integrity: sha512-kVJwaQn5VUu6DIddxd/jz3QupTPg0tNYq+mpFP8wYsRF5JgzPA9fPVw+CfwlTPwA1w7gzEY42S8pj6M3uev5CQ==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@rc-component/trigger': 1.13.0(react-dom@18.1.0)(react@18.1.0)
+      classnames: 2.3.2
+      rc-motion: 2.7.3(react-dom@18.1.0)(react@18.1.0)
+      rc-overflow: 1.2.8(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
+      react: 18.1.0
+      react-dom: 18.1.0(react@18.1.0)
+    dev: false
+
   /rc-motion@2.6.0(react-dom@18.1.0)(react@18.1.0):
     resolution: {integrity: sha512-1MDWA9+i174CZ0SIDenSYm2Wb9YbRkrexjZWR0CUFu7D6f23E8Y0KsTgk9NGOLJsGak5ELZK/Y5lOlf5wQdzbw==}
     peerDependencies:
@@ -33006,7 +33499,7 @@ packages:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
       rc-motion: 2.7.3(react-dom@18.1.0)(react@18.1.0)
-      rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
     dev: false
@@ -33142,6 +33635,24 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
+      react: 18.1.0
+      react-dom: 18.1.0(react@18.1.0)
+    dev: false
+
+  /rc-pagination@3.5.0(react-dom@18.1.0)(react@18.1.0):
+    resolution: {integrity: sha512-lUBVtVVUn7gGsq4mTyVpcZQr+AMcljbMiL/HcCmSdFrcsK0iZVKwwbXDxhz2IV0JXUs9Hzepr5sQFaF+9ad/pQ==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      classnames: 2.3.2
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
     dev: false
@@ -33331,7 +33842,40 @@ packages:
       classnames: 2.3.2
       dayjs: 1.11.7
       moment: 2.29.4
-      rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
+      react: 18.1.0
+      react-dom: 18.1.0(react@18.1.0)
+    dev: false
+
+  /rc-picker@3.8.1(dayjs@1.11.7)(react-dom@18.1.0)(react@18.1.0):
+    resolution: {integrity: sha512-Td63/F/V+36dXMEvjuqCNEahBR8S4yocgH7XXY+NrJh6+8dJM+X+5w0PgEjYo0LKkDvfGcu5CpdLG0gobnyLWA==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      date-fns: '>= 2.x'
+      dayjs: '>= 1.x'
+      luxon: '>= 3.x'
+      moment: '>= 2.x'
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+    peerDependenciesMeta:
+      date-fns:
+        optional: true
+      dayjs:
+        optional: true
+      luxon:
+        optional: true
+      moment:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@rc-component/trigger': 1.13.0(react-dom@18.1.0)(react@18.1.0)
+      classnames: 2.3.2
+      dayjs: 1.11.7
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
     dev: false
@@ -33421,6 +33965,25 @@ packages:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
       rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      react: 18.1.0
+      react-dom: 18.1.0(react@18.1.0)
+    dev: false
+
+  /rc-rate@2.12.0(react-dom@18.1.0)(react@18.1.0):
+    resolution: {integrity: sha512-g092v5iZCdVzbjdn28FzvWebK2IutoVoiTeqoLTj9WM7SjA/gOJIw5/JFZMRyJYYVe1jLAU2UhAfstIpCNRozg==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      classnames: 2.3.2
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
     dev: false
@@ -33601,7 +34164,7 @@ packages:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
       rc-motion: 2.7.3(react-dom@18.1.0)(react@18.1.0)
-      rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
     dev: false
@@ -33735,7 +34298,7 @@ packages:
       classnames: 2.3.2
       rc-motion: 2.7.3(react-dom@18.1.0)(react@18.1.0)
       rc-overflow: 1.2.8(react-dom@18.1.0)(react@18.1.0)
-      rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       rc-virtual-list: 3.5.2(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
@@ -34038,7 +34601,7 @@ packages:
       '@rc-component/context': 1.3.0(react-dom@18.1.0)(react@18.1.0)
       classnames: 2.3.2
       rc-resize-observer: 1.3.1(react-dom@18.1.0)(react@18.1.0)
-      rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
     dev: false
@@ -34194,7 +34757,30 @@ packages:
       rc-menu: 9.8.4(react-dom@18.1.0)(react@18.1.0)
       rc-motion: 2.7.3(react-dom@18.1.0)(react@18.1.0)
       rc-resize-observer: 1.3.1(react-dom@18.1.0)(react@18.1.0)
-      rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
+      react: 18.1.0
+      react-dom: 18.1.0(react@18.1.0)
+    dev: false
+
+  /rc-tabs@12.7.1(react-dom@18.1.0)(react@18.1.0):
+    resolution: {integrity: sha512-NrltXEYIyiDP5JFu85NQwc9eR+7e50r/6MNXYDyG1EMIFNc7BgDppzdpnD3nW4NHYWw5wLIThCURGib48OCTBg==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      classnames: 2.3.2
+      rc-dropdown: 4.1.0(react-dom@18.1.0)(react@18.1.0)
+      rc-menu: 9.9.2(react-dom@18.1.0)(react@18.1.0)
+      rc-motion: 2.7.3(react-dom@18.1.0)(react@18.1.0)
+      rc-resize-observer: 1.3.1(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
     dev: false
@@ -34494,8 +35080,8 @@ packages:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
       rc-select: 14.5.0(react-dom@18.1.0)(react@18.1.0)
-      rc-tree: 5.7.0(react-dom@18.1.0)(react@18.1.0)
-      rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      rc-tree: 5.7.4(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
     dev: false
@@ -34581,6 +35167,27 @@ packages:
       rc-virtual-list: 3.4.13(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
+
+  /rc-tree@5.7.4(react-dom@18.1.0)(react@18.1.0):
+    resolution: {integrity: sha512-7VfDq4jma+6fvlzfDXvUJ34SaO2EWkcXGBmPgeFmVKsLNNXcKGl4cRAhs6Ts1zqnX994vu/hb3f1dyTjn43RFg==}
+    engines: {node: '>=10.x'}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      classnames: 2.3.2
+      rc-motion: 2.7.3(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
+      rc-virtual-list: 3.5.2(react-dom@18.1.0)(react@18.1.0)
+      react: 18.1.0
+      react-dom: 18.1.0(react@18.1.0)
+    dev: false
 
   /rc-trigger@5.3.1(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-5gaFbDkYSefZ14j2AdzucXzlWgU2ri5uEjkHvsf1ynRhdJbKxNOnw4PBZ9+FVULNGFiDzzlVF8RJnR9P/xrnKQ==}
@@ -34749,6 +35356,38 @@ packages:
       react-dom: 18.1.0(react@18.1.0)
       react-is: 16.13.1
 
+  /rc-util@5.33.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-mq2NkEAnHklq4fgU/JqjiE0PS8+8u33gEWw2bDUNDPck3OroPpSgw/8oEyuFrvPgaZEmt9BgQdh59JfQt2cU+w==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+      react-is: 16.13.1
+
+  /rc-util@5.33.0(react-dom@18.1.0)(react@18.1.0):
+    resolution: {integrity: sha512-mq2NkEAnHklq4fgU/JqjiE0PS8+8u33gEWw2bDUNDPck3OroPpSgw/8oEyuFrvPgaZEmt9BgQdh59JfQt2cU+w==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      react: 18.1.0
+      react-dom: 18.1.0(react@18.1.0)
+      react-is: 16.13.1
+
   /rc-virtual-list@3.4.13(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-cPOVDmcNM7rH6ANotanMDilW/55XnFPw0Jh/GQYtrzZSy3AmWvCnqVNyNC/pgg3lfVmX2994dlzAhuUrd4jG7w==}
     engines: {node: '>=8.x'}
@@ -34802,7 +35441,7 @@ packages:
       '@babel/runtime': 7.21.0
       classnames: 2.3.2
       rc-resize-observer: 1.3.1(react-dom@18.1.0)(react@18.1.0)
-      rc-util: 5.30.0(react-dom@18.1.0)(react@18.1.0)
+      rc-util: 5.33.0(react-dom@18.1.0)(react@18.1.0)
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
     dev: false
@@ -38331,6 +38970,33 @@ packages:
       uglify-js: 3.17.4
       webpack: 5.75.0(esbuild@0.17.19)(uglify-js@3.17.4)(webpack-cli@5.0.1)
 
+  /terser-webpack-plugin@5.3.6(uglify-js@3.17.4)(webpack@5.76.1):
+    resolution: {integrity: sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+      webpack:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.15
+      jest-worker: 27.5.1
+      schema-utils: 3.1.1
+      serialize-javascript: 6.0.0
+      terser: 5.16.1
+      uglify-js: 3.17.4
+      webpack: 5.76.1(uglify-js@3.17.4)
+    dev: true
+
   /terser@5.16.1:
     resolution: {integrity: sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==}
     engines: {node: '>=10'}
@@ -40420,6 +41086,46 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  /webpack@5.76.1(uglify-js@3.17.4):
+    resolution: {integrity: sha512-4+YIK4Abzv8172/SGqObnUjaIHjLEuUasz9EwQj/9xmPPkYJy2Mh03Q/lJfSD3YLzbxy5FeTq5Uw0323Oh6SJQ==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/eslint-scope': 3.7.4
+      '@types/estree': 0.0.51
+      '@webassemblyjs/ast': 1.11.1
+      '@webassemblyjs/wasm-edit': 1.11.1
+      '@webassemblyjs/wasm-parser': 1.11.1
+      acorn: 8.8.2
+      acorn-import-assertions: 1.8.0(acorn@8.8.2)
+      browserslist: 4.21.5
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.10.0
+      es-module-lexer: 0.9.3
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.10
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.1.1
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.6(uglify-js@3.17.4)(webpack@5.76.1)
+      watchpack: 2.4.0
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    dev: true
 
   /webpackbar@5.0.2(webpack@5.76.1):
     resolution: {integrity: sha512-BmFJo7veBDgQzfWXl/wwYXr/VFus0614qZ8i9znqcl9fnEdiVkdbi0TedLQ6xAK92HZHDJ0QmyQ0fmuZPAgCYQ==}


### PR DESCRIPTION
修复使用 addLocale 追加 messages 时，原有 momentlocal 丢失问题。
```ts
addLocale('zh-CN', {
      welcome: '欢迎！',
});
```
修复前，在追加 locale 之后，antd 内置的 locale 会丢失
![Untitled1](https://github.com/umijs/umi/assets/11746742/164233cd-a8b9-48b6-913e-2b353a0369c5)
修复后
![Untitled](https://github.com/umijs/umi/assets/11746742/ae4238dd-8665-445f-a834-8b8f5ef2a25f)

Closes: https://github.com/umijs/umi/issues/10694