### PR TITLE
feat: check bundler before apply styled babel plugin

### DIFF
--- a/packages/core/src/service/service.ts
+++ b/packages/core/src/service/service.ts
@@ -58,6 +58,7 @@ export class Service {
     mpa?: {
       entry?: { [key: string]: string }[];
     };
+    bundler?: string;
     [key: string]: any;
   } = {};
   args: yParser.Arguments = { _: [], $0: '' };

--- a/packages/plugins/src/styled-components.ts
+++ b/packages/plugins/src/styled-components.ts
@@ -20,6 +20,9 @@ export default (api: IApi) => {
   // dev:  displayName
   // prod: minify
   api.modifyConfig((memo) => {
+    // only apply babel plugin in webpack and vite
+    if (!['webpack', 'vite'].includes(api.appData.bundler)) return memo;
+
     const isProd = api.env === 'production';
     const pluginConfig = {
       // https://github.com/styled-components/babel-plugin-styled-components/blob/f8e9fb480d1645be8be797d73e49686bdf98975b/src/utils/options.js#L11

--- a/packages/plugins/src/styled-components.ts
+++ b/packages/plugins/src/styled-components.ts
@@ -21,7 +21,7 @@ export default (api: IApi) => {
   // prod: minify
   api.modifyConfig((memo) => {
     // only apply babel plugin in webpack and vite
-    if (!['webpack', 'vite'].includes(api.appData.bundler)) return memo;
+    if (!['webpack', 'vite'].includes(api.appData.bundler!)) return memo;
 
     const isProd = api.env === 'production';
     const pluginConfig = {

--- a/packages/preset-umi/src/features/appData/appData.ts
+++ b/packages/preset-umi/src/features/appData/appData.ts
@@ -56,6 +56,7 @@ export default (api: IApi) => {
     memo.globalJS = globalJS;
     memo.overridesCSS = overridesCSS;
     memo.globalLoading = globalLoading;
+    memo.bundler = 'webpack';
 
     const gitDir = findGitDir(api.paths.cwd);
     if (gitDir) {

--- a/packages/preset-umi/src/features/vite/vite.ts
+++ b/packages/preset-umi/src/features/vite/vite.ts
@@ -11,6 +11,12 @@ export default (api: IApi) => {
     enableBy: api.EnableBy.config,
   });
 
+  api.modifyAppData((memo) => {
+    memo.bundler = 'vite';
+
+    return memo;
+  });
+
   api.modifyConfig((memo) => {
     // like vite, use to pre-bundling dependencies in vite mode
     memo.alias['@fs'] = api.cwd;


### PR DESCRIPTION
仅在 webpack 和 vite 构建器时应用 styled-componets 的 babel 插件，因为 Mako 不支持 babel 插件避免抛出警告，未来会以其他方式支持 styled-components babel 插件提供的能力