### PR TITLE
[WIP] feat: add sourcemap && improve getUmiAlias

### DIFF
--- a/.fatherrc.base.ts
+++ b/.fatherrc.base.ts
@@ -3,5 +3,6 @@ import { defineConfig } from 'father';
 export default defineConfig({
   cjs: {
     output: 'dist',
+    sourcemap: true,
   },
 });

--- a/packages/umi/src/test.ts
+++ b/packages/umi/src/test.ts
@@ -32,7 +32,9 @@ let service: Service;
 
 export async function getUmiAlias() {
   if (!service) {
-    service = new Service();
+    service = new Service({
+      defaultConfigFiles: [],
+    });
     await service.run2({
       name: 'setup',
       args: { quiet: true },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
     "esModuleInterop": true,
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
- feat: `getUmiAlias` actually call "setup" service to collect umi alias. It has a defect when used to test umi-plugin. It will ready the config file in user's project and that could result "invalid config key" error. It can be improved by allowing developer to specify a config path.
- chore: add sourcemap  & declarationMap generation to improve DX when developing umi.