### PR TITLE
refactor(preset-umi): export route preload types for prebundle

### DIFF
--- a/packages/preset-umi/src/features/routePreloadOnLoad/utils.ts
+++ b/packages/preset-umi/src/features/routePreloadOnLoad/utils.ts
@@ -4,7 +4,9 @@
 
 import type { IRouteChunkFilesMap } from './routePreloadOnLoad';
 
-interface IPreloadRouteFile {
+export type { IRouteChunkFilesMap };
+
+export interface IPreloadRouteFile {
   type: 'js' | 'css' | (string & {});
   url: string;
   attrs: ([string, string] | [string])[];


### PR DESCRIPTION
导出路由资源预加载 utils 的类型，便于内部工具对该模块进行预打包再分发