### PR TITLE
fix: 修复 npmClient 配置为 tnpm，但 tnpm mode 为 npm 时 layout 插件注入绝对路径 types 问题

### DIFF
--- a/packages/plugins/src/layout.ts
+++ b/packages/plugins/src/layout.ts
@@ -117,10 +117,15 @@ export default (api: IApi) => {
   });
 
   api.onGenerateFiles(() => {
+    let realNpmClient = api.appData.npmClient;
     // tnpm 作为 npmClient 时，可能使用不同的安装模式
-    const realNpmClient =
-      (api.appData.npmClient === NpmClientEnum.tnpm && api.pkg.tnpm?.mode) ||
-      api.appData.npmClient;
+    if (
+      api.appData.npmClient === NpmClientEnum.tnpm &&
+      api.pkg.tnpm?.mode &&
+      [NpmClientEnum.npm, NpmClientEnum.yarn].includes(api.pkg.tnpm.mode)
+    ) {
+      realNpmClient = api.pkg.tnpm.mode;
+    }
     // use absolute path to types references in `npm/yarn` will cause case problems.
     // https://github.com/umijs/umi/discussions/10947
     // https://github.com/umijs/umi/discussions/11570

--- a/packages/plugins/src/layout.ts
+++ b/packages/plugins/src/layout.ts
@@ -117,11 +117,15 @@ export default (api: IApi) => {
   });
 
   api.onGenerateFiles(() => {
+    // tnpm 作为 npmClient 时，可能使用不同的安装模式
+    const realNpmClient =
+      (api.appData.npmClient === NpmClientEnum.tnpm && api.pkg.tnpm?.mode) ||
+      api.appData.npmClient;
     // use absolute path to types references in `npm/yarn` will cause case problems.
     // https://github.com/umijs/umi/discussions/10947
     // https://github.com/umijs/umi/discussions/11570
     const isFlattedDepsDir = [NpmClientEnum.npm, NpmClientEnum.yarn].includes(
-      api.appData.npmClient,
+      realNpmClient,
     );
     const PKG_TYPE_REFERENCE = `
 /// <reference types="${


### PR DESCRIPTION
想了一下，这个场景：
```
// config.ts
npmClient: "tnpm"

// package.json
tnpm: { mode: "npm" }
```
应该算是预期的场景，期望使用的 npm 工具确实是`tnpm`，比如`installWithNpmClient`确实期望使用`tnpm`进行安装。只不过 layout 这个场景确实需要判断 tnpm.mode 是否是`npm`