### PR TITLE
feat: add useAntdConfig

### DIFF
--- a/docs/docs/docs/max/antd.md
+++ b/docs/docs/docs/max/antd.md
@@ -161,14 +161,16 @@ export const antd: RuntimeAntdConfig = (memo) => {
 };
 ```
 
-### 动态切换主题
+### 动态切换全局配置
 
 **注意：该功能仅 antd v5 可用**
 
-当存在主题相关的配置时开启
+通过 `useAntdConfig` / `useAntdConfigSetter` 方法来动态获取、修改 antd 的 `ConfigProvider` 配置，通常可用于动态修改主题。
+
+注：此功能需依赖 `ConfigProvider` ，请一并开启 `configProvider: {}` 。
 
 ```tsx
-import { Layout, Space, Button, version, theme } from 'antd';
+import { Layout, Space, Button, version, theme, MappingAlgorithm } from 'antd';
 import { useAntdConfig, useAntdConfigSetter } from 'umi';
 const { darkAlgorithm, defaultAlgorithm } = theme;
 
@@ -183,12 +185,23 @@ export default function Page() {
         <Switch
           checked={antdConfig?.theme?.algorithm.includes(darkAlgorithm)}
           onChange={(data) => {
+            // 此配置会与原配置深合并
             setAntdConfig({
               theme: {
                 algorithm: [
                   data ? darkAlgorithm : defaultAlgorithm,
                 ],
               },
+            });
+            // or 
+            setAntdConfig((config) => {
+              const algorithm = config.theme!.algorithm as MappingAlgorithm[];
+              if (algorithm.includes(darkAlgorithm)) {
+                config.theme!.algorithm = [defaultAlgorithm]
+              } else {
+                config.theme!.algorithm = [darkAlgorithm];
+              }
+              return config;
             });
           }}
         ></Switch>

--- a/docs/docs/docs/max/antd.md
+++ b/docs/docs/docs/max/antd.md
@@ -161,6 +161,45 @@ export const antd: RuntimeAntdConfig = (memo) => {
 };
 ```
 
+### 动态切换主题
+
+**注意：该功能仅 antd v5 可用**
+
+当存在主题相关的配置时开启
+
+```tsx
+import { Layout, Space, Button, version, theme } from 'antd';
+import { useAntdConfig, useAntdConfigSetter } from 'umi';
+const { darkAlgorithm, defaultAlgorithm } = theme;
+
+export default function Page() {
+  const setAntdConfig = useAntdConfigSetter();
+  const antdConfig = useAntdConfig();
+  return (
+    <Layout>
+      <h1>with antd@{version}</h1>
+      <Space>
+        isDarkTheme
+        <Switch
+          checked={antdConfig?.theme?.algorithm.includes(darkAlgorithm)}
+          onChange={(data) => {
+            setAntdConfig({
+              theme: {
+                algorithm: [
+                  data ? darkAlgorithm : defaultAlgorithm,
+                ],
+              },
+            });
+          }}
+        ></Switch>
+      </Space>
+    </Layout>
+  );
+}
+```
+
+使用 `setAntdConfig` 可以动态修改 [antd@5 ConfigProvider](https://ant.design/components/config-provider-cn) 组件支持的所有属性。
+
 ## FAQ
 
 ### 如何使用 antd 的其他版本？

--- a/examples/with-antd-5/app.ts
+++ b/examples/with-antd-5/app.ts
@@ -1,9 +1,12 @@
+import { theme } from 'antd';
 import { RuntimeAntdConfig } from 'umi';
 
 export const antd: RuntimeAntdConfig = (memo) => {
   memo.appConfig ??= {};
   memo.appConfig.message ??= {};
   memo.appConfig.message.duration = 5;
+
+  memo.theme!.algorithm = theme.darkAlgorithm;
 
   return memo;
 };

--- a/examples/with-antd-5/pages/index.tsx
+++ b/examples/with-antd-5/pages/index.tsx
@@ -22,6 +22,9 @@ const checkHasAlgorithm = (
   antdConfig: ConfigProviderProps,
   algorithm: MappingAlgorithm,
 ) => {
+  if (!antdConfig?.theme?.algorithm) {
+    return false;
+  }
   const nowAlgorithm = Array.isArray(antdConfig?.theme?.algorithm)
     ? antdConfig?.theme?.algorithm
     : [antdConfig?.theme?.algorithm];
@@ -55,6 +58,17 @@ export default function Page() {
   };
   const isDark = checkHasAlgorithm(antdConfig, darkAlgorithm);
   const isCompact = checkHasAlgorithm(antdConfig, compactAlgorithm);
+  const changeTheme = (theme: MappingAlgorithm) => {
+    setAntdConfig((config) => {
+      const algorithm = config.theme!.algorithm as MappingAlgorithm[];
+      if (algorithm.includes(theme)) {
+        config.theme!.algorithm = algorithm.filter((item) => item !== theme);
+      } else {
+        config.theme!.algorithm = [...algorithm, theme];
+      }
+      return config;
+    });
+  };
   return (
     <div
       style={{
@@ -83,15 +97,8 @@ export default function Page() {
         isDarkTheme
         <Switch
           checked={isDark}
-          onChange={(data) => {
-            setAntdConfig({
-              theme: {
-                algorithm: [
-                  data ? darkAlgorithm : defaultAlgorithm,
-                  isCompact && compactAlgorithm,
-                ].filter(Boolean) as MappingAlgorithm[],
-              },
-            });
+          onChange={() => {
+            changeTheme(darkAlgorithm);
           }}
         ></Switch>
       </Space>
@@ -100,14 +107,7 @@ export default function Page() {
         <Switch
           checked={isCompact}
           onChange={(data) => {
-            setAntdConfig({
-              theme: {
-                algorithm: [
-                  isDark ? darkAlgorithm : defaultAlgorithm,
-                  data && compactAlgorithm,
-                ].filter(Boolean) as MappingAlgorithm[],
-              },
-            });
+            changeTheme(compactAlgorithm);
           }}
         ></Switch>
       </Space>

--- a/examples/with-antd-5/pages/index.tsx
+++ b/examples/with-antd-5/pages/index.tsx
@@ -1,18 +1,46 @@
-import { App, Button, Space, theme, version } from 'antd';
-import React, { useState } from 'react';
-import { getLocale, setLocale, useIntl } from 'umi';
+import {
+  App,
+  Button,
+  MappingAlgorithm,
+  Space,
+  Switch,
+  theme,
+  version,
+} from 'antd';
+import type { ConfigProviderProps } from 'antd/es/config-provider';
+import { useState } from 'react';
+import {
+  getLocale,
+  setLocale,
+  useAntdConfig,
+  useAntdConfigSetter,
+  useIntl,
+} from 'umi';
+const { useToken, darkAlgorithm, defaultAlgorithm, compactAlgorithm } = theme;
+
+const checkHasAlgorithm = (
+  antdConfig: ConfigProviderProps,
+  algorithm: MappingAlgorithm,
+) => {
+  const nowAlgorithm = Array.isArray(antdConfig?.theme?.algorithm)
+    ? antdConfig?.theme?.algorithm
+    : [antdConfig?.theme?.algorithm];
+  return nowAlgorithm?.includes(algorithm);
+};
 
 export default function Page() {
+  const setAntdConfig = useAntdConfigSetter();
+  const antdConfig = useAntdConfig();
   const [isZh, setIsZh] = useState(true);
   // 若要使用 useApp hook，须先在 antd 插件中配置 appConfig
   const { message, modal } = App.useApp();
   const locale = getLocale();
-  const { token } = theme.useToken();
+  const { token } = useToken();
 
   const showModal = () => {
     modal.confirm({
       title: 'Hai',
-      content: '注意 Modal 内的按钮样式应该和页面中的按钮样一致',
+      content: '注意 Modal 内的按钮样式应该和页面中的按钮样式一致',
       maskClosable: true,
     });
   };
@@ -25,7 +53,8 @@ export default function Page() {
     // app.txt 中配置了 appConfig.message.duration = 5
     message.info('Hai');
   };
-
+  const isDark = checkHasAlgorithm(antdConfig, darkAlgorithm);
+  const isCompact = checkHasAlgorithm(antdConfig, compactAlgorithm);
   return (
     <div
       style={{
@@ -33,6 +62,7 @@ export default function Page() {
         height: '100vh',
       }}
     >
+      {Math.random()}
       <h1>with antd@{version}</h1>
       <Space>
         <Button onClick={sayHai}>Say Hai</Button>
@@ -48,6 +78,38 @@ export default function Page() {
         >
           {msg}
         </Button>
+      </Space>
+      <Space>
+        isDarkTheme
+        <Switch
+          checked={isDark}
+          onChange={(data) => {
+            setAntdConfig({
+              theme: {
+                algorithm: [
+                  data ? darkAlgorithm : defaultAlgorithm,
+                  isCompact && compactAlgorithm,
+                ].filter(Boolean) as MappingAlgorithm[],
+              },
+            });
+          }}
+        ></Switch>
+      </Space>
+      <Space>
+        isCompactTheme
+        <Switch
+          checked={isCompact}
+          onChange={(data) => {
+            setAntdConfig({
+              theme: {
+                algorithm: [
+                  isDark ? darkAlgorithm : defaultAlgorithm,
+                  data && compactAlgorithm,
+                ].filter(Boolean) as MappingAlgorithm[],
+              },
+            });
+          }}
+        ></Switch>
       </Space>
     </div>
   );

--- a/examples/with-antd-5/tsconfig.json
+++ b/examples/with-antd-5/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.umi/tsconfig.json"
+}

--- a/packages/plugins/src/antd.ts
+++ b/packages/plugins/src/antd.ts
@@ -164,6 +164,11 @@ export default (api: IApi) => {
       }
     }
 
+    // 如果使用静态主题配置，需要搭配 ConfigProvider ，否则无效，我们自动开启它
+    if (antd.dark || antd.compact) {
+      antd.configProvider ??= {};
+    }
+
     return memo;
   });
 
@@ -202,6 +207,11 @@ export default (api: IApi) => {
     return [];
   });
 
+  const lodashPkg = dirname(require.resolve('lodash/package.json'));
+  const lodashPath = {
+    merge: winPath(join(lodashPkg, 'merge')),
+  };
+
   // antd config provider & app component
   api.onGenerateFiles(() => {
     const withConfigProvider = !!api.config.antd.configProvider;
@@ -209,8 +219,6 @@ export default (api: IApi) => {
     const styleProvider = api.config.antd.styleProvider;
     const userInputCompact = api.config.antd.compact;
     const userInputDark = api.config.antd.dark;
-
-    // Hack StyleProvider
 
     const ieTarget = !!api.config.targets?.ie || !!api.config.legacy;
 
@@ -242,19 +250,27 @@ export default (api: IApi) => {
     }
 
     // Template
+    const configProvider =
+      withConfigProvider && JSON.stringify(api.config.antd.configProvider);
+    const appConfig =
+      appComponentAvailable && JSON.stringify(api.config.antd.appConfig);
+    const enableV5ThemeAlgorithm =
+      isV5 && (userInputCompact || userInputDark)
+        ? { compact: userInputCompact, dark: userInputDark }
+        : false;
+    const hasConfigProvider = configProvider || enableV5ThemeAlgorithm;
+    // 拥有 `ConfigProvider` 时，我们默认提供修改 antd 全局配置的便捷方法（仅限 antd 5）
+    const antdConfigSetter = isV5 && hasConfigProvider;
     api.writeTmpFile({
       path: `runtime.tsx`,
       context: {
-        configProvider:
-          withConfigProvider && JSON.stringify(api.config.antd.configProvider),
-        appConfig:
-          appComponentAvailable && JSON.stringify(api.config.antd.appConfig),
+        configProvider,
+        appConfig,
         styleProvider: styleProviderConfig,
         // 是否启用了 v5 的 theme algorithm
-        enableV5ThemeAlgorithm:
-          isV5 && (userInputCompact || userInputDark)
-            ? { compact: userInputCompact, dark: userInputDark }
-            : false,
+        enableV5ThemeAlgorithm,
+        antdConfigSetter,
+        lodashPath,
         /**
          * 是否重构了全局静态配置。 重构后需要在运行时将全局静态配置传入到 ConfigProvider 中。
          * 实际上 4.13.0 重构后有一个 bug，真正的 warn 出现在 4.13.1，并且 4.13.1 修复了这个 bug。
@@ -285,29 +301,31 @@ export type IRuntimeConfig = {
       `,
     });
 
