### PR TITLE
feat(core): IAdd type fix

### DIFF
--- a/examples/boilerplate/plugin.ts
+++ b/examples/boilerplate/plugin.ts
@@ -30,4 +30,11 @@ export default (api: IApi) => {
     args;
     // console.log('> onCheckCode', args);
   });
+
+  api.addHTMLScripts({
+    async fn() {
+      return [`console.log('async scripts hello world')`];
+    },
+    stage: 100,
+  });
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -99,10 +99,10 @@ export interface IAdd<T, U> {
   (args: {
     fn: {
       (args: T): Promise<U | U[]>;
-      name?: string;
-      before?: string | string[];
-      stage?: number;
     };
+    name?: string;
+    before?: string | string[];
+    stage?: number;
   }): void;
 }
 


### PR DESCRIPTION
当 hook 是异步的并且使用 stage 的场景, 类型错误
修复下列场景使用类型错误
```tsx
api.addHTMLScripts({
    async fn() {
      return [`console.log('async scripts hello world')`];
    },
    stage: 100,
 });
```