### PR TITLE
feat: support routeMode prepend & match

### DIFF
--- a/examples/qiankun-master/.umirc.ts
+++ b/examples/qiankun-master/.umirc.ts
@@ -22,6 +22,7 @@ export default {
   routes: [
     { path: '/', redirect: '/home' },
     { path: '/home', component: 'index' },
+    { path: '/nav', component: 'never' },
     {
       path: '/slave/*',
       microApp: 'slave',

--- a/examples/qiankun-master/app.ts
+++ b/examples/qiankun-master/app.ts
@@ -1,0 +1,16 @@
+export const qiankun = {
+  master: {
+    routes: [
+      {
+        path: '/nav',
+        microApp: 'slave',
+        mode: 'match',
+      },
+      {
+        path: '/count',
+        microApp: 'slave',
+        mode: 'match',
+      },
+    ],
+  },
+};

--- a/examples/qiankun-master/pages/index.tsx
+++ b/examples/qiankun-master/pages/index.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 // @ts-ignore
-import { Link, MicroAppWithMemoHistory } from '@umijs/max';
+import { Link } from '@umijs/max';
 // @ts-ignore
-import { Drawer } from 'antd';
 
 export default function HomePage() {
   return (
@@ -12,6 +11,9 @@ export default function HomePage() {
       <div>
         <Link to="/slave/home">
           <button>go-slave</button>
+        </Link>
+        <Link to="/nav">
+          <button>go-match-slave</button>
         </Link>
       </div>
     </div>

--- a/examples/qiankun-master/pages/never.tsx
+++ b/examples/qiankun-master/pages/never.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function () {
+  return <div style={{ color: 'red' }}>never seen</div>;
+}

--- a/examples/qiankun-slave/cypress/e2e/example.cy.ts
+++ b/examples/qiankun-slave/cypress/e2e/example.cy.ts
@@ -6,7 +6,7 @@ describe('QianKun Plugin', () => {
   it('can navigate to slave', () => {
     // contains https://docs.cypress.io/api/commands/contains
     cy.visit('/home');
-    cy.get('a').click();
+    cy.get('a[href*="/slave/home"]').click();
 
     cy.contains('Slave Home Page');
   });
@@ -42,6 +42,15 @@ describe('QianKun Plugin', () => {
       cy.contains('count:0');
       cy.get('button').click();
       cy.contains('count:1');
+    });
+  });
+
+  describe('microApp route first', () => {
+    it('not hit indexApp route', () => {
+      // contains https://docs.cypress.io/api/commands/contains
+      cy.visit('/nav');
+
+      cy.contains('never seen').should('not.exist');
     });
   });
 

--- a/packages/plugins/libs/qiankun/master/common.ts
+++ b/packages/plugins/libs/qiankun/master/common.ts
@@ -5,8 +5,10 @@
  * @since 2019-06-20
  */
 
-import React, { ReactComponentElement } from 'react';
+import React from 'react';
 import { Navigate, type IRouteProps } from 'umi';
+import { getMicroAppRouteComponent } from './getMicroAppRouteComponent';
+import type { MicroAppRoute } from './types';
 
 export const defaultMountContainerId = 'root-subapp';
 
@@ -44,14 +46,7 @@ function testPathWithStaticPrefix(pathPrefix: string, realPath: string) {
 // }
 
 export function patchMicroAppRoute(
-  route: any,
-  getMicroAppRouteComponent: (opts: {
-    appName: string;
-    base: string;
-    routePath: string;
-    masterHistoryType: string;
-    routeProps?: any;
-  }) => string | ReactComponentElement<any>,
+  route: MicroAppRoute,
   masterOptions: {
     base: string;
     masterHistoryType: string;
@@ -75,8 +70,8 @@ export function patchMicroAppRoute(
       }
     }
 
-    // 自动追加通配符，匹配子应用的路由
-    if (!route.path.endsWith('/*')) {
+    // 在前缀模式下，自动追加通配符，匹配子应用的路由
+    if (route.mode === 'prepend' && !route.path.endsWith('/*')) {
       route.path = route.path.replace(/\/?$/, '/*');
     }
 
@@ -90,6 +85,7 @@ export function patchMicroAppRoute(
       appName: microAppName,
       base,
       routePath: route.path,
+      routeMode: route.mode,
       masterHistoryType,
       routeProps,
     };

--- a/packages/plugins/libs/qiankun/master/getMicroAppRouteComponent.tsx.tpl
+++ b/packages/plugins/libs/qiankun/master/getMicroAppRouteComponent.tsx.tpl
@@ -6,18 +6,21 @@ export function getMicroAppRouteComponent(opts: {
   appName: string;
   base: string;
   routePath: string;
+  routeMode: 'match' | 'prepend';
   masterHistoryType: string;
   routeProps?: any;
 }) {
-  const { base, masterHistoryType, appName, routeProps, routePath } = opts;
+  const { base, masterHistoryType, appName, routeProps, routePath, routeMode = 'prepend' } = opts;
   const RouteComponent = () => {
     const match = useMatch(routePath);
     const url = match ? match.pathnameBase : '';
     // 默认取静态配置的 base
     let umiConfigBase = base === '/' ? '' : base;
+    // 匹配模式下，routePath 不会作为 prefix
+    const prefix = routeMode === 'match' ? '' : (url.endsWith('/') ? url.substr(0, url.length - 1) : url);
 
     // 拼接子应用挂载路由
-    let runtimeMatchedBase = umiConfigBase + (url.endsWith('/') ? url.substr(0, url.length - 1) : url);
+    let runtimeMatchedBase = umiConfigBase + prefix;
 
     {{#dynamicRoot}}
     // @see https://github.com/umijs/umi/blob/master/packages/preset-built-in/src/plugins/commands/htmlUtils.ts#L102

--- a/packages/plugins/libs/qiankun/master/masterRuntimePlugin.tsx
+++ b/packages/plugins/libs/qiankun/master/masterRuntimePlugin.tsx
@@ -5,10 +5,9 @@ import { getPluginManager } from '@@/core/plugin';
 import { prefetchApps } from 'qiankun';
 import { ApplyPluginsType } from 'umi';
 import { insertRoute, noop, patchMicroAppRoute } from './common';
-import { getMicroAppRouteComponent } from './getMicroAppRouteComponent';
 import { getMasterOptions, setMasterOptions } from './masterOptions';
-import { MasterOptions, MicroAppRoute } from './types';
 import { deepFilterLeafRoutes } from './routeUtils';
+import { MasterOptions, MicroAppRoute } from './types';
 
 let microAppRuntimeRoutes: MicroAppRoute[];
 
@@ -55,9 +54,8 @@ function patchMicroAppRouteComponent(routes: any[]) {
       getMasterOptions() as MasterOptions;
     microAppRuntimeRoutes.reverse().forEach((microAppRoute) => {
       const patchRoute = (route: any) => {
-        patchMicroAppRoute(route, getMicroAppRouteComponent, {
+        patchMicroAppRoute(route, {
           base,
-          routePath: route.path,
           masterHistoryType,
           routeBindingAlias,
         });

--- a/packages/plugins/libs/qiankun/master/types.ts
+++ b/packages/plugins/libs/qiankun/master/types.ts
@@ -18,6 +18,11 @@ export type App = {
 export type MicroAppRoute = {
   path: string;
   microApp: string;
+  /**
+   * prepend 既作为匹配规则，也作为子应用 router.basename
+   * match 仅作为匹配规则
+   */
+  mode: 'match' | 'prepend';
 } & Record<string, any>;
 
 export type MasterOptions = {

--- a/packages/plugins/libs/qiankun/slave/slaveRuntimePlugin.ts
+++ b/packages/plugins/libs/qiankun/slave/slaveRuntimePlugin.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
-import qiankunRender, { contextOptsStack } from './lifecycles';
 import { createHistory } from '@@/core/history';
+import qiankunRender, { contextOptsStack } from './lifecycles';
 
 export function render(oldRender: any) {
   return qiankunRender().then(oldRender);
@@ -11,7 +11,9 @@ export function modifyClientRenderOpts(memo: any) {
   const clientRenderOpts = contextOptsStack.shift();
   const { basename, historyType } = memo;
 
-  const newBasename = clientRenderOpts?.basename || basename;
+  // use ?? instead of ||, incase clientRenderOpts.basename is ''
+  // only break when microApp has a config.base and mount path is /*
+  const newBasename = clientRenderOpts?.basename ?? basename;
   const newHistoryType = clientRenderOpts?.historyType || historyType;
 
   if (newHistoryType !== historyType || newBasename !== basename) {


### PR DESCRIPTION
- 新增了 `qiankun.master.routes[].mode: 'match' | 'prepend'`，`match` 时仅作为匹配规则，不会作为 router 前缀
- ~~修复了主子应用路由相同时，优先匹配主应用路由的 bug，可能会有 breakingChange~~