### PR TITLE
feat(plugins): use app name as qiankun library name by default

### DIFF
--- a/docs/docs/docs/max/micro-frontend.md
+++ b/docs/docs/docs/max/micro-frontend.md
@@ -576,6 +576,8 @@ qiankun: {
 
 当您使用 antd 作为项目组件库时，可以向子应用传入 `autoCaptureError` 属性以开启子应用错误捕获能力，插件将会自动调用 antd 的 [`<Result />` 组件](https://ant.design/components/result-cn/)作为错误捕获组件。
 
+如（文案语言会自动读取 umi locale 配置切换）：<img src="https://mdn.alipayobjects.com/huamei_zvchwx/afts/img/A*gAAVRrAJJNEAAAAAAAAAAAAADuWEAQ/original">
+
 如果通过路由的模式引入子应用，可以配置如下：
 
 ```ts

--- a/packages/plugins/src/qiankun/slave.ts
+++ b/packages/plugins/src/qiankun/slave.ts
@@ -183,7 +183,7 @@ export interface IRuntimeConfig {
   api.chainWebpack((config) => {
     assert(api.pkg.name, 'You should have name in package.json.');
     // 默认不修改 library chunk 的 name，从而确保可以通过 window[appName] 访问到导出
-    const { shouldNotAddLibraryChunkName = true } = (api.config.qiankun || {}).slave!;
+    const { shouldNotAddLibraryChunkName } = (api.config.qiankun || {}).slave!;
     config.output
       .libraryTarget('umd')
       .library(

--- a/packages/plugins/src/qiankun/slave.ts
+++ b/packages/plugins/src/qiankun/slave.ts
@@ -183,7 +183,8 @@ export interface IRuntimeConfig {
   api.chainWebpack((config) => {
     assert(api.pkg.name, 'You should have name in package.json.');
     // 默认不修改 library chunk 的 name，从而确保可以通过 window[appName] 访问到导出
-    const { shouldNotAddLibraryChunkName = true } = (api.config.qiankun || {}).slave!;
+    // mfsu 关闭的时候才可以修改，否则可能导致配合 mfsu 时，子应用的 umd chunk 无法被正确加载
+    const { shouldNotAddLibraryChunkName = api.config.mfsu === false } = (api.config.qiankun || {}).slave!;
     config.output
       .libraryTarget('umd')
       .library(

--- a/packages/plugins/src/qiankun/slave.ts
+++ b/packages/plugins/src/qiankun/slave.ts
@@ -184,7 +184,7 @@ export interface IRuntimeConfig {
     assert(api.pkg.name, 'You should have name in package.json.');
     // 默认不修改 library chunk 的 name，从而确保可以通过 window[appName] 访问到导出
     // mfsu 关闭的时候才可以修改，否则可能导致配合 mfsu 时，子应用的 umd chunk 无法被正确加载
-    const { shouldNotAddLibraryChunkName = api.config.mfsu === false } = (api.config.qiankun || {}).slave!;
+    const { shouldNotAddLibraryChunkName = !Boolean(api.config.mfsu) } = (api.config.qiankun || {}).slave!;
     config.output
       .libraryTarget('umd')
       .library(

--- a/packages/plugins/src/qiankun/slave.ts
+++ b/packages/plugins/src/qiankun/slave.ts
@@ -183,7 +183,7 @@ export interface IRuntimeConfig {
   api.chainWebpack((config) => {
     assert(api.pkg.name, 'You should have name in package.json.');
     // 默认不修改 library chunk 的 name，从而确保可以通过 window[appName] 访问到导出
-    const { shouldNotAddLibraryChunkName } = (api.config.qiankun || {}).slave!;
+    const { shouldNotAddLibraryChunkName = true } = (api.config.qiankun || {}).slave!;
     config.output
       .libraryTarget('umd')
       .library(

--- a/packages/plugins/src/qiankun/slave.ts
+++ b/packages/plugins/src/qiankun/slave.ts
@@ -182,7 +182,8 @@ export interface IRuntimeConfig {
 
   api.chainWebpack((config) => {
     assert(api.pkg.name, 'You should have name in package.json.');
-    const { shouldNotAddLibraryChunkName } = (api.config.qiankun || {}).slave!;
+    // 默认不修改 library chunk 的 name，从而确保可以通过 window[appName] 访问到导出
+    const { shouldNotAddLibraryChunkName = true } = (api.config.qiankun || {}).slave!;
     config.output
       .libraryTarget('umd')
       .library(


### PR DESCRIPTION
- ref https://github.com/umijs/plugins/pull/948
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/umi/11530)
<!-- Reviewable:end -->
