### PR TITLE
chore: add opts.react for bundler

### DIFF
--- a/packages/preset-umi/src/commands/build.ts
+++ b/packages/preset-umi/src/commands/build.ts
@@ -1,5 +1,5 @@
 import { getMarkup } from '@umijs/server';
-import { chalk, fsExtra, logger, rimraf } from '@umijs/utils';
+import { chalk, fsExtra, logger, rimraf, semver } from '@umijs/utils';
 import { writeFileSync } from 'fs';
 import { dirname, join, resolve } from 'path';
 import type { IApi, IOnGenerateFiles } from '../types';
@@ -97,7 +97,13 @@ umi build --clean
           umi: join(api.paths.absTmpPath, 'umi.ts'),
         },
       });
+      const isGTEReact17 =
+        api.appData.react?.version &&
+        semver.gte(api.appData.react.version, '17.0.0');
       const opts = {
+        react: {
+          runtime: isGTEReact17 ? 'automatic' : 'classic',
+        },
         config: api.config,
         cwd: api.cwd,
         entry,

--- a/packages/preset-umi/src/commands/dev/dev.ts
+++ b/packages/preset-umi/src/commands/dev/dev.ts
@@ -6,6 +6,7 @@ import {
   logger,
   portfinder,
   rimraf,
+  semver,
   winPath,
 } from '@umijs/utils';
 import { existsSync, readdirSync, readFileSync } from 'fs';
@@ -347,7 +348,13 @@ PORT=8888 umi dev
         },
       });
 
+      const isGTEReact17 =
+        api.appData.react?.version &&
+        semver.gte(api.appData.react.version, '17.0.0');
       const opts: any = {
+        react: {
+          runtime: isGTEReact17 ? 'automatic' : 'classic',
+        },
         config: api.config,
         pkg: api.pkg,
         cwd: api.cwd,


### PR DESCRIPTION
目前主要是给 mako 用，让 mako 能自适配 react 的 runtime 类型。