### PR TITLE
fix: using tsx loader to parse jsx files

### DIFF
--- a/packages/bundler-utils/src/index.ts
+++ b/packages/bundler-utils/src/index.ts
@@ -1,7 +1,6 @@
 import { importLazy, logger, winPath } from '@umijs/utils';
-import { extname } from 'path';
 import { init, parse } from '../compiled/es-module-lexer';
-import { Loader, transformSync } from '../compiled/esbuild';
+import { transformSync } from '../compiled/esbuild';
 
 const babelCodeFrame: typeof import('../compiled/babel/code-frame') =
   importLazy(require.resolve('../compiled/babel/code-frame'));
@@ -17,7 +16,7 @@ export function parseModuleSync(opts: { content: string; path: string }) {
   if (opts.path.endsWith('.tsx') || opts.path.endsWith('.jsx')) {
     try {
       content = transformSync(content, {
-        loader: extname(opts.path).slice(1) as Loader,
+        loader: 'tsx',
         format: 'esm',
       }).code;
     } catch (e) {


### PR DESCRIPTION
fix https://github.com/umijs/umi/discussions/11646#discussioncomment-7054052 

当 jsx 文件中使用了装饰器，我们应该还使用 tsx loader 去解析他，因为 esbuild transform 不支持在 js 里用装饰器（最新版除外，因为从 [v0.18.5](https://github.com/evanw/esbuild/releases/tag/v0.18.5) 开始已经支持了 ecma 新版 deco ）
