### PR TITLE
refactor(ssr): correct logic for get dist path

### DIFF
--- a/packages/preset-umi/src/features/ssr/utils.ts
+++ b/packages/preset-umi/src/features/ssr/utils.ts
@@ -1,5 +1,5 @@
-import { join } from 'path';
 import { existsSync } from 'fs';
+import { basename, join } from 'path';
 import { IApi } from '../../types';
 
 /** esbuild plugin for resolving umi imports */
@@ -29,6 +29,11 @@ export function absServerBuildPath(api: IApi) {
     );
   }
 
+  // server output path will not be removed before compile
+  // so remove require cache to avoid outdated asset path when enable hash
+  delete require.cache[manifestPath];
   const manifest = require(manifestPath);
-  return join(api.paths.cwd, 'server', manifest.assets['umi.js'])
+  // basename use to strip public path
+  // ex. /foo/umi.xxx.js -> umi.xxx.js
+  return join(api.paths.cwd, 'server', basename(manifest.assets['umi.js']));
 }


### PR DESCRIPTION
修复 server 产物路径添加 hash 后（关联 PR：#11698 ）引入的两个问题：
1. 配置 `publicPath` 时 server 产物路径获取错误的问题
2. 重复构建且 hash 不一致时 server 产物路径获取错误的问题