### PR TITLE
fix(preset-umi): chainWebpack hook args for ssr bundling

### DIFF
--- a/packages/preset-umi/src/features/ssr/webpack/webpack.ts
+++ b/packages/preset-umi/src/features/ssr/webpack/webpack.ts
@@ -34,10 +34,10 @@ export const build = async (api: IApi, opts: any) => {
   bundlerOpts.watch = api.env === 'development';
 
   // override chainWebpack
-  bundlerOpts.chainWebpack = async (memo: WebpackChain) => {
+  bundlerOpts.chainWebpack = async (memo: WebpackChain, opts: any) => {
     const absOutputFile = absServerBuildPath(api);
 
-    await oChainWebpack(memo);
+    await oChainWebpack(memo, { ...opts, ssr: true });
     memo.entryPoints.clear();
     memo.entry('umi').add(resolve(api.paths.absTmpPath, 'umi.server.ts'));
     memo.target('node');


### PR DESCRIPTION
修复 ssr 产物构建前，触发 `chainWebpack` 钩子缺少参数的问题，以及加上了 `ssr: true` 的标记便于插件区分当前的 webpack 配置目标