### PR TITLE
fix(preset-umi): wrong async script mark for pre-prendered static site app

### DIFF
--- a/packages/preset-umi/src/features/exportStatic/exportStatic.ts
+++ b/packages/preset-umi/src/features/exportStatic/exportStatic.ts
@@ -148,15 +148,21 @@ export default (api: IApi) => {
     const { publicPath } = api.config;
     const htmlData = api.appData.exportHtmlData;
     const htmlFiles: { path: string; content: string }[] = [];
+    const { markupArgs: defaultMarkupArgs } = opts;
+    let asyncMarkupArgs: typeof defaultMarkupArgs;
 
     for (const { file, route, prerender } of htmlData) {
-      let { markupArgs } = opts;
+      let markupArgs = defaultMarkupArgs;
+
+      // mark async for the scripts of pre-rendered html
       if (api.config.ssr && prerender) {
-        markupArgs.scripts.forEach((script: any) => {
-          if (script.src) {
-            script.async = true;
-          }
-        });
+        // copy args to avoid affect original object
+        markupArgs = asyncMarkupArgs ??= {
+          ...markupArgs,
+          scripts: markupArgs.scripts.map((script: any) =>
+            script.src ? { ...script, async: true } : script,
+          ),
+        };
       }
 
       // handle relative publicPath, such as `./`


### PR DESCRIPTION
修复静态站点预渲染的时候，可能出现错误的 async script 标记的问题，原因是 `markupArgs` 对象被重复使用了，解法是根据是否开启预渲染拆分为 `defaultMarkupArgs` 和 `asyncMarkupArgs`，这样也能避免重复执行带来不必要的开销

ref: #11469 

cc @MadCcc 