### PR TITLE
refactor: handle rapid mode for tnpm and cnpm detection

### DIFF
--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -243,8 +243,10 @@ export async function getConfig(opts: IOpts): Promise<Configuration> {
     // 使用 immutablePaths 避免 node_modules 的内容被写入缓存
     // tnpm 安装的依赖路径中同时包含包名和版本号，满足 immutablePaths 使用的条件
     // 同时配置 managedPaths 将 tnpm 的软连接结构标记为可信，避免执行快照序列化时 OOM
-    // ref: smallfish
-    if (/*isTnpm*/ require('@umijs/utils/package').__npminstall_done) {
+    // 此处通过软链的目标文件夹名称来判断 node_modules 是否为 tnpm 的 npminstall 模式
+    // 因为 rapid 模式下 package.json 中没有 __npminstall_done 的标记
+    // ex. node_modules/_@umijs_utils@4.0.83@@umijs/utils/package.json
+    if (require.resolve('@umijs/utils/package').includes('_@umijs_utils@')) {
       const nodeModulesPath =
         opts.cache.absNodeModulesPath ||
         join(opts.rootDir || opts.cwd, 'node_modules');


### PR DESCRIPTION
检测 tnpm 和 cnpm 的相关逻辑支持 rapid 模式，主要有两处：
1. 设置 webpack 持久缓存 snapshot：将 tnpm 安装目录结构的判定从 `__npminstall_done` 标记改为软链的目标文件夹名称，以解决在 tnpm npminstall mode + rapid mode 时 snapshot 配置未设置导致缓存序列化 OOM 的问题
2. 判断 npmClient 的工具方法：将 `__npminstall_done` + `_resolved` 的判定组合改为 `_resolved` + `.package-lock.json` 的组合，以解决在 rapid 模式下没有 `__npminstall_done` 字段导致 npmClient 识别错误的问题

问题原因：和 tnpm 同学确认在 rapid 模式下使用 npminstall 模式安装，package.json 里不会有 `__npminstall_done` 和 `_resoved` 标记，而雨燕云构建环境默认是 rapid 模式

穷举情况：
- npminstall mode + native fs => generate _resolved field in package.json
- npminstall mode + rapid fs => generate .package-lock.json in node_modules
- npm mode + native fs => generate .package-lock.json in node_modules
- npm mode + rapid fs => generate .package-lock.json in node_modules

注1：为什么 Bigfish 4 的持久缓存可以正常工作，因为 Bigfish merge 了 tnpm 提供的 cache config，它也设置了一份 snapshot 正好补齐