### PR TITLE
fix: fix styled-component displayname

### DIFF
--- a/packages/babel-preset-umi/src/index.ts
+++ b/packages/babel-preset-umi/src/index.ts
@@ -70,6 +70,9 @@ export default (_context: any, opts: IOpts) => {
       opts.pluginStyledComponents && [
         require.resolve('babel-plugin-styled-components'),
         {
+          // 该 plugin 会校验 styled 的来源
+          // 如果不是 `styled-components`, 需要手动引入后才能使 displayName 生效
+          topLevelImportPaths: ['@umijs/max'],
           ...opts.pluginStyledComponents,
         },
       ],


### PR DESCRIPTION
styled-components 中使用 `displayName` 来进行开发环境 class 优化时，加入了新的参数对引入 styled 的来源进行了控制：

https://github.com/styled-components/babel-plugin-styled-components/blob/main/src/utils/detectors.js#L14C8-L14C37

所以需要配置 `topLevelImportPaths` 参数后，`displayName` 参数才能生效。

`topLevelImportPaths` 参数在 styled-components 的文档中并未体现，所以放入默认配置比起放进文档中让用户自己配置更能减少用户心智负担