### PR TITLE
fix: `ssr` `exportStatic` not handled with `base`

### DIFF
--- a/examples/ssr-export-static-basename/.umirc.ts
+++ b/examples/ssr-export-static-basename/.umirc.ts
@@ -1,0 +1,6 @@
+export default {
+  ssr: {},
+  exportStatic: {},
+  hash: true,
+  base: '/a/',
+};

--- a/examples/ssr-export-static-basename/package.json
+++ b/examples/ssr-export-static-basename/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@example/ssr-export-static-basename",
+  "private": true,
+  "description": "当 umi 配置表中设置了 base 后, ssr 输出的预渲染页面中的 a 标签需要有正确的 base 前缀",
+  "scripts": {
+    "build": "umi build",
+    "dev": "umi dev",
+    "setup": "umi setup",
+    "start": "npm run dev"
+  },
+  "dependencies": {
+    "umi": "workspace:*"
+  }
+}

--- a/examples/ssr-export-static-basename/src/pages/about/index.tsx
+++ b/examples/ssr-export-static-basename/src/pages/about/index.tsx
@@ -1,0 +1,15 @@
+import { Link } from 'umi';
+
+const About = () => {
+  return (
+    <div>
+      <div>
+        <strong>about</strong> page
+      </div>
+      <br />
+      <Link to="/">to home</Link>
+    </div>
+  );
+};
+
+export default About;

--- a/examples/ssr-export-static-basename/src/pages/index.tsx
+++ b/examples/ssr-export-static-basename/src/pages/index.tsx
@@ -1,0 +1,15 @@
+import { Link } from 'umi';
+
+const Home = () => {
+  return (
+    <div>
+      <div>
+        <strong>home</strong> page
+      </div>
+      <br />
+      <Link to="/about">to about</Link>
+    </div>
+  );
+};
+
+export default Home;

--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -514,6 +514,7 @@ if (process.env.NODE_ENV === 'development') {
             join(api.paths.absOutputPath, 'build-manifest.json'),
           ),
           env: JSON.stringify(api.env),
+          basename: api.config.base,
         },
       });
     }

--- a/packages/preset-umi/templates/server.tpl
+++ b/packages/preset-umi/templates/server.tpl
@@ -51,6 +51,7 @@ const createOpts = {
   helmetContext,
   createHistory,
   ServerInsertedHTMLContext,
+  basename: '{{{basename}}}'
 };
 const requestHandler = createRequestHandler(createOpts);
 export const renderRoot = createUmiHandler(createOpts);

--- a/packages/renderer-react/src/server.tsx
+++ b/packages/renderer-react/src/server.tsx
@@ -14,18 +14,27 @@ interface IHtmlProps {
   loaderData: { [routeKey: string]: any };
   manifest: any;
   metadata?: IMetadata;
+  basename?: string;
 }
 
 // Get the root React component for ReactDOMServer.renderToString
 export async function getClientRootComponent(opts: IHtmlProps) {
-  const basename = '/';
+  const basename = opts.basename || '/';
   const components = { ...opts.routeComponents };
   const clientRoutes = createClientRoutes({
     routesById: opts.routes,
     routeComponents: components,
   });
+
+  // If router has a basename, location should be concatenated with that basename
+  let finalLocation;
+  if (basename.endsWith('/')) {
+    finalLocation = basename.slice(0, -1) + opts.location;
+  } else {
+    finalLocation = basename + opts.location;
+  }
   let rootContainer = (
-    <StaticRouter basename={basename} location={opts.location}>
+    <StaticRouter basename={basename} location={finalLocation}>
       <Routes />
     </StaticRouter>
   );

--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -36,6 +36,7 @@ interface CreateRequestHandlerOptions extends CreateRequestServerlessOptions {
   createHistory: (opts: any) => any;
   helmetContext?: any;
   ServerInsertedHTMLContext: React.Context<ServerInsertedHTMLHook | null>;
+  basename?: string;
 }
 
 interface IExecLoaderOpts {
@@ -78,6 +79,7 @@ function createJSXGenerator(opts: CreateRequestHandlerOptions) {
       getRoutes,
       createHistory,
       sourceDir,
+      basename,
     } = opts;
 
     // make import { history } from 'umi' work
@@ -148,6 +150,7 @@ function createJSXGenerator(opts: CreateRequestHandlerOptions) {
       manifest,
       loaderData,
       metadata,
+      basename,
     };
 
     const element = (await opts.getClientRootComponent(


### PR DESCRIPTION
fix: [#11233](https://github.com/umijs/umi/issues/11233)

修复开启 `ssr` 后输出产物中的前端路由链接 `href` 没有正确的 `base` 前缀的问题.