### PR TITLE
fix: `modifyHtml#path` when `exportStatic` is enabled

### DIFF
--- a/packages/preset-umi/src/features/exportStatic/exportStatic.ts
+++ b/packages/preset-umi/src/features/exportStatic/exportStatic.ts
@@ -220,7 +220,11 @@ export default (api: IApi) => {
       }
 
       // append html file
-      const htmlContent = await getMarkup(markupArgs);
+      const htmlContent = await getMarkup({
+        ...markupArgs,
+        // https://github.com/umijs/umi/issues/12108
+        path: route.path,
+      });
 
       htmlFiles.push({
         path: file,


### PR DESCRIPTION
fix #12108

修理开启 `exportStatic` 时， `api.modifyHtml($, path)` 第二个参数不正确的问题。