### PR TITLE
feat(bundler-webpack): css support config cssPublicPath

### DIFF
--- a/docs/docs/docs/api/config.md
+++ b/docs/docs/docs/api/config.md
@@ -381,6 +381,12 @@ crossorigin: {}
 - [cssnano 参考](https://cssnano.co/docs/config-file/)
 - [parcelCSS 参考](https://github.com/parcel-bundler/parcel-css/blob/master/node/index.d.ts)
 
+## cssPublicPath
+- 类型：`String`
+- 默认值：`./`
+
+为 CSS 中的图片、文件等外部资源指定自定义公共路径。作用类似于 `publicPath` 默认值是 `./`
+
 ## cssLoader
 
 - 类型：`object`

--- a/docs/docs/docs/api/config.md
+++ b/docs/docs/docs/api/config.md
@@ -385,7 +385,7 @@ crossorigin: {}
 - 类型：`String`
 - 默认值：`./`
 
-为 CSS 中的图片、文件等外部资源指定自定义公共路径。作用类似于 `publicPath` 默认值是 `./`
+为 CSS 中的图片、文件等外部资源指定自定义公共路径。作用类似于 `publicPath` 默认值是 `./`。
 
 ## cssLoader
 

--- a/packages/bundler-webpack/src/config/cssRules.ts
+++ b/packages/bundler-webpack/src/config/cssRules.ts
@@ -43,6 +43,8 @@ export async function addCSSRules(opts: IOpts) {
     },
   ];
 
+  const cssPublicPath = userConfig.cssPublicPath || './';
+
   for (const { name, test, loader, loaderOptions } of rulesConfig) {
     const rule = config.module.rule(name);
     const nestRulesConfig = [
@@ -76,7 +78,7 @@ export async function addCSSRules(opts: IOpts) {
             ),
           )
           .options({
-            publicPath: './',
+            publicPath: cssPublicPath,
             emit: true,
             esModule: true,
           });

--- a/packages/bundler-webpack/src/schema.ts
+++ b/packages/bundler-webpack/src/schema.ts
@@ -59,6 +59,7 @@ export function getSchemas(): Record<string, (arg: { zod: typeof z }) => any> {
         CSSMinifier.none,
       ]),
     cssMinifierOptions: ({ zod }) => zod.record(zod.string(), zod.any()),
+    cssPublicPath: ({ zod }) => zod.string(),
     deadCode: ({ zod }) =>
       zod
         .object({


### PR DESCRIPTION
一些业务 会配置静态资源目录 比如
```ts
 config.output
      .filename(`js/[name].[contenthash:8].js`)
      .chunkFilename('js/[name].[contenthash:8].async.js');

if (!api.config.styleLoader) {
  config.plugin('mini-css-extract-plugin').tap(([options]) => {
    return [
      {
        ...options,
        filename: 'css/[name].[contenthash:8].css',
        chunkFilename: 'css/[name].[contenthash:8].chunk.css',
        ignoreOrder: true,
      },
    ];
  });
}
```
这时  `publicPath` 默认是 `./` 时资源访问会有问题、 通过 chainWebpack 手动改的成本较高. 参考 vue-cli  新增了 `cssPublicPath` 允许自定义