### PR TITLE
refactor(preset-umi): make 3rd-party chunk name clean

### DIFF
--- a/packages/preset-umi/src/features/tmpFiles/routes.ts
+++ b/packages/preset-umi/src/features/tmpFiles/routes.ts
@@ -315,9 +315,15 @@ export function componentToChunkName(
           ),
           '',
         )
+        // 丢弃 .pnpm 下的多层 node_modules 避免 chunkName 过长
+        // ex. node_modules/.pnpm/dumi@2.1.19_xxxx/node_modules/dumi/dist/client/pages/404
+        .replace(/.+(node_modules(\/|\\))/, '$1')
+        // 丢弃 tnpm 目录下的软链结构避免 chunkName 过长
+        // ex. node_modules/_@umijs_utils@4.0.83@@umijs/utils/dist/index.js
+        .replace(/(\/|\\)_@?([^@]+@){2}/, '$1')
         .replace(/^.(\/|\\)/, '')
         .replace(/(\/|\\)/g, '__')
-        // 转换 tnpm node_modules 目录中的 @ 符号，它在 URL 上会被转义，可能导致 CDN 托管失败
+        // 转换 node_modules 目录中的 @ 符号，它在 URL 上会被转义，可能导致 CDN 托管失败
         .replace(/@/g, '_')
         .replace(/\.jsx?$/, '')
         .replace(/\.tsx?$/, '')


### PR DESCRIPTION
对路由表中引用 node_modules 下的路由组件 chunk name 做优化，主要处理 pnpm 和 tnpm 的文件结构，对比效果：

```bash
# pnpm 目录
# node_modules/.pnpm/dumi@2.1.19_xxxx/node_modules/dumi/dist/client/pages/404.js
# 改动前
nm__.pnpm__dumi_2.1.19_xxxx__node_modules__dumi__dist__client__pages__404

# 改动后
nm__dumi__dist__client__pages__404

# tnpm 目录
# node_modules/_@umijs_utils@4.0.83@@umijs/utils/dist/index.js
# 改动前
nm____umijs_utils_4.0.83__umijs__utils__dist__index

# 改动后
nm___umijs__utils__dist__index
```

问题背景：之前 dumi 为了解 chunk name 引起的 CDN 资源托管问题（包括但不限于 https://github.com/umijs/dumi/issues/1487 ），用 alias 实现了 chunk name 的优化（见 https://github.com/umijs/dumi/pull/1601 ），但这个实现的前提是 layouts 不会被 server loader 处理，因为 server loader 解析 route component 时不会处理 alias，在 https://github.com/umijs/umi/pull/11666 后 layouts 也会被 server loader 处理，导致 4.0.84 发布后 dumi 应用报错

解决方案：把 chunk name 的简化交给 Umi 来处理 + dumi 回滚之前的方案

为什么不让 server loader 对路由组件的解析支持 alias：加上 alias 的处理也会比较麻烦，需要使用 enhanced-resolve，需要把 getRoutes 变成 async，问题会被扩大