### PR TITLE
feat(preset-umi): throw by default when pre-render error

### DIFF
--- a/docs/docs/docs/api/config.md
+++ b/docs/docs/docs/api/config.md
@@ -585,7 +585,7 @@ export default {
 
 ## exportStatic
 
-- 类型：`{ extraRoutePaths: IUserExtraRoute[] | (() => IUserExtraRoute[] | Promise<IUserExtraRoute[]>) }`
+- 类型：`{ extraRoutePaths: IUserExtraRoute[] | (() => IUserExtraRoute[] | Promise<IUserExtraRoute[]>), ignorePreRenderError: boolean }`
 - 默认值：`undefined`
 
 开启该配置后会针对每个路由单独输出 HTML 文件，通常用于静态站点托管。例如项目有如下路由：
@@ -654,6 +654,17 @@ export default {
 }
 ```
 
+`exportStatic` 在搭配 `ssr` 使用时会进行预渲染，在预渲染失败时会抛出异常并终止构建，可以通过配置 `ignorePreRenderError` 来忽略预渲染失败的错误，例如：
+
+```ts
+// .umirc.ts
+export default {
+  exportStatic: {
+    // 忽略预渲染失败的错误
+    ignorePreRenderError: true,
+  },
+}
+```
 
 ## favicons
 

--- a/packages/preset-umi/src/features/exportStatic/exportStatic.ts
+++ b/packages/preset-umi/src/features/exportStatic/exportStatic.ts
@@ -59,7 +59,7 @@ function getExportHtmlData(routes: Record<string, IRoute>): IExportHtmlItem[] {
  */
 async function getPreRenderedHTML(api: IApi, htmlTpl: string, path: string) {
   const {
-    exportStatic: { notThrow = false },
+    exportStatic: { ignorePreRenderError = false },
   } = api.config;
   markupRender ??= require(absServerBuildPath(api))._markupGenerator;
 
@@ -85,7 +85,7 @@ async function getPreRenderedHTML(api: IApi, htmlTpl: string, path: string) {
     logger.info(`Pre-render for ${path}`);
   } catch (err) {
     logger.error(`Pre-render ${path} error: ${err}`);
-    if (!notThrow) {
+    if (!ignorePreRenderError) {
       throw err;
     }
   }
@@ -132,7 +132,7 @@ export default (api: IApi) => {
               zod.function(),
               zod.array(zod.string()),
             ]),
-            notThrow: zod.boolean().default(false),
+            ignorePreRenderError: zod.boolean().default(false),
           })
           .deepPartial(),
     },

--- a/packages/preset-umi/src/features/exportStatic/exportStatic.ts
+++ b/packages/preset-umi/src/features/exportStatic/exportStatic.ts
@@ -86,7 +86,7 @@ async function getPreRenderedHTML(api: IApi, htmlTpl: string, path: string) {
   } catch (err) {
     logger.error(`Pre-render ${path} error: ${err}`);
     if (!notThrow) {
-      process.exit(1);
+      throw err;
     }
   }
 

--- a/packages/preset-umi/src/features/exportStatic/exportStatic.ts
+++ b/packages/preset-umi/src/features/exportStatic/exportStatic.ts
@@ -58,6 +58,9 @@ function getExportHtmlData(routes: Record<string, IRoute>): IExportHtmlItem[] {
  * get pre-rendered html by route path
  */
 async function getPreRenderedHTML(api: IApi, htmlTpl: string, path: string) {
+  const {
+    exportStatic: { notThrow = false },
+  } = api.config;
   markupRender ??= require(absServerBuildPath(api))._markupGenerator;
 
   try {
@@ -82,6 +85,9 @@ async function getPreRenderedHTML(api: IApi, htmlTpl: string, path: string) {
     logger.info(`Pre-render for ${path}`);
   } catch (err) {
     logger.error(`Pre-render ${path} error: ${err}`);
+    if (!notThrow) {
+      process.exit(1);
+    }
   }
 
   return htmlTpl;
@@ -126,6 +132,7 @@ export default (api: IApi) => {
               zod.function(),
               zod.array(zod.string()),
             ]),
+            notThrow: zod.boolean().default(false),
           })
           .deepPartial(),
     },


### PR DESCRIPTION
### Background

现在 Pre-render 失败时仍会跑完整个构建，用户不注意的话就不会发现有编译问题。

### Solution

1. Pre-render 失败时抛错并终止进程
2. 添加 `exportStatic.ignorePreRenderError` 配置，开启后会和以前的行为一样

![image](https://github.com/umijs/umi/assets/27722486/77b98386-3346-4ba8-98af-7d107810b469)
