### PR TITLE
fix(bundler-webpack): Fix hmr failure caused by exporting clientLoader or routeProps from routing components

### DIFF
--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -28,7 +28,6 @@
     "test": "umi-scripts jest-turbo"
   },
   "dependencies": {
-    "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
     "@svgr/core": "6.5.1",
     "@svgr/plugin-jsx": "^6.5.1",
     "@svgr/plugin-svgo": "^6.5.1",
@@ -37,6 +36,7 @@
     "@umijs/bundler-utils": "workspace:*",
     "@umijs/case-sensitive-paths-webpack-plugin": "^1.0.1",
     "@umijs/mfsu": "workspace:*",
+    "@umijs/react-refresh-webpack-plugin": "0.5.11",
     "@umijs/utils": "workspace:*",
     "cors": "^2.8.5",
     "css-loader": "6.7.1",

--- a/packages/bundler-webpack/src/config/fastRefreshPlugin.ts
+++ b/packages/bundler-webpack/src/config/fastRefreshPlugin.ts
@@ -1,6 +1,6 @@
-// @ts-ignore
-import FastRefreshPlugin from '@pmmmwh/react-refresh-webpack-plugin/lib';
 import Config from '@umijs/bundler-webpack/compiled/webpack-5-chain';
+// @ts-ignore
+import FastRefreshPlugin from '@umijs/react-refresh-webpack-plugin/lib';
 import { MFSU_NAME } from '../constants';
 import { Env, IConfig } from '../types';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1908,9 +1908,6 @@ importers:
 
   packages/bundler-webpack:
     dependencies:
-      '@pmmmwh/react-refresh-webpack-plugin':
-        specifier: 0.5.10
-        version: 0.5.10(react-refresh@0.14.0)(webpack@5.76.1)
       '@svgr/core':
         specifier: 6.5.1
         version: 6.5.1
@@ -1935,6 +1932,9 @@ importers:
       '@umijs/mfsu':
         specifier: workspace:*
         version: link:../mfsu
+      '@umijs/react-refresh-webpack-plugin':
+        specifier: 0.5.11
+        version: 0.5.11(react-refresh@0.14.0)(webpack@5.76.1)
       '@umijs/utils':
         specifier: workspace:*
         version: link:../utils
@@ -13263,7 +13263,7 @@ packages:
       playwright-core: 1.27.1
     dev: true
 
-  /@pmmmwh/react-refresh-webpack-plugin@0.5.10(react-refresh@0.14.0)(webpack@5.76.1):
+  /@pmmmwh/react-refresh-webpack-plugin@0.5.10(react-refresh@0.14.0):
     resolution: {integrity: sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==}
     engines: {node: '>= 10.13'}
     peerDependencies:
@@ -13301,7 +13301,7 @@ packages:
       react-refresh: 0.14.0
       schema-utils: 3.1.1
       source-map: 0.7.4
-      webpack: 5.76.1(@swc/core@1.3.67)(uglify-js@3.17.4)
+    dev: true
 
   /@pmmmwh/react-refresh-webpack-plugin@0.5.7:
     resolution: {integrity: sha512-bcKCAzF0DV2IIROp9ZHkRJa6O4jy7NlnHdWL3GmcUxYWNjLXkK5kfELELwEfSP5hXPfVL/qOGMAROuMQb9GG8Q==}
@@ -16313,7 +16313,7 @@ packages:
     resolution: {integrity: sha512-T+Kuxg5ujvQeLMZe9wNVjFU0kjQa5WzuJmi5pAvw840W+k2Z3NyyzbMFC2mS8UYxVoHdVrtmfLuR3Epe0TSOPg==}
     hasBin: true
     dependencies:
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.10(react-refresh@0.14.0)(webpack@5.76.1)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.10(react-refresh@0.14.0)
       '@svgr/core': 6.5.1
       '@svgr/plugin-jsx': 6.5.1(@svgr/core@6.5.1)
       '@svgr/plugin-svgo': 6.5.1(@svgr/core@6.5.1)
@@ -16351,7 +16351,7 @@ packages:
     resolution: {integrity: sha512-T+Kuxg5ujvQeLMZe9wNVjFU0kjQa5WzuJmi5pAvw840W+k2Z3NyyzbMFC2mS8UYxVoHdVrtmfLuR3Epe0TSOPg==}
     hasBin: true
     dependencies:
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.10(react-refresh@0.14.0)(webpack@5.76.1)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.10(react-refresh@0.14.0)
       '@svgr/core': 6.5.1
       '@svgr/plugin-jsx': 6.5.1(@svgr/core@6.5.1)
       '@svgr/plugin-svgo': 6.5.1(@svgr/core@6.5.1)
@@ -16954,6 +16954,47 @@ packages:
       - webpack-hot-middleware
       - webpack-plugin-serve
     dev: true
+
+  /@umijs/react-refresh-webpack-plugin@0.5.11(react-refresh@0.14.0)(webpack@5.76.1):
+    resolution: {integrity: sha512-RtFvB+/GmjRhpHcqNgnw8iWZpTlxOnmNxi8eDcecxMmxmSgeDj25LV0jr4Q6rOhv3GTIfVGBhkwz+khGT5tfmg==}
+    engines: {node: '>= 10.13'}
+    peerDependencies:
+      '@types/webpack': 4.x || 5.x
+      react-refresh: '>=0.10.0 <1.0.0'
+      sockjs-client: ^1.4.0
+      type-fest: '>=0.17.0 <5.0.0'
+      webpack: '>=4.43.0 <6.0.0'
+      webpack-dev-server: 3.x || 4.x
+      webpack-hot-middleware: 2.x
+      webpack-plugin-serve: 0.x || 1.x
+    peerDependenciesMeta:
+      '@types/webpack':
+        optional: true
+      sockjs-client:
+        optional: true
+      type-fest:
+        optional: true
+      webpack:
+        optional: true
+      webpack-dev-server:
+        optional: true
+      webpack-hot-middleware:
+        optional: true
+      webpack-plugin-serve:
+        optional: true
+    dependencies:
+      ansi-html-community: 0.0.8
+      common-path-prefix: 3.0.0
+      core-js-pure: 3.29.0
+      error-stack-parser: 2.1.4
+      find-up: 5.0.0
+      html-entities: 2.3.3
+      loader-utils: 2.0.4
+      react-refresh: 0.14.0
+      schema-utils: 3.1.1
+      source-map: 0.7.4
+      webpack: 5.76.1(@swc/core@1.3.67)(uglify-js@3.17.4)
+    dev: false
 
   /@umijs/renderer-react@4.0.0-canary.20220628.2(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-tBZhIPo9s87KlX1FUuVPk4/XYKHe7uqAvtDlK3HVncvkMPoLmt0A730vF8xTN0AMscNT7x+YYETxtNG8muCmMQ==}


### PR DESCRIPTION
参考 ice 的实现 https://github.com/alibaba/ice/pull/6442 修复路由组件导出 clientLoader 或者 routeProps 时 react 组件热更新失效导致的应用级别刷新