### PR TITLE
fix: repeat runtime plugin key

### DIFF
--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -430,27 +430,44 @@ if (process.env.NODE_ENV === 'development') {
       key: 'addRuntimePlugin',
       initialValue: [api.appData.appJS?.path].filter(Boolean),
     });
-    const validKeys = [
-      ...new Set(
-        await api.applyPlugins({
-          key: 'addRuntimePluginKey',
-          initialValue: [
-            'patchRoutes',
-            'patchClientRoutes',
-            'modifyContextOpts',
-            'modifyClientRenderOpts',
-            'rootContainer',
-            'innerProvider',
-            'i18nProvider',
-            'accessProvider',
-            'dataflowProvider',
-            'outerProvider',
-            'render',
-            'onRouteChange'
-          ]
-        })
-      )
-    ];
+
+    function checkDuplicatePluginKeys(arr: string[]) {
+      const duplicates: string[] = [];
+      arr.reduce((prev, curr) => {
+        if (prev[curr]) {
+          duplicates.push(curr);
+        } else {
+          prev[curr] = true;
+        }
+        return prev;
+      }, {} as { [k: string]: boolean });
+      if (duplicates.length) {
+        throw new Error(
+          `The plugin key cannot be duplicated. (${duplicates.join(', ')})`,
+        );
+      }
+    }
+
+    const validKeys = await api.applyPlugins({
+      key: 'addRuntimePluginKey',
+      initialValue: [
+        'patchRoutes',
+        'patchClientRoutes',
+        'modifyContextOpts',
+        'modifyClientRenderOpts',
+        'rootContainer',
+        'innerProvider',
+        'i18nProvider',
+        'accessProvider',
+        'dataflowProvider',
+        'outerProvider',
+        'render',
+        'onRouteChange',
+      ],
+    });
+
+    checkDuplicatePluginKeys(validKeys);
+
     const appPluginRegExp = /(\/|\\)app.(ts|tsx|jsx|js)$/;
     api.writeTmpFile({
       noPluginDir: true,

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -433,7 +433,7 @@ if (process.env.NODE_ENV === 'development') {
 
     function checkDuplicatePluginKeys(arr: string[]) {
       const duplicates: string[] = [];
-      arr.reduce<{ [k: string]: boolean }>((prev, curr) => {
+      arr.reduce<Record<string, boolean>>((prev, curr) => {
         if (prev[curr]) {
           duplicates.push(curr);
         } else {

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -433,14 +433,14 @@ if (process.env.NODE_ENV === 'development') {
 
     function checkDuplicatePluginKeys(arr: string[]) {
       const duplicates: string[] = [];
-      arr.reduce((prev, curr) => {
+      arr.reduce<{ [k: string]: boolean }>((prev, curr) => {
         if (prev[curr]) {
           duplicates.push(curr);
         } else {
           prev[curr] = true;
         }
         return prev;
-      }, {} as { [k: string]: boolean });
+      }, {});
       if (duplicates.length) {
         throw new Error(
           `The plugin key cannot be duplicated. (${duplicates.join(', ')})`,

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -430,23 +430,27 @@ if (process.env.NODE_ENV === 'development') {
       key: 'addRuntimePlugin',
       initialValue: [api.appData.appJS?.path].filter(Boolean),
     });
-    const validKeys = await api.applyPlugins({
-      key: 'addRuntimePluginKey',
-      initialValue: [
-        'patchRoutes',
-        'patchClientRoutes',
-        'modifyContextOpts',
-        'modifyClientRenderOpts',
-        'rootContainer',
-        'innerProvider',
-        'i18nProvider',
-        'accessProvider',
-        'dataflowProvider',
-        'outerProvider',
-        'render',
-        'onRouteChange',
-      ],
-    });
+    const validKeys = [
+      ...new Set(
+        await api.applyPlugins({
+          key: 'addRuntimePluginKey',
+          initialValue: [
+            'patchRoutes',
+            'patchClientRoutes',
+            'modifyContextOpts',
+            'modifyClientRenderOpts',
+            'rootContainer',
+            'innerProvider',
+            'i18nProvider',
+            'accessProvider',
+            'dataflowProvider',
+            'outerProvider',
+            'render',
+            'onRouteChange'
+          ]
+        })
+      )
+    ];
     const appPluginRegExp = /(\/|\\)app.(ts|tsx|jsx|js)$/;
     api.writeTmpFile({
       noPluginDir: true,


### PR DESCRIPTION
基于某些特殊场景我需要通过插件执行`addRuntimePluginKey`，处于umi限制我无法知道哪些key已经被添加，所以我可能会重复add，但最终产物中会产生重复的`key`，例如两个`layout`、两个`qiankun`等等，所以我想它需要被去重。