### PR TITLE
docs: compat with old hash anchors

### DIFF
--- a/docs/.dumi/theme/builtins/HashAnchorCompat/index.tsx
+++ b/docs/.dumi/theme/builtins/HashAnchorCompat/index.tsx
@@ -1,0 +1,17 @@
+import { useLayoutEffect } from 'react';
+
+interface IHashAnchorCompatProps {
+  from: string;
+  to: string;
+}
+
+export default function HashAnchorCompat({ from, to }: IHashAnchorCompatProps) {
+  useLayoutEffect(() => {
+    const hash = window.location.hash;
+    if (hash === from) {
+      window.location.hash = to;
+    }
+  }, []);
+
+  return null;
+}

--- a/docs/docs/docs/api/runtime-config.md
+++ b/docs/docs/docs/api/runtime-config.md
@@ -144,6 +144,8 @@ export const layout: RuntimeConfig = {
 
 ### onRouteChange
 
+<HashAnchorCompat from="#onroutechange-routes-clientroutes-location-action-basename-isfirst-" to="#onroutechange"></HashAnchorCompat>
+
 - type: `(args: { routes: Routes; clientRoutes: Routes; location: Location; action: Action; basename: string; isFirst: boolean }) => void`
 
 在初始加载和路由切换时做一些事情。
@@ -178,6 +180,8 @@ export function onRouteChange({ clientRoutes, location }) {
 
 ### patchRoutes
 
+<HashAnchorCompat from="#patchroutes-routes-" to="#patchroutes"></HashAnchorCompat>
+
 - type: `(args: { routes: Routes; routeComponents }) => void`
 
 ```ts
@@ -193,6 +197,8 @@ export function patchRoutes({ routes, routeComponents }) {
 注：如需动态更新路由，建议使用 `patchClientRoutes()` ，否则你可能需要同时修改 `routes` 和 `routeComponents`。
 
 ### patchClientRoutes
+
+<HashAnchorCompat from="#patchclientroutes-routes-" to="#patchclientroutes"></HashAnchorCompat>
 
 - type: `(args: { routes: Routes; }) => void`
 
@@ -270,6 +276,8 @@ Umi 内置了 `qiankun` 插件来提供微前端的能力，具体参考[插件�
 
 ### render
 
+<HashAnchorCompat from="#renderoldrender-function" to="#render"></HashAnchorCompat>
+
 - Type: `(oldRender: Function)=>void`
 
 覆写 render。
@@ -293,6 +301,8 @@ export function render(oldRender) {
 如果你使用了 `import { request } from 'umi';` 来请求数据，那么你可以通过该配置来自定义中间件、拦截器、错误处理适配等。具体参考 [request](../max/request) 插件配置。
 
 ### rootContainer
+
+<HashAnchorCompat from="#rootcontainerlastrootcontainer-args" to="#rootcontainer"></HashAnchorCompat>
 
 - Type: `(container: JSX.Element,args: { routes: Routes; plugin; history: History }) => JSX.Element;`
 


### PR DESCRIPTION
close #12158

因为：

 - https://github.com/umijs/umi/commit/0a666fc535d89d95bb6d71200b1b969081c9c6f5

 - https://github.com/umijs/umi/commit/5d64b5c81048647c5804e90de3305d8f87d535a0

以上两个对文档 title 的改动，导致以前的 hash 锚点失效了，大面积历史 url 无法正常跳转。

由于大量历史锚点（特别是 `patchClientRoutes` 等）使用的十分频繁，所以影响面非常大，比较严重。

此 PR 兼容了历史锚点并跳转到新锚点。

注：若以后还需改动 title ，应考虑将跳转逻辑变为 map 映射，防止过多兼容逻辑反复运行的成本。