### PR TITLE
SSR适配ER render

### DIFF
--- a/packages/preset-umi/src/features/ssr/ssr.ts
+++ b/packages/preset-umi/src/features/ssr/ssr.ts
@@ -134,8 +134,9 @@ export function useServerInsertedHTML(callback: () => React.ReactNode): void {
       writeFileSync(
         join(api.cwd, 'api/umi.server.js'),
         `
+const manifest = require('../server/build-manifest.json');
 export default function handler(request, response) {
-  require('../server/umi.server.js').default(request, response);
+    require(manifest.assets["umi.js"]).default(request, response);
 }
       `.trimStart(),
         'utf-8',

--- a/packages/preset-umi/src/features/ssr/utils.ts
+++ b/packages/preset-umi/src/features/ssr/utils.ts
@@ -1,4 +1,5 @@
 import { join } from 'path';
+import { existsSync } from 'fs';
 import { IApi } from '../../types';
 
 /** esbuild plugin for resolving umi imports */
@@ -21,6 +22,13 @@ export function absServerBuildPath(api: IApi) {
     return join(api.paths.absTmpPath, 'server/umi.server.js');
   }
   const manifestPath = join(api.paths.cwd, 'server', 'build-manifest.json');
+  if (api.userConfig.ssr.serverBuildPath || !existsSync(manifestPath)) {
+    return join(
+      api.paths.cwd,
+      api.userConfig.ssr.serverBuildPath || 'server/umi.server.js',
+    );
+  }
+
   const manifest = require(manifestPath);
   return join(api.paths.cwd, 'server', manifest.assets['umi.js'])
 }

--- a/packages/preset-umi/src/features/ssr/utils.ts
+++ b/packages/preset-umi/src/features/ssr/utils.ts
@@ -20,8 +20,7 @@ export function absServerBuildPath(api: IApi) {
   if (api.env === 'development') {
     return join(api.paths.absTmpPath, 'server/umi.server.js');
   }
-  return join(
-    api.paths.cwd,
-    api.userConfig.ssr.serverBuildPath || 'server/umi.server.js',
-  );
+  const manifestPath = join(api.paths.cwd, 'server', 'build-manifest.json');
+  const manifest = require(manifestPath);
+  return join(api.paths.cwd, 'server', manifest.assets['umi.js'])
 }

--- a/packages/preset-umi/src/features/ssr/webpack/webpack.ts
+++ b/packages/preset-umi/src/features/ssr/webpack/webpack.ts
@@ -12,8 +12,8 @@ export const build = async (api: IApi, opts: any) => {
   const bundlerOpts: any = lodash.cloneDeep(opts);
   const oChainWebpack = bundlerOpts.chainWebpack;
   const isDev = opts.env === Env.development;
-  const { userConfig } = opts;
-  const useHash = (opts.hash || (userConfig.hash && !isDev));
+  const { userConfig, config } = opts;
+  const useHash = (config.hash || (userConfig?.hash && !isDev));
   // disable deadCode check
   delete bundlerOpts.config.deadCode;
 

--- a/packages/preset-umi/src/features/ssr/webpack/webpack.ts
+++ b/packages/preset-umi/src/features/ssr/webpack/webpack.ts
@@ -4,13 +4,16 @@ import { lodash, logger } from '@umijs/utils';
 import { dirname, resolve } from 'path';
 import { IApi } from '../../../types';
 import { absServerBuildPath } from '../utils';
+import { Env } from "@umijs/bundler-webpack/dist/types";
 
 export const build = async (api: IApi, opts: any) => {
   logger.wait('[SSR] Compiling...');
   const now = new Date().getTime();
   const bundlerOpts: any = lodash.cloneDeep(opts);
   const oChainWebpack = bundlerOpts.chainWebpack;
-
+  const isDev = opts.env === Env.development;
+  const { userConfig } = opts;
+  const useHash = (opts.hash || (userConfig.hash && !isDev));
   // disable deadCode check
   delete bundlerOpts.config.deadCode;
 
@@ -45,8 +48,8 @@ export const build = async (api: IApi, opts: any) => {
 
     memo.output
       .path(dirname(absOutputFile))
-      .filename('[name].[hash:8].server.js')
-      .chunkFilename('[name].server.js')
+      .filename(useHash ? '[name].[contenthash:8].server.js' : 'umi.server.js')
+      .chunkFilename(useHash ? '[name].[contenthash:8].server.js' : '[name].server.js')
       .libraryTarget('commonjs2');
 
     // remove useless progress plugin

--- a/packages/preset-umi/src/features/ssr/webpack/webpack.ts
+++ b/packages/preset-umi/src/features/ssr/webpack/webpack.ts
@@ -48,8 +48,8 @@ export const build = async (api: IApi, opts: any) => {
 
     memo.output
       .path(dirname(absOutputFile))
-      .filename(useHash ? '[name].[contenthash:8].server.js' : 'umi.server.js')
-      .chunkFilename(useHash ? '[name].[contenthash:8].server.js' : '[name].server.js')
+      .filename(useHash ? 'umi.[contenthash:8].server.js' : 'umi.server.js')
+      .chunkFilename(useHash ? 'umi.[contenthash:8].server.js' : 'umi.server.js')
       .libraryTarget('commonjs2');
 
     // remove useless progress plugin

--- a/packages/preset-umi/src/features/ssr/webpack/webpack.ts
+++ b/packages/preset-umi/src/features/ssr/webpack/webpack.ts
@@ -45,7 +45,7 @@ export const build = async (api: IApi, opts: any) => {
 
     memo.output
       .path(dirname(absOutputFile))
-      .filename('umi.server.js')
+      .filename('[name].[hash:8].server.js')
       .chunkFilename('[name].server.js')
       .libraryTarget('commonjs2');
 

--- a/packages/preset-umi/templates/server.tpl
+++ b/packages/preset-umi/templates/server.tpl
@@ -27,7 +27,9 @@ export function getValidKeys() {
 }
 
 export function getManifest() {
-  return JSON.parse(require('fs').readFileSync('{{{ assetsPath }}}', 'utf-8'));
+  return JSON.parse(require('fs').readFileSync(
+  process.env.UNIO_RESOURCE_DIR ? process.env.UNIO_RESOURCE_DIR + '/build-manifest.json' :
+  '{{{ assetsPath }}}', 'utf-8'));
 }
 
 export function createHistory(opts) {

--- a/packages/preset-umi/templates/server.tpl
+++ b/packages/preset-umi/templates/server.tpl
@@ -4,7 +4,7 @@ import { createHistory as createClientHistory } from './core/history';
 import { getPlugins as getClientPlugins } from './core/plugin';
 import { ServerInsertedHTMLContext } from './core/serverInsertedHTMLContext';
 import { PluginManager } from '{{{ umiPluginPath }}}';
-import createRequestHandler, { createMarkupGenerator, createUnioHandler, createUnioSeaverLoader } from '{{{ umiServerPath }}}';
+import createRequestHandler, { createMarkupGenerator, createUmiHandler, createUmiServerLoader } from '{{{ umiServerPath }}}';
 
 let helmetContext;
 
@@ -54,8 +54,8 @@ const createOpts = {
   ServerInsertedHTMLContext,
 };
 const requestHandler = createRequestHandler(createOpts);
-const unioHandler = createUnioHandler(createOpts);
-const unioSeaverLoader = createUnioSeaverLoader(createOpts);
+export const renderRoot = createUmiHandler(createOpts);
+export const serverLoader = createUmiServerLoader(createOpts);
 
 export const _markupGenerator = createMarkupGenerator(createOpts);
 

--- a/packages/preset-umi/templates/server.tpl
+++ b/packages/preset-umi/templates/server.tpl
@@ -4,7 +4,7 @@ import { createHistory as createClientHistory } from './core/history';
 import { getPlugins as getClientPlugins } from './core/plugin';
 import { ServerInsertedHTMLContext } from './core/serverInsertedHTMLContext';
 import { PluginManager } from '{{{ umiPluginPath }}}';
-import createRequestHandler, { createMarkupGenerator } from '{{{ umiServerPath }}}';
+import createRequestHandler, { createMarkupGenerator, createUnioHandler, createUnioSeaverLoader } from '{{{ umiServerPath }}}';
 
 let helmetContext;
 
@@ -54,6 +54,8 @@ const createOpts = {
   ServerInsertedHTMLContext,
 };
 const requestHandler = createRequestHandler(createOpts);
+const unioHandler = createUnioHandler(createOpts);
+const unioSeaverLoader = createUnioSeaverLoader(createOpts);
 
 export const _markupGenerator = createMarkupGenerator(createOpts);
 

--- a/packages/preset-umi/templates/server.tpl
+++ b/packages/preset-umi/templates/server.tpl
@@ -28,7 +28,7 @@ export function getValidKeys() {
 
 export function getManifest() {
   return JSON.parse(require('fs').readFileSync(
-  process.env.UNIO_RESOURCE_DIR ? process.env.UNIO_RESOURCE_DIR + '/build-manifest.json' :
+  process.env.SSR_RESOURCE_DIR ? process.env.SSR_RESOURCE_DIR + '/build-manifest.json' :
   '{{{ assetsPath }}}', 'utf-8'));
 }
 

--- a/packages/renderer-react/src/server.tsx
+++ b/packages/renderer-react/src/server.tsx
@@ -13,6 +13,7 @@ export async function getClientRootComponent(opts: {
   location: string;
   loaderData: { [routeKey: string]: any };
   manifest: any;
+  withoutHTML?: boolean;
 }) {
   const basename = '/';
   const components = { ...opts.routeComponents };
@@ -41,21 +42,25 @@ export async function getClientRootComponent(opts: {
       args: {},
     });
   }
+  const app = (
+    <AppContext.Provider
+      value={{
+        routes: opts.routes,
+        routeComponents: opts.routeComponents,
+        clientRoutes,
+        pluginManager: opts.pluginManager,
+        basename,
+        clientLoaderData: {},
+        serverLoaderData: opts.loaderData,
+      }}
+    >
+      {rootContainer}
+    </AppContext.Provider>
+  );
+  if (opts.withoutHTML) return app;
   return (
     <Html loaderData={opts.loaderData} manifest={opts.manifest}>
-      <AppContext.Provider
-        value={{
-          routes: opts.routes,
-          routeComponents: opts.routeComponents,
-          clientRoutes,
-          pluginManager: opts.pluginManager,
-          basename,
-          clientLoaderData: {},
-          serverLoaderData: opts.loaderData,
-        }}
-      >
-        {rootContainer}
-      </AppContext.Provider>
+      {app}
     </Html>
   );
 }

--- a/packages/renderer-react/src/server.tsx
+++ b/packages/renderer-react/src/server.tsx
@@ -57,7 +57,9 @@ export async function getClientRootComponent(opts: {
       {rootContainer}
     </AppContext.Provider>
   );
-  if (opts.withoutHTML) return app;
+  if (opts.withoutHTML) {
+    return app;
+  }
   return (
     <Html loaderData={opts.loaderData} manifest={opts.manifest}>
       {app}

--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -245,7 +245,7 @@ export function createUmiHandler(
       const jsx = await jsxGeneratorDeferrer(new URL(req.url).pathname);
 
       if (!jsx) {
-        reject(new Error('jsx is null'));
+        reject(new Error('找不到资源'));
         return;
       }
 

--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -277,9 +277,10 @@ export function createUnioSeaverLoader(
   opts: CreateRequestHandlerOptions,
 ) {
   return async function (req: any) {
+    const query = Object.fromEntries(new URL(req.url).searchParams)
     // 切换路由场景下，会通过此 API 执行 server loader
     const data = await executeLoader(
-      req.query.route,
+      query.route,
       opts.routesWithServerLoader,
     );
     return Readable.from(JSON.stringify(data), {encoding: 'utf8'})

--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import * as ReactDomServer from 'react-dom/server';
 import { matchRoutes } from 'react-router-dom';
-import { Writable, Readable } from 'stream';
+import { Readable, Writable } from 'stream';
 import type { IRoutesById } from './types';
 
 interface RouteLoaders {
@@ -23,6 +23,7 @@ interface CreateRequestHandlerOptions {
   createHistory: (opts: any) => any;
   helmetContext?: any;
   ServerInsertedHTMLContext: React.Context<ServerInsertedHTMLHook | null>;
+  withoutHTML?: boolean;
 }
 
 const createJSXProvider = (
@@ -102,6 +103,7 @@ function createJSXGenerator(opts: CreateRequestHandlerOptions) {
       location: url,
       manifest,
       loaderData,
+      withoutHTML: opts.withoutHTML,
     };
 
     const element = (await opts.getClientRootComponent(
@@ -235,10 +237,11 @@ export default function createRequestHandler(
   };
 }
 
-export function createUmiHandler(
-  opts: CreateRequestHandlerOptions,
-) {
-  const jsxGeneratorDeferrer = createJSXGenerator(opts);
+export function createUmiHandler(opts: CreateRequestHandlerOptions) {
+  const jsxGeneratorDeferrer = createJSXGenerator({
+    ...opts,
+    withoutHTML: true,
+  });
 
   return function (req: Request) {
     return new Promise(async (resolve, reject) => {
@@ -249,7 +252,7 @@ export function createUmiHandler(
         return;
       }
 
-      let buf = Buffer.alloc(0)
+      let buf = Buffer.alloc(0);
       const writable = new Writable();
 
       writable._write = (chunk, _encoding, next) => {
@@ -258,7 +261,7 @@ export function createUmiHandler(
       };
 
       writable.on('finish', async () => {
-        resolve(Readable.from(buf))
+        resolve(Readable.from(buf));
       });
 
       const stream = await ReactDomServer.renderToPipeableStream(jsx.element, {
@@ -270,20 +273,15 @@ export function createUmiHandler(
           reject(err);
         },
       });
-    })
+    });
   };
 }
 
-export function createUmiServerLoader(
-  opts: CreateRequestHandlerOptions,
-) {
+export function createUmiServerLoader(opts: CreateRequestHandlerOptions) {
   return async function (req: Request) {
-    const query = Object.fromEntries(new URL(req.url).searchParams)
+    const query = Object.fromEntries(new URL(req.url).searchParams);
     // 切换路由场景下，会通过此 API 执行 server loader
-    return await executeLoader(
-      query.route,
-      opts.routesWithServerLoader,
-    );
+    return await executeLoader(query.route, opts.routesWithServerLoader);
   };
 }
 

--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -252,27 +252,13 @@ export function createUmiHandler(opts: CreateRequestHandlerOptions) {
         return;
       }
 
-      let buf = Buffer.alloc(0);
-      const writable = new Writable();
-
-      writable._write = (chunk, _encoding, next) => {
-        buf = Buffer.concat([buf, chunk]);
-        next();
-      };
-
-      writable.on('finish', async () => {
-        resolve(Readable.from(buf));
-      });
-
-      const stream = await ReactDomServer.renderToPipeableStream(jsx.element, {
+      const stream = await ReactDomServer.renderToReadableStream(jsx.element, {
         bootstrapScripts: [jsx.manifest.assets['umi.js'] || '/umi.js'],
-        onShellReady() {
-          stream.pipe(writable);
-        },
         onError(err: any) {
           reject(err);
         },
       });
+      resolve(stream);
     });
   };
 }

--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -245,7 +245,7 @@ export function createUmiHandler(
       const jsx = await jsxGeneratorDeferrer(new URL(req.url).pathname);
 
       if (!jsx) {
-        reject(new Error('找不到资源'));
+        reject(new Error('no page resource'));
         return;
       }
 

--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import * as ReactDomServer from 'react-dom/server';
 import { matchRoutes } from 'react-router-dom';
-import { Readable, Writable } from 'stream';
+import { Writable } from 'stream';
 import type { IRoutesById } from './types';
 
 interface RouteLoaders {


### PR DESCRIPTION
- createUmiHandler只返回根节点的内容，不要返回整个 html 的
- SSR输出的server.js路径带上hash
- server.js中的build-manifest.json文件路径支持SSR_RESOURCE_DIR环境变量
- 返回流式response renderToPipeableStream，提升SSR首字节时间