-    if (isV5) {
+    if (antdConfigSetter) {
       api.writeTmpFile({
         path: 'index.tsx',
         content: `import React from 'react';
-import { AntdContext, AntdContextSetter } from './context';
-        
+import { AntdConfigContext, AntdConfigContextSetter } from './context';
+
 export function useAntdConfig() {
-  return React.useContext(AntdContext);
+  return React.useContext(AntdConfigContext);
 }
-        
+
 export function useAntdConfigSetter() {
-  return React.useContext(AntdContextSetter);
+  return React.useContext(AntdConfigContextSetter);
 }`,
       });
       api.writeTmpFile({
         path: 'context.tsx',
         content: `import React from 'react';
 import type { ConfigProviderProps } from 'antd/es/config-provider';
-        
-export const AntdContext = React.createContext<ConfigProviderProps>({});
-export const AntdContextSetter = React.createContext((data:ConfigProviderProps)=>{
-  console.error('To use this feature, please enable one of the three configurations: antd.dark, antd.compact, antd.configProvider,or antd.appConfig,');
-});
+
+export const AntdConfigContext = React.createContext<ConfigProviderProps>(null!);
+export const AntdConfigContextSetter = React.createContext<React.Dispatch<React.SetStateAction<ConfigProviderProps>>>(
+  () => {
+    console.error(\`The 'useAntdConfigSetter()' method depends on the antd 'ConfigProvider', requires one of 'antd.configProvider' / 'antd.dark' / 'antd.compact' to be enabled.\`);
+  }
+);
 `,
       });
     }

--- a/packages/plugins/src/antd.ts
+++ b/packages/plugins/src/antd.ts
@@ -284,6 +284,33 @@ export type IRuntimeConfig = {
 };
       `,
     });
+
+    if (isV5) {
+      api.writeTmpFile({
+        path: 'index.tsx',
+        content: `import React from 'react';
+import { AntdContext, AntdContextSetter } from './context';
+        
+export function useAntdConfig() {
+  return React.useContext(AntdContext);
+}
+        
+export function useAntdConfigSetter() {
+  return React.useContext(AntdContextSetter);
+}`,
+      });
+      api.writeTmpFile({
+        path: 'context.tsx',
+        content: `import React from 'react';
+import type { ConfigProviderProps } from 'antd/es/config-provider';
+        
+export const AntdContext = React.createContext<ConfigProviderProps>({});
+export const AntdContextSetter = React.createContext((data:ConfigProviderProps)=>{
+  console.error('To use this feature, please enable one of the three configurations: antd.dark, antd.compact, antd.configProvider,or antd.appConfig,');
+});
+`,
+      });
+    }
   });
 
   api.addRuntimePlugin(() => {

--- a/packages/plugins/templates/antd/runtime.ts.tpl
+++ b/packages/plugins/templates/antd/runtime.ts.tpl
@@ -24,6 +24,118 @@ import {
 {{/styleProvider}}
 import { getPluginManager } from '../core/plugin';
 
+{{#enableV5ThemeAlgorithm}}
+import { AntdContext, AntdContextSetter } from './context';
+{{/enableV5ThemeAlgorithm}}
+
+const AntdProvider = ({ container }) => {
+{{^configProvider}}
+{{^enableV5ThemeAlgorithm}}
+  // 三个条件都不成立的时候，直接返回 
+  return container
+{{^styleProvider}}
+{{/styleProvider}}
+{{/enableV5ThemeAlgorithm}}
+{{/configProvider}}
+  
+  const {
+    appConfig,
+    ...finalConfigProvider
+  } = getAntdConfig();
+
+{{#enableV5ThemeAlgorithm}}
+  // Add token algorithm for antd5 only
+  finalConfigProvider.theme ??= {};
+  finalConfigProvider.theme.algorithm = [
+    {{#enableV5ThemeAlgorithm.compact}}
+    theme.compactAlgorithm,
+    {{/enableV5ThemeAlgorithm.compact}}
+    {{#enableV5ThemeAlgorithm.dark}}
+    theme.darkAlgorithm,
+    {{/enableV5ThemeAlgorithm.dark}}
+  ];
+  const [antdConfig, setConfig] = React.useState(finalConfigProvider);
+  const setAntdConfig = (data) => {
+    const mergeConfig = {
+      ...antdConfig,
+      ...data,
+      theme: {
+        ...(antdConfig?.theme || {}),
+        ...(data?.theme || {}),
+      },
+    };
+    setConfig(mergeConfig);
+  };
+{{/enableV5ThemeAlgorithm}}
+
+{{^enableV5ThemeAlgorithm}}
+const antdConfig = finalConfigProvider;
+{{/enableV5ThemeAlgorithm}}
+  {{#configProvider}}
+  {{^disableInternalStatic}}
+  if (antdConfig.prefixCls) {
+    Modal.config({
+      rootPrefixCls: antdConfig.prefixCls
+    });
+    message.config({
+      prefixCls: `${antdConfig.prefixCls}-message`
+    });
+    notification.config({
+      prefixCls: `${antdConfig.prefixCls}-notification`
+    });
+  }
+  {{/disableInternalStatic}}
+
+  {{#disableInternalStatic}}
+  if (antdConfig.prefixCls) {
+    ConfigProvider.config({
+      prefixCls: antdConfig.prefixCls,
+    });
+  };
+  {{/disableInternalStatic}}
+
+  if (antdConfig.iconPrefixCls) {
+    // Icons in message need to set iconPrefixCls via ConfigProvider.config()
+    ConfigProvider.config({
+      iconPrefixCls: antdConfig.iconPrefixCls,
+    });
+  };
+
+  if (antdConfig.theme) {
+    // Pass config theme to static method
+    ConfigProvider.config({
+      theme: antdConfig.theme,
+    });
+  }
+
+{{/configProvider}}
+
+  return (
+{{#enableV5ThemeAlgorithm}}
+    <AntdContextSetter.Provider value={setAntdConfig}>
+      <AntdContext.Provider value={antdConfig}>
+{{/enableV5ThemeAlgorithm}}
+{{#styleProvider}}
+    <StyleProvider
+      {{#styleProvider.hashPriority}}
+      hashPriority="{{{styleProvider.hashPriority}}}"
+      {{/styleProvider.hashPriority}}
+      {{#styleProvider.legacyTransformer}}
+      transformers={[legacyLogicalPropertiesTransformer]}
+      {{/styleProvider.legacyTransformer}}
+    >
+{{/styleProvider}}
+        <ConfigProvider {...antdConfig}>{container}</ConfigProvider>
+{{#styleProvider}}
+        </StyleProvider>
+{{/styleProvider}}
+{{#enableV5ThemeAlgorithm}}
+      </AntdContext.Provider>
+    </AntdContextSetter.Provider>
+{{/enableV5ThemeAlgorithm}}
+  );
+}
+
 let cacheAntdConfig = null;
 
 const getAntdConfig = () => {
@@ -45,90 +157,9 @@ const getAntdConfig = () => {
 }
 
 export function rootContainer(rawContainer) {
-  const {
-    appConfig,
-    ...finalConfigProvider
-  } = getAntdConfig();
-  let container = rawContainer;
-
-{{#configProvider}}
-  {{^disableInternalStatic}}
-  if (finalConfigProvider.prefixCls) {
-    Modal.config({
-      rootPrefixCls: finalConfigProvider.prefixCls
-    });
-    message.config({
-      prefixCls: `${finalConfigProvider.prefixCls}-message`
-    });
-    notification.config({
-      prefixCls: `${finalConfigProvider.prefixCls}-notification`
-    });
-  }
-  {{/disableInternalStatic}}
-
-  {{#disableInternalStatic}}
-  if (finalConfigProvider.prefixCls) {
-    ConfigProvider.config({
-      prefixCls: finalConfigProvider.prefixCls,
-    });
-  };
-  {{/disableInternalStatic}}
-
-  if (finalConfigProvider.iconPrefixCls) {
-    // Icons in message need to set iconPrefixCls via ConfigProvider.config()
-    ConfigProvider.config({
-      iconPrefixCls: finalConfigProvider.iconPrefixCls,
-    });
-  };
-
-  if (finalConfigProvider.theme) {
-    // Pass config theme to static method
-    ConfigProvider.config({
-      theme: finalConfigProvider.theme,
-    });
-  }
-
-  container = <ConfigProvider {...finalConfigProvider}>{container}</ConfigProvider>;
-{{/configProvider}}
-
-{{#enableV5ThemeAlgorithm}}
-  // Add token algorithm for antd5 only
-  container = (
-    <ConfigProvider
-      theme={({
-        algorithm: [
-          {{#enableV5ThemeAlgorithm.compact}}
-          theme.compactAlgorithm,
-          {{/enableV5ThemeAlgorithm.compact}}
-          {{#enableV5ThemeAlgorithm.dark}}
-          theme.darkAlgorithm,
-          {{/enableV5ThemeAlgorithm.dark}}
-        ],
-      })}
-    >
-      {container}
-    </ConfigProvider>
-  );
-{{/enableV5ThemeAlgorithm}}
-
-{{#styleProvider}}
-  container = (
-    <StyleProvider
-      {{#styleProvider.hashPriority}}
-      hashPriority="{{{styleProvider.hashPriority}}}"
-      {{/styleProvider.hashPriority}}
-      {{#styleProvider.legacyTransformer}}
-      transformers={[legacyLogicalPropertiesTransformer]}
-      {{/styleProvider.legacyTransformer}}
-    >
-      {container}
-    </StyleProvider>
-  );
-{{/styleProvider}}
-
+  const container = (<AntdProvider container={rawContainer}/>)
   return container;
 }
-
 {{#appConfig}}
 // The App component should be under ConfigProvider
 // plugin-locale has other ConfigProvider


### PR DESCRIPTION
提供 useAntdConfig 和 useAntdConfigSetter 供用户在项目中修改 antd 的配置。

```tsx
import { Layout, Space, Button, version, theme } from 'antd';
import { useAntdConfig, useAntdConfigSetter } from 'umi';
const { darkAlgorithm, defaultAlgorithm } = theme;

export default function Page() {
  const setAntdConfig = useAntdConfigSetter();
  const antdConfig = useAntdConfig();
  return (
    <Layout>
      <h1>with antd@{version}</h1>
      <Space>
        isDarkTheme
        <Switch
          checked={antdConfig?.theme?.algorithm.includes(darkAlgorithm)}
          onChange={(data) => {
            setAntdConfig({
              theme: {
                algorithm: [
                  data ? darkAlgorithm : defaultAlgorithm,
                ],
              },
            });
          }}
        ></Switch>
      </Space>
    </Layout>
  );
}
```

需要注意的是，该方法只能修改 antd 支持的配置，不支持 umi 相关的几个配置，如 dark 。
这是之前和 @fz6m 讨论的结果，导致用户在一键切换暗黑风格的操作上，需要在业务侧处理更多的逻辑，如 examples/with-antd-5/pages/index.tsx

```tsx
const checkHasAlgorithm = (
  antdConfig: ConfigProviderProps,
  algorithm: MappingAlgorithm,
) => {
  const nowAlgorithm = Array.isArray(antdConfig?.theme?.algorithm)
    ? antdConfig?.theme?.algorithm
    : [antdConfig?.theme?.algorithm];
  return nowAlgorithm?.includes(algorithm);
};

```