### PR TITLE
fix(preset-umi): disable route preload feature if unnecessary

### DIFF
--- a/packages/preset-umi/src/features/routePreloadOnLoad/routePreloadOnLoad.ts
+++ b/packages/preset-umi/src/features/routePreloadOnLoad/routePreloadOnLoad.ts
@@ -206,10 +206,13 @@ async function getRoutePathFilesMap(
 export default (api: IApi) => {
   let routeChunkFilesMap: IRouteChunkFilesMap;
 
-  // enable when package name available
-  // because preload script use package name as attribute prefix value
   api.describe({
-    enableBy: () => Boolean(api.pkg.name),
+    enableBy: () =>
+      // enable when package name available
+      // because preload script use package name as attribute prefix value
+      Boolean(api.pkg.name) &&
+      // vite mode is not supported currently
+      !api.config.vite,
   });
 
   api.addHTMLHeadScripts(() => {


### PR DESCRIPTION
修复子路由资源预加载特性在不必要的情况下也执行所引发的问题：
1. 报错的场景：开启 vite 模式，因为尚未适配 vite 的 stats，先禁用后续再支持
2. 浪费构建耗时：开启 MPA、`routeLoader: cjs` 这两种情况
3. 浪费 HTML 尺寸：`import to require` 的情况

Case 整理自 @fz6m ref: https://github.com/umijs/umi/issues/12185#issuecomment-1985126804

Close #12185 