### PR TITLE
fix: hooks should keep alive even when not in ssr

### DIFF
--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -620,10 +620,16 @@ if (process.env.NODE_ENV === 'development') {
           exports.push(`export { TestBrowser } from './testBrowser';`);
         }
       }
-      if (api.config.ssr && api.appData.framework === 'react') {
-        exports.push(
-          `export { useServerInsertedHTML } from './core/serverInsertedHTMLContext';`,
-        );
+      if (api.appData.framework === 'react') {
+        if (api.config.ssr) {
+          exports.push(
+            `export { useServerInsertedHTML } from './core/serverInsertedHTMLContext';`,
+          );
+        } else {
+          exports.push(
+            `export const useServerInsertedHTML: Function = () => {};`,
+          );
+        }
       }
       // plugins
       exports.push('// plugins');


### PR DESCRIPTION
follow up #11227

在 dev 下，`useServerInsertedHTML` hook 仍然需要一个占位方法。否则会报错：
![image](https://github.com/umijs/umi/assets/5378891/3f6543b6-953b-42f0-854a-310f77998d68)


SSR 下 OOM 是因为 staticRes 没有释放导致：
<img width="676" alt="截屏2023-07-24 14 18 00" src="https://github.com/umijs/umi/assets/5378891/24224552-3da6-4682-a79c-c1e93e1832e1">

