### PR TITLE
revert: "fix(ssr): support ant design pro ssr (#11702)"

### DIFF
--- a/examples/ant-design-pro/config/config.ts
+++ b/examples/ant-design-pro/config/config.ts
@@ -313,15 +313,28 @@ export default defineConfig({
   mfsu: {
     // esbuild: true,
   },
-  chainWebpack(memo) {
+  chainWebpack(memo: any) {
     memo.plugin('monaco-editor').use(MonacoEditorWebpackPlugin, []);
     return memo;
   },
-  ssr: {
-    builder: 'webpack',
-    platform: 'node',
-  },
-  exportStatic: {},
+  // openAPI: [
+  //   {
+  //     requestLibPath: "import { request } from 'umi'",
+  //     // 或者使用在线的版本
+  //     // schemaPath: "https://gw.alipayobjects.com/os/antfincdn/M%24jrzTTYJN/oneapi.json"
+  //     schemaPath: join(__dirname, 'oneapi.json'),
+  //     mock: false,
+  //   },
+  //   {
+  //     requestLibPath: "import { request } from 'umi'",
+  //     schemaPath: 'https://gw.alipayobjects.com/os/antfincdn/CA1dOm%2631B/openapi.json',
+  //     projectName: 'swagger',
+  //   },
+  // ],
+  // nodeModulesTransform: {
+  //   type: 'none',
+  // },
+  // exportStatic: {},
   codeSplitting: {
     jsStrategy: 'granularChunks',
   },

--- a/packages/bundler-webpack/src/config/ssrPlugin.ts
+++ b/packages/bundler-webpack/src/config/ssrPlugin.ts
@@ -23,11 +23,9 @@ const PLUGIN_NAME = 'SSR_PLUGIN';
 class SSRPlugin {
   opts: IOpts;
   manifest: Map<string, string>;
-  isGenManifest: boolean;
   constructor(opts: IOpts) {
     this.opts = opts;
     this.manifest = new Map();
-    this.isGenManifest = false;
   }
   apply(compiler: Compiler) {
     // ref: https://github.com/webdeveric/webpack-assets-manifest
@@ -72,16 +70,13 @@ class SSRPlugin {
           2,
         );
         if (
-          (process.env.NODE_ENV === 'production' ||
-            this.opts.userConfig.writeToDisk) &&
-          !this.isGenManifest
+          process.env.NODE_ENV === 'production' ||
+          this.opts.userConfig.writeToDisk
         ) {
-          // 如果已经生成了,就不管了。不然会报错重复添加
           compilation.emitAsset(
             'build-manifest.json',
             new sources.RawSource(assetsSource, false),
           );
-          this.isGenManifest = true;
         } else {
           const outputPath = compiler.options.output.path!;
           fsExtra.mkdirpSync(outputPath);

--- a/packages/preset-umi/src/features/exportStatic/exportStatic.ts
+++ b/packages/preset-umi/src/features/exportStatic/exportStatic.ts
@@ -31,11 +31,10 @@ function getExportHtmlData(routes: Record<string, IRoute>): IExportHtmlItem[] {
     if (
       // skip layout
       !route.isLayout &&
-      route?.path &&
       // skip dynamic route for win, because `:` is not allowed in file name
-      (!IS_WIN || !route?.path?.includes('/:')) &&
+      (!IS_WIN || !route.path.includes('/:')) &&
       // skip `*` route, because `*` is not working for most site serve services
-      (!route?.path?.includes('*') ||
+      (!route.path.includes('*') ||
         // except `404.html`
         is404)
     ) {

--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -204,11 +204,11 @@ export function createMarkupGenerator(opts: CreateRequestHandlerOptions) {
             html = html.replace(
               /(<\/head>)/,
               [
-                opts.helmetContext.helmet?.title?.toString(),
-                opts.helmetContext.helmet?.priority?.toString(),
-                opts.helmetContext.helmet?.meta?.toString(),
-                opts.helmetContext.helmet?.link?.toString(),
-                opts.helmetContext.helmet?.script?.toString(),
+                opts.helmetContext.helmet.title.toString(),
+                opts.helmetContext.helmet.priority.toString(),
+                opts.helmetContext.helmet.meta.toString(),
+                opts.helmetContext.helmet.link.toString(),
+                opts.helmetContext.helmet.script.toString(),
                 '$1',
               ]
                 .filter(Boolean)


### PR DESCRIPTION
This reverts commit a8303837e2f33c8a82642b302ac57cf367af1bee.

先回退该 PR 的改动发版，回退原因：
1. `route.path` 的判定会影响 `index.html` 的生成，因为首页的 `route.path` 默认是 `''`
2. 了解到 1 的改动是为了解 `undefined.html` 的问题，但还没有复现该问题，需要找到真正原因，理论上 `route` 对象都应该有 `path`，在这里判定也许不是本质解
3. `helmetContext.helmet` 默认情况下是一定存在的，如果不存在说明 `HelmetProvider` 的注入存在问题，这里做 `?.` 只是避免报错但没有解决 ssr helmet 信息丢失的问题，在 pro 项目里可以复现该问题，但 dumi 同样用了 ssr + exportStatic 却工作正常，需要看下真正原因