### PR TITLE
fix(template): tsconfig include source

### DIFF
--- a/packages/create-umi/templates/plugin/tsconfig.json
+++ b/packages/create-umi/templates/plugin/tsconfig.json
@@ -15,5 +15,6 @@
     "isolatedModules": false,
     "noEmit": false,
     "declaration": true
-  }
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
来源 https://github.com/umijs/father/issues/746

修复 father 没有添加 tsconfig `include` 设置会构建失败的问题。