### PR TITLE
fix: script in pre-render html should be defer or async

### DIFF
--- a/examples/ssr-demo/.umirc.ts
+++ b/examples/ssr-demo/.umirc.ts
@@ -7,5 +7,4 @@ export default {
   ssr: {
     serverBuildPath: './umi.server.js',
   },
-  exportStatic: {},
 };

--- a/examples/ssr-demo/.umirc.ts
+++ b/examples/ssr-demo/.umirc.ts
@@ -7,4 +7,5 @@ export default {
   ssr: {
     serverBuildPath: './umi.server.js',
   },
+  exportStatic: {},
 };

--- a/packages/preset-umi/src/features/exportStatic/exportStatic.ts
+++ b/packages/preset-umi/src/features/exportStatic/exportStatic.ts
@@ -261,4 +261,9 @@ export function modifyClientRenderOpts(memo: any) {
   api.addRuntimePlugin(() => {
     return [`@@/core/exportStaticRuntimePlugin.ts`];
   });
+
+  api.modifyHTML(($) => {
+    $('script[src^="/umi."]').attr('async', '');
+    return $;
+  });
 };

--- a/packages/preset-umi/src/features/exportStatic/exportStatic.ts
+++ b/packages/preset-umi/src/features/exportStatic/exportStatic.ts
@@ -144,6 +144,12 @@ export default (api: IApi) => {
 
     for (const { file, route, prerender } of htmlData) {
       let { markupArgs } = opts;
+      markupArgs.scripts = markupArgs.scripts.map((script: any) => {
+        if (script.src) {
+          script.async = true;
+        }
+        return script;
+      });
 
       // handle relative publicPath, such as `./`
       if (publicPath.startsWith('.')) {
@@ -260,10 +266,5 @@ export function modifyClientRenderOpts(memo: any) {
 
   api.addRuntimePlugin(() => {
     return [`@@/core/exportStaticRuntimePlugin.ts`];
-  });
-
-  api.modifyHTML(($) => {
-    $('script[src^="/umi."]').attr('async', '');
-    return $;
   });
 };

--- a/packages/preset-umi/src/features/exportStatic/exportStatic.ts
+++ b/packages/preset-umi/src/features/exportStatic/exportStatic.ts
@@ -144,12 +144,13 @@ export default (api: IApi) => {
 
     for (const { file, route, prerender } of htmlData) {
       let { markupArgs } = opts;
-      markupArgs.scripts = markupArgs.scripts.map((script: any) => {
-        if (script.src) {
-          script.async = true;
-        }
-        return script;
-      });
+      if (api.config.ssr && prerender) {
+        markupArgs.scripts.forEach((script: any) => {
+          if (script.src) {
+            script.async = true;
+          }
+        });
+      }
 
       // handle relative publicPath, such as `./`
       if (publicPath.startsWith('.')) {


### PR DESCRIPTION
Pre-render 产出的 HTML 中 umi.js 没有带上 async，导致阻塞了后面的 script，也就是 react 替换 Suspense 内的 HTML 的脚本：
![image](https://github.com/umijs/umi/assets/27722486/1e43d583-a187-4cf4-be31-4af2bd020569)

因为渲染 HTML 时 Suspense 内的 HTML 是 append 到最开始打出的 HTML 后面的，也就是在 `<html>` 标签外边，所以一开始浏览器不会渲染这部分。但是由于 umi 有一个 router 级别的 Suspense，所以导致的结果就是会白屏直到 umi.js 执行完。这会严重影响 FCP 和 LCP，优化后 antd 官网的 FCP 从 2s 降低到了 400ms。

看了一眼 SSR 是有给 umi.js 加 async 的，不知道有没有更好的写法？
