### PR TITLE
fix(codemod): configPath maybe .umirc.ts or .umirc.js

### DIFF
--- a/codemod/src/prepare.ts
+++ b/codemod/src/prepare.ts
@@ -75,6 +75,7 @@ export async function prepare(opts: { cwd: string; pattern: any; args?: any }) {
 
   return {
     config,
+    configPath: mainConfigFile,
     absAppJSPath,
     pkg,
     pkgPath,

--- a/codemod/src/runner/config.ts
+++ b/codemod/src/runner/config.ts
@@ -1,8 +1,6 @@
 import * as t from '@umijs/bundler-utils/compiled/babel/types';
 import { lodash } from '@umijs/utils';
-import assert from 'assert';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
 import { update as appJSUpdate } from '../appJSUpdater';
 import { update } from '../configUpdater';
 import { info } from '../logger';
@@ -123,17 +121,12 @@ export class Runner {
       setKeys['layout.locale'] = false;
     }
 
-    const configFile = join(this.cwd, 'config/config.ts');
-    assert(
-      existsSync(configFile),
-      `Could not find config file at ${configFile}`,
-    );
     const {
       config: { code },
       routesConfig: { filePath: routeFilePath, code: routeCode } = {} as any,
     } = update({
-      code: readFileSync(configFile, 'utf-8'),
-      filePath: configFile,
+      code: readFileSync(this.context.configPath, 'utf-8'),
+      filePath: this.context.configPath,
       updates: {
         del: deleteKeys,
         set: setKeys,
@@ -164,7 +157,7 @@ export class Runner {
         },
       },
     });
-    writeFileSync(configFile, code);
+    writeFileSync(this.context.configPath, code);
     if (routeCode) {
       writeFileSync(routeFilePath, routeCode);
     }


### PR DESCRIPTION
- 问题：当应用使用 .umirc.ts 作为配置文件，执行 pnpm dlx @umijs/codemod@latest 命令报配置文件未找到错误
- 处理：prepare 过程获知配置文件路径，通过 context 传入 ConfigRunner