### PR TITLE
fix: use pull_request event instead of pull_request_target for security reason

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -1,7 +1,7 @@
 name: PullRequest Checker
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - closed
     paths-ignore:


### PR DESCRIPTION
pull_request_target 会基于 master 分支运行且生成的 GITHUB_TOKEN 具备写权限，可能导致仓库密钥被恶意 pr 窃取。改成 pull_request 的唯一副作用是当一个新的 contributor 提交了 pr 并修改了 contributors.json 时（将自己的 id 加入到了列表），当前 pr 被合并后可能不会触发加群通知，因为对照的是当前 pr 分支的 contributors.json 而不是 master 分支的 contributors 列表

see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/umi/11512)
<!-- Reviewable:end -->
