### PR TITLE
feat: ✨ support testing esm only pkg

### DIFF
--- a/examples/test-test/esm_only_pkg/main.js
+++ b/examples/test-test/esm_only_pkg/main.js
@@ -1,0 +1,2 @@
+export default "in_esm_only_pkg";
+

--- a/examples/test-test/esm_only_pkg/package.json
+++ b/examples/test-test/esm_only_pkg/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "esm_only_pkg",
+  "version": "1.0.0",
+  "module": "main.js",
+  "dependencies": {}
+}

--- a/examples/test-test/foo.test.ts
+++ b/examples/test-test/foo.test.ts
@@ -21,6 +21,7 @@ test('class', () => {
       return 'foo';
     }
   }
+
   const a = new A();
   expect(a.foo()).toEqual('foo');
 });

--- a/examples/test-test/importEsmOnlyPackage.test.ts
+++ b/examples/test-test/importEsmOnlyPackage.test.ts
@@ -1,0 +1,6 @@
+// @ts-ignore
+import x from './esm_only_pkg';
+
+test('import from esm only pkg', () => {
+  expect(x).toEqual('in_esm_only_pkg');
+});

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -85,6 +85,7 @@ export function createConfig(opts?: {
       '<rootDir>/packages/.+/fixtures',
     ],
     setupFiles: [require.resolve('../setupFiles/shim')],
+    resolver: require.resolve('./resolver.js'),
   };
   if (opts?.target === 'browser') {
     config.testEnvironment = 'jsdom';

--- a/packages/testing/src/resolver.js
+++ b/packages/testing/src/resolver.js
@@ -1,0 +1,17 @@
+/*
+* reference: https://jestjs.io/docs/configuration#resolver-string
+*
+* */
+module.exports = (path, options) => {
+  // Call the defaultResolver, so we leverage its cache, error handling, etc.
+  return options.defaultResolver(path, {
+    ...options,
+    // Use packageFilter to process parsed `package.json` before the resolution (see https://www.npmjs.com/package/resolve#resolveid-opts-cb)
+    packageFilter: pkg => {
+      return {
+        ...pkg,
+        main: pkg.main || pkg.module,
+      };
+    },
+  });
+};


### PR DESCRIPTION
默认支持解析只有 `module` 字段的 npm 包。

避免内部测试组件库引起的 “明明包已经安装 但是  cant resolve“  的答疑。