### PR TITLE
fix: mock OPTIONS

### DIFF
--- a/examples/create-umi-pro/cypress/e2e/smoke.cy.ts
+++ b/examples/create-umi-pro/cypress/e2e/smoke.cy.ts
@@ -23,9 +23,16 @@ describe('Basic Test', () => {
   });
 
   it('access ok', () => {
+    cy.intercept('OPTIONS', '/api/v1/queryUserList').as(
+      'queryUserListPermissionCheck',
+    );
+
     cy.visit('/access');
 
-    cy.get('button.ant-btn').contains('只有 Admin 可以看到这个按钮');
+    cy.get('button.btn-admin').contains('只有 Admin 可以看到这个按钮');
+    cy.wait('@queryUserListPermissionCheck', { timeout: 10000 })
+      .get('button.btn-options')
+      .contains('只有通过 OPTIONS 请求进行动态权限校验成功的可以看到这个按钮');
   });
 
   it('simple CRUD ok', () => {

--- a/examples/create-umi-pro/mock/userAPI.ts
+++ b/examples/create-umi-pro/mock/userAPI.ts
@@ -11,6 +11,12 @@ export default {
       errorCode: 0,
     });
   },
+  'OPTIONS /api/v1/queryUserList': (req: any, res: any) => {
+    res.json({
+      success: true,
+      errorCode: 0,
+    });
+  },
   'PUT /api/v1/user/': (req: any, res: any) => {
     res.json({
       success: true,

--- a/examples/create-umi-pro/src/pages/Access/index.tsx
+++ b/examples/create-umi-pro/src/pages/Access/index.tsx
@@ -1,9 +1,20 @@
+import { queryUserListPermissionCheck } from '@/services/demo/UserController';
 import { PageContainer } from '@ant-design/pro-components';
 import { Access, useAccess } from '@umijs/max';
-import { Button } from 'antd';
+import { Button, Typography } from 'antd';
+import { useEffect, useState } from 'react';
 
 const AccessPage: React.FC = () => {
   const access = useAccess();
+  const [hasQueryPermission, setHasQueryPermission] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const { success } = await queryUserListPermissionCheck();
+      setHasQueryPermission(success ?? false);
+    })();
+  }, []);
+
   return (
     <PageContainer
       ghost
@@ -11,9 +22,19 @@ const AccessPage: React.FC = () => {
         title: '权限示例',
       }}
     >
-      <Access accessible={access.canSeeAdmin}>
-        <Button>只有 Admin 可以看到这个按钮</Button>
-      </Access>
+      <Typography.Paragraph>
+        <Access accessible={access.canSeeAdmin}>
+          <Button className="btn-admin">只有 Admin 可以看到这个按钮</Button>
+        </Access>
+      </Typography.Paragraph>
+
+      <Typography.Paragraph>
+        <Access accessible={hasQueryPermission}>
+          <Button className="btn-options">
+            只有通过 OPTIONS 请求进行动态权限校验成功的可以看到这个按钮
+          </Button>
+        </Access>
+      </Typography.Paragraph>
     </PageContainer>
   );
 };

--- a/examples/create-umi-pro/src/services/demo/UserController.ts
+++ b/examples/create-umi-pro/src/services/demo/UserController.ts
@@ -24,6 +24,16 @@ export async function queryUserList(
   });
 }
 
+/** 此处后端没有提供注释 GET /api/v1/queryUserList */
+export async function queryUserListPermissionCheck(options?: {
+  [key: string]: any;
+}) {
+  return request<API.PermissionCheckResult>('/api/v1/queryUserList', {
+    method: 'OPTIONS',
+    ...(options || {}),
+  });
+}
+
 /** 此处后端没有提供注释 POST /api/v1/user */
 export async function addUser(
   body?: API.UserInfoVO,

--- a/examples/create-umi-pro/src/services/demo/typings.d.ts
+++ b/examples/create-umi-pro/src/services/demo/typings.d.ts
@@ -3,7 +3,7 @@
 
 declare namespace API {
   interface PageInfo {
-    /** 
+    /**
 1 */
     current?: number;
     pageSize?: number;
@@ -12,7 +12,7 @@ declare namespace API {
   }
 
   interface PageInfo_UserInfo_ {
-    /** 
+    /**
 1 */
     current?: number;
     pageSize?: number;
@@ -65,4 +65,9 @@ declare namespace API {
   }
 
   type definitions_0 = null;
+
+  interface PermissionCheckResult {
+    success?: boolean;
+    errorMessage?: string;
+  }
 }

--- a/packages/bundler-webpack/src/server/server.ts
+++ b/packages/bundler-webpack/src/server/server.ts
@@ -35,15 +35,6 @@ export async function createServer(opts: IOpts): Promise<any> {
   // 避免在 https 模式下时「Cannot access 'ws' before initialization」的报错
   let ws: ReturnType<typeof createWebSocketServer>;
 
-  // cros
-  app.use(
-    cors({
-      origin: true,
-      methods: ['GET', 'HEAD', 'PUT', 'POST', 'PATCH', 'DELETE', 'OPTIONS'],
-      credentials: true,
-    }),
-  );
-
   // compression
   app.use(require('@umijs/bundler-webpack/compiled/compression')());
 
@@ -71,6 +62,15 @@ export async function createServer(opts: IOpts): Promise<any> {
 
   // before middlewares
   (opts.beforeMiddlewares || []).forEach((m) => app.use(m));
+
+  // cros, need put after mock middleware
+  app.use(
+    cors({
+      origin: true,
+      methods: ['GET', 'HEAD', 'PUT', 'POST', 'PATCH', 'DELETE', 'OPTIONS'],
+      credentials: true,
+    }),
+  );
 
   // webpack dev middleware
   const configs = Array.isArray(webpackConfig)


### PR DESCRIPTION
The `cors` middleware intercepted all OPTIONS requests, causing the business mock OPTIONS interfaces to not take effect. 

The issue was resolved by placing the `cors` middleware after the business middlewares.
