### PR TITLE
fix: Make nl-NL use correct label

### DIFF
--- a/packages/plugins/templates/locale/SelectLang.tpl
+++ b/packages/plugins/templates/locale/SelectLang.tpl
@@ -284,7 +284,7 @@ const defaultLangUConfigMap = {
   },
   'nl-NL': {
     lang: 'nl-NL',
-    label: 'Vlaams',
+    label: 'Nederlands',
     icon: '🇳🇱',
     title: 'Taal'
   },


### PR DESCRIPTION
nl-BE is correctly using the label 'Vlaams'. nl-NL is not the same. This should use the label 'Nederlands'. Changed that in this PR.