### PR TITLE
fix(preset-umi): modifyHTML hook oom in large static site app

### DIFF
--- a/packages/preset-umi/src/commands/dev/getMarkupArgs.ts
+++ b/packages/preset-umi/src/commands/dev/getMarkupArgs.ts
@@ -42,6 +42,8 @@ export async function getMarkupArgs(opts: { api: IApi }) {
       let $ = cheerio.load(memo, {
         // @ts-ignore
         decodeEntities: false,
+        // reduce memory overhead, to avoid oom in antd site with `exportStatic: {}`
+        _useHtmlParser2: true,
       });
       $ = await opts.api.applyPlugins({
         key: 'modifyHTML',


### PR DESCRIPTION
修复在大型静态站点应用（比如 antd 官网）中，开启 `exportStatic` 可能导致 `modifyHTML` 钩子 OOM 的问题，原因是 cheerio 默认使用 parse5 作为 HTML 解析器，但在动辄一两百个页面的静态站点应用中 parse5 很容易消耗过量内存导致 OOM，解决方案是将 cheerio 的 HTML 解析器切换为内存开销更小的 `htmlparser2`。

为什么之前 antd 官网没出现 OOM？推测是由于子路由资源预加载方案 #12095 追加了一个 inline script，且站点越大它的尺寸会越大，这成了 OOM 的导火索。

切换 HTML 解析器有什么副作用？此前 cheerio 切换默认解析器是为了解一系列的问题，详见 https://github.com/cheeriojs/cheerio/pull/985 但其中属于缺陷的问题在 htmlparser2 中已经修复，其他已知副作用对 Umi 的场景应该不受影响：
1. 不对 HTML 字符串默认套 `<html><head></head><body></body></html>`
2. 不自动补全标签，例如自动补全 `table` 中的 `tbody`、`tr` 等
3. 不自动转义实体字符，比如 `<div><=</div>` 会原样输出（现代浏览器会正确处理 `<`）
4. 缺少闭合标签的行为不一致，比如 `<ul>1<ul>2<ul>` 会变成嵌套而不是并集