### PR TITLE
Doc/fix: Corrected type definition of state in Link component

### DIFF
--- a/docs/docs/api/api.md
+++ b/docs/docs/api/api.md
@@ -195,7 +195,7 @@ declare function Link(props: {
   prefetch?: boolean;
   to: string | Partial<{ pathname: string; search: string; hash: string }>;
   replace?: boolean;
-  state?: boolean;
+  state?: any;
   reloadDocument?: boolean;
 }): React.ReactElement;
 ```


### PR DESCRIPTION
The state prop of the Link component should be any according to the LinkProps type definition.
<img width="685" alt="image" src="https://github.com/umijs/umi/assets/17156560/02c76ccd-a15a-4db0-b966-a9bb42386cf0">
