### PR TITLE
fix: add layout file when collect ssr loader

### DIFF
--- a/packages/preset-umi/src/features/tmpFiles/__snapshots__/routes.test.ts.snap
+++ b/packages/preset-umi/src/features/tmpFiles/__snapshots__/routes.test.ts.snap
@@ -57,8 +57,6 @@ exports[`getRoutes 1`] = `
     "path": "/absolute",
   },
   "@@/global-layout": {
-    "__content": "",
-    "__isJSFile": true,
     "absPath": "/",
     "file": "@/layouts/index.tsx",
     "id": "@@/global-layout",

--- a/packages/preset-umi/src/features/tmpFiles/__snapshots__/routes.test.ts.snap
+++ b/packages/preset-umi/src/features/tmpFiles/__snapshots__/routes.test.ts.snap
@@ -57,6 +57,8 @@ exports[`getRoutes 1`] = `
     "path": "/absolute",
   },
   "@@/global-layout": {
+    "__content": "",
+    "__isJSFile": true,
     "absPath": "/",
     "file": "@/layouts/index.tsx",
     "id": "@@/global-layout",

--- a/packages/preset-umi/src/features/tmpFiles/routes.ts
+++ b/packages/preset-umi/src/features/tmpFiles/routes.ts
@@ -144,9 +144,12 @@ export async function getRoutes(opts: {
       }
 
       const isJSFile = /.[jt]sx?$/.test(file);
-      routes[id].__content = readFileSync(file, 'utf-8');
+      // layout route 这里不需要这些属性
+      if (!routes[id].isLayout) {
+        routes[id].__content = readFileSync(file, 'utf-8');
+        routes[id].__isJSFile = isJSFile;
+      }
       routes[id].__absFile = winPath(file);
-      routes[id].__isJSFile = isJSFile;
 
       const enableSSR = opts.api.config.ssr;
       const enableClientLoader = opts.api.config.clientLoader;


### PR DESCRIPTION
### Background
解决在收集 ssr 路由相关信息时遗漏 layout 文件的问题
目前在编译时收集路由 serverLoader 时只包含了页面文件，layout 文件也需要支持配置 serverLoader、clientLoader
### Solution
- 改变收集数据的位置，调整到 add layout 之后执行