### PR TITLE
fix(preset-umi): overrides not works for body selector

### DIFF
--- a/packages/preset-umi/src/features/overrides/overrides.ts
+++ b/packages/preset-umi/src/features/overrides/overrides.ts
@@ -32,8 +32,8 @@ export default (api: IApi) => {
                 // special :first-child to promote html selector priority
                 return `html:first-child`;
               } else if (/^body([\s+~>[:]|$)/.test(selector)) {
-                // use :root parent to promote body selector priority
-                return `:root ${selector}`;
+                // use html parent to promote body selector priority
+                return `html ${selector}`;
               }
 
               return prefixedSelector;


### PR DESCRIPTION
修复 `overrides.less` 中的 `body` 选择器无法自动提升权重的问题

之前的写法有误，以为 `* + xx` 可以提升权重，但由于 `*` 本身权重为 0，所以 `* + body` 和 `body` 的权重是一样的，无法实现提升权重的目的

为什么不用 `:root`？因为 `:root` 只支持 Edge，考虑到还是有 Umi 项目需要开启 legacy 配置项兼容 IE，所以用了 html