### PR TITLE
chore: set pnpm version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install pnpm (node 14)
         if: ${{ matrix.node-version == '14.x' }}
-        run: npm install -g @pnpm/exe@8.6.0
+        run: npm install -g @pnpm/exe@8.6.2
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/package.json
+++ b/package.json
@@ -120,10 +120,10 @@
     "umi-scripts": "workspace:*",
     "zx": "^7.1.1"
   },
-  "packageManager": "pnpm@8.6.0",
+  "packageManager": "pnpm@8.6.2",
   "engines": {
     "node": ">=14",
-    "pnpm": ">=8"
+    "pnpm": "^8.6.2"
   },
   "//why-overrides-browserslist": "See scripts/bundleDeps.ts",
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: false


### PR DESCRIPTION
lockfileVersion: '6.1' 之前的 pnpm 不能跑，改回 6.0
pnpm 最新的版本 8.6.2 又把 lock version 回退到了 6.0 ，所以这里统一把版本指定为 8.6.2 ，详见 https://github.com/pnpm/pnpm/releases/tag/v8.6.2
