### PR TITLE
fix: 剔除srcTranspiler无用none枚举

### DIFF
--- a/docs/docs/docs/api/config.md
+++ b/docs/docs/docs/api/config.md
@@ -1384,7 +1384,7 @@ styles: [`body { color: red; }`, `https://a.com/b.css`],
 
 ## srcTranspiler
 
-- 类型：`string` 可选的值：`babel`, `swc`, `esbuild`, `none`
+- 类型：`string` 可选的值：`babel`, `swc`, `esbuild`
 - 默认值：`babel`
 
 配置构建时转译 js/ts 的工具。

--- a/packages/bundler-webpack/src/schema.ts
+++ b/packages/bundler-webpack/src/schema.ts
@@ -167,7 +167,6 @@ export function getSchemas(): Record<string, (arg: { zod: typeof z }) => any> {
         Transpiler.babel,
         Transpiler.esbuild,
         Transpiler.swc,
-        Transpiler.none,
       ]),
     srcTranspilerOptions: ({ zod }) =>
       zod


### PR DESCRIPTION
`config.srcTranspiler`中没有支持`none`，文档和类型中却显示可用。短时间可能也不会支持？https://github.com/umijs/umi/issues/11727