### PR TITLE
fix(doc): plugins should be installed in deps

### DIFF
--- a/docs/docs/api/runtime-config.md
+++ b/docs/docs/api/runtime-config.md
@@ -69,7 +69,7 @@ export default {
 2. 或者手动开启数据流功能的插件使用该功能：
 
    ```bash
-     pnpm add -D @umijs/plugins
+     pnpm add @umijs/plugins
    ```
 
    ```ts

--- a/docs/docs/guides/use-plugins.md
+++ b/docs/docs/guides/use-plugins.md
@@ -7,7 +7,7 @@ import { Message } from 'umi';
 在普通的 Umi 应用中，默认 **不附带任何插件** ，如需使用 Max 的功能（如 数据流、antd 等），需要手动安装插件并开启他们：
 
 ```bash
-  pnpm add -D @umijs/plugins
+  pnpm add @umijs/plugins
 ```
 
 如开启 antd 插件：

--- a/docs/docs/max/react-query.md
+++ b/docs/docs/max/react-query.md
@@ -15,7 +15,7 @@ export default {
 如果是 umi，先安装 `@umijs/plugins` 依赖，再通过配置开启。
 
 ```bash
-$ pnpm i @umijs/plugins -D
+$ pnpm i @umijs/plugins
 ```
 
 ```ts

--- a/docs/docs/max/styled-components.md
+++ b/docs/docs/max/styled-components.md
@@ -15,7 +15,7 @@ export default {
 如果是 umi，先安装 `@umijs/plugins` 依赖，再通过配置开启。
 
 ```bash
-$ pnpm i @umijs/plugins -D
+$ pnpm i @umijs/plugins
 ```
 
 ```ts


### PR DESCRIPTION
为什么要将 @umijs/plugins 安装到 devDependencies 中呢？
1. 生产环境没有 @umijs/plugins 项目是跑不起来的，比如执行 pnpm install --production
2. 使用 umi 作为脚手架，一般来讲开发的是 web app 而不是 npm package，没有必要作特意区分
不知道我的理解对不对