### PR TITLE
feat(RQ): improve react-query plugin

### DIFF
--- a/docs/docs/docs/max/react-query.md
+++ b/docs/docs/docs/max/react-query.md
@@ -29,6 +29,14 @@ export default {
 }
 ```
 
+:::info
+注：在使用时，请务必检查关于 `refetchOnWindowFocus` 的配置项，详见 [运行时配置项](#运行时配置项) 。
+:::
+
+## 版本
+
+默认使用的是 [TanStack Query](https://tanstack.com/query/latest) v4 版本，若需使用最新 v5 版本，手动安装 v5 版本的 `@tanstack/react-query` 与 `@tanstack/react-query-devtools` 依赖即可。
+
 ## 特性
 
 插件帮你做了几件事，
@@ -66,27 +74,26 @@ export default {
 - `devtool`：object
 - `queryClient`: object
 
-比如：
+例子：
 
 ```ts
-const API_SERVER = '/path/to/api/server';
-export const reactQuery = {
+// src/app.ts
+
+import { RuntimeReactQueryType } from 'umi';
+
+export const reactQuery: RuntimeReactQueryType = {
   devtool: { 
     initialIsOpen: true,
   },
   queryClient: {
-	  defaultOptions: {
-	    queries: {
-	      queryFn: async ({ queryKey }) => {
-	        const res = await fetch(`${API_SERVER}/${queryKey.join('/')}`);
-	        if (res.status !== 200) {
-	          throw new Error(res.statusText);
-	        }
-	        return res.json();
-	      }
-	    }
-	  }
+    defaultOptions: {
+      queries: {
+        // 🟡 此配置具有的表现往往令人出乎意料，若无特殊需求，请默认关闭
+        refetchOnWindowFocus: false,
+      },
+    },
   },
 };
 ```
 
+注：绝大多数项目中，**你都应该默认设定 `refetchOnWindowFocus: false`** ，否则将引发出人意料的反复获取数据效果（这在 SWR 中被称为 [`revalidateOnFocus`](https://swr.vercel.app/zh-CN/docs/api#options) ）。

--- a/examples/with-react-query-v5/.umirc.ts
+++ b/examples/with-react-query-v5/.umirc.ts
@@ -1,0 +1,4 @@
+export default {
+  plugins: ['@umijs/plugins/dist/react-query'],
+  reactQuery: {},
+};

--- a/examples/with-react-query-v5/app.ts
+++ b/examples/with-react-query-v5/app.ts
@@ -1,0 +1,14 @@
+import { RuntimeReactQueryType } from 'umi';
+
+export const reactQuery: RuntimeReactQueryType = {
+  queryClient: {
+    defaultOptions: {
+      queries: {
+        refetchOnWindowFocus: false,
+      },
+    },
+  },
+  devtool: {
+    buttonPosition: 'bottom-left',
+  },
+};

--- a/examples/with-react-query-v5/package.json
+++ b/examples/with-react-query-v5/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@example/with-react-query-v5",
+  "private": true,
+  "scripts": {
+    "build": "umi build",
+    "dev": "umi dev",
+    "start": "npm run dev"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.28.6",
+    "@tanstack/react-query-devtools": "^5.28.6",
+    "umi": "workspace:*"
+  }
+}

--- a/examples/with-react-query-v5/pages/index.tsx
+++ b/examples/with-react-query-v5/pages/index.tsx
@@ -1,0 +1,30 @@
+import { useQuery } from 'umi';
+import '../style.less';
+
+export default function HomePage() {
+  const { isFetching, data } = useQuery({
+    queryKey: ['repoData'],
+    queryFn: () => {
+      return new Promise<{ stargazers_count: number }>((resolve, _) => {
+        setTimeout(async () => {
+          const res = await fetch('https://api.github.com/repos/umijs/umi');
+          const json = await res.json();
+          resolve(json);
+        }, 500);
+      });
+    },
+  });
+
+  return (
+    <div className="container">
+      <div>
+        <p className="title">UmiJS x react-query v5</p>
+        {isFetching ? (
+          <p>Loading ...</p>
+        ) : (
+          <p>UmiJS has {data?.stargazers_count} stars now!</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/examples/with-react-query-v5/readme.md
+++ b/examples/with-react-query-v5/readme.md
@@ -1,0 +1,3 @@
+# react-query-v5
+
+An example of using [UmiJS](https://umijs.org/zh-CN) with [react-query](https://github.com/TanStack/query) v5.

--- a/examples/with-react-query-v5/style.less
+++ b/examples/with-react-query-v5/style.less
@@ -1,0 +1,22 @@
+body {
+  font-family: 'Lucida Sans', sans-serif;
+}
+
+.container {
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  div {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .title {
+    font-size: 64px;
+  }
+
+}

--- a/examples/with-react-query-v5/tsconfig.json
+++ b/examples/with-react-query-v5/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.umi/tsconfig.json"
+}

--- a/examples/with-react-query/app.ts
+++ b/examples/with-react-query/app.ts
@@ -1,0 +1,14 @@
+import { RuntimeReactQueryType } from 'umi';
+
+export const reactQuery: RuntimeReactQueryType = {
+  queryClient: {
+    defaultOptions: {
+      queries: {
+        refetchOnWindowFocus: false,
+      },
+    },
+  },
+  devtool: {
+    position: 'bottom-left',
+  },
+};

--- a/examples/with-react-query/pages/index.tsx
+++ b/examples/with-react-query/pages/index.tsx
@@ -2,7 +2,7 @@ import { useQuery } from 'umi';
 import '../style.less';
 
 export default function HomePage() {
-  const { isLoading, data } = useQuery(['repoData'], () =>
+  const { isFetching, data } = useQuery(['repoData'], () =>
     fetch('https://api.github.com/repos/umijs/umi').then((res) => res.json()),
   );
 
@@ -10,7 +10,7 @@ export default function HomePage() {
     <div className="container">
       <div>
         <p className="title">UmiJS x react-query</p>
-        {isLoading && <p>Loading ...</p>}
+        {isFetching && <p>Loading ...</p>}
         {data && <p>UmiJS has {data.stargazers_count} stars now!</p>}
       </div>
     </div>

--- a/examples/with-react-query/tsconfig.json
+++ b/examples/with-react-query/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.umi/tsconfig.json"
+}

--- a/packages/plugins/src/react-query.ts
+++ b/packages/plugins/src/react-query.ts
@@ -143,57 +143,76 @@ export function rootContainer(container) {
         : '',
     });
 
+    const exportMembers: string[] = [
+      // from @tanstack/query-core
+      'QueryClient',
+      'QueryCache',
+      'MutationCache',
+      'QueryObserver',
+      'InfiniteQueryObserver',
+      'QueriesObserver',
+      'MutationObserver',
+      // from @tanstack/react-query
+      'useQuery',
+      'useQueries',
+      'useInfiniteQuery',
+      'useMutation',
+      'useIsFetching',
+      'useIsMutating',
+      ...(useV5
+        ? [
+            'useMutationState',
+            'useSuspenseQuery',
+            'useSuspenseInfiniteQuery',
+            'useSuspenseQueries',
+            'queryOptions',
+            'infiniteQueryOptions',
+          ]
+        : []),
+      'QueryClientProvider',
+      'useQueryClient',
+      'QueryErrorResetBoundary',
+      'useQueryErrorResetBoundary',
+      'useIsRestoring',
+      'IsRestoringProvider',
+    ].filter(Boolean);
+
     api.writeTmpFile({
       path: 'index.tsx',
       content: `
 export {
-  // from @tanstack/query-core
-  QueryClient,
-  MutationObserver,
-  MutationCache,
-  InfiniteQueryObserver,
-  QueriesObserver,
-  QueryObserver,
-  QueryCache,
-  // from @tanstack/react-query
-  useIsRestoring,
-  IsRestoringProvider,
-  useInfiniteQuery,
-  useIsMutating,
-  useIsFetching,
-  useMutation,
-  useQueries,
-  useQuery,
-  QueryClientProvider,
-  useQueryClient,
-  QueryErrorResetBoundary,
-  useQueryErrorResetBoundary,
-  ${useV5 ? 'queryOptions,' : ''}
+  ${exportMembers.join(',\n  ')}
 } from '${pkgPath}';
       `,
     });
+
+    const exportTypes: string[] = [
+      // from @tanstack/query-core
+      'Query',
+      'QueryState',
+      'Mutation',
+      // from @tanstack/react-query
+      'QueriesResults',
+      'QueriesOptions',
+      'QueryErrorResetBoundaryProps',
+      'QueryClientProviderProps',
+      useV4 && 'ContextOptions as QueryContextOptions,',
+      'UseQueryOptions',
+      'UseBaseQueryOptions',
+      'UseQueryResult',
+      'UseBaseQueryResult',
+      'UseInfiniteQueryOptions',
+      'UseMutationResult',
+      'UseMutateFunction',
+      'UseMutateAsyncFunction',
+      'UseBaseMutationResult',
+    ].filter(Boolean);
 
     api.writeTmpFile({
       path: 'types.d.ts',
       content: `
 export type {
-  // from @tanstack/query-core
-  Query, QueryState, Mutation,
-  // from @tanstack/react-query
-  QueriesResults,
-  QueriesOptions,
-  QueryErrorResetBoundaryProps,
-  QueryClientProviderProps,
-  ${useV4 ? 'ContextOptions as QueryContextOptions,' : ''}
-  UseQueryOptions,
-  UseBaseQueryOptions,
-  UseQueryResult,
-  UseBaseQueryResult,
-  UseInfiniteQueryOptions,
-  UseMutationResult,
-  UseMutateFunction,
-  UseMutateAsyncFunction,
-  UseBaseMutationResult,
+  ${exportTypes.join(',\n  ')}
 } from '${pkgPath}';
       `,
     });

--- a/packages/plugins/src/react-query.ts
+++ b/packages/plugins/src/react-query.ts
@@ -141,7 +141,7 @@ export function rootContainer(container) {
   );
 }
       `
-        : '',
+        : 'export {}',
     });
 
     const exportMembers: string[] = [

--- a/packages/plugins/src/utils/npmClient.ts
+++ b/packages/plugins/src/utils/npmClient.ts
@@ -1,0 +1,21 @@
+import type { IApi } from 'umi';
+import { NpmClientEnum } from 'umi/plugin-utils';
+
+const FLATTED_NPM_CLIENT: NpmClientEnum[] = [
+  NpmClientEnum.npm,
+  NpmClientEnum.yarn,
+];
+
+export const isFlattedNodeModulesDir = (api: IApi) => {
+  let currentNpmClient = api.appData.npmClient;
+  // tnpm 作为 npmClient 时，可能使用不同的安装模式
+  const tnpmCompatMode: string | undefined =
+    api.appData.npmClient === NpmClientEnum.tnpm && api.pkg.tnpm?.mode;
+  if (tnpmCompatMode) {
+    if (FLATTED_NPM_CLIENT.includes(api.pkg.tnpm.mode)) {
+      return true;
+    }
+  }
+  const isFlattedDir = FLATTED_NPM_CLIENT.includes(currentNpmClient);
+  return isFlattedDir;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1423,6 +1423,18 @@ importers:
         specifier: workspace:*
         version: link:../../packages/umi
 
+  examples/with-react-query-v5:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.28.6
+        version: 5.28.6(react@18.1.0)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.28.6
+        version: 5.28.6(@tanstack/react-query@5.28.6)(react@18.1.0)
+      umi:
+        specifier: workspace:*
+        version: link:../../packages/umi
+
   examples/with-react-three-fiber:
     dependencies:
       '@react-three/drei':
@@ -16348,6 +16360,14 @@ packages:
   /@tanstack/query-core@4.24.10:
     resolution: {integrity: sha512-2QywqXEAGBIUoTdgn1lAB4/C8QEqwXHj2jrCLeYTk2xVGtLiPEUD8jcMoeB2noclbiW2mMt4+Fq7fZStuz3wAQ==}
 
+  /@tanstack/query-core@5.28.6:
+    resolution: {integrity: sha512-hnhotV+DnQtvtR3jPvbQMPNMW4KEK0J4k7c609zJ8muiNknm+yoDyMHmxTWM5ZnlZpsz0zOxYFr+mzRJNHWJsA==}
+    dev: false
+
+  /@tanstack/query-devtools@5.28.6:
+    resolution: {integrity: sha512-DXJGqbrsteWU9XehDf6s3k3QxwQqGUlNXpitsF1xbwkYBcDaAakiC6hjJSMfPBHOrbZCnWfAGCVf4vh2D75/xw==}
+    dev: false
+
   /@tanstack/react-query-devtools@4.24.10(@tanstack/react-query@4.24.10)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-1uzJNLdLjRsNt4O5ldv1SYPevWvSdHtKIyVJeUv4hSERPEhrKKfa8WC3dBOX24CdLEYH2ndLZW4ZiC9nzSKCtg==}
     peerDependencies:
@@ -16388,6 +16408,20 @@ packages:
       use-sync-external-store: 1.2.0(react@18.1.0)
     dev: false
 
+  /@tanstack/react-query-devtools@5.28.6(@tanstack/react-query@5.28.6)(react@18.1.0):
+    resolution: {integrity: sha512-xSfskHlM2JkP7WpN89UqhJV2RbFxg8YnOMzQz+EEzWSsgxMI5Crce8HO9pcUAcJce8gSmw93RQwuKNdG3FbT6w==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.28.6
+      react: ^18.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+    dependencies:
+      '@tanstack/query-devtools': 5.28.6
+      '@tanstack/react-query': 5.28.6(react@18.1.0)
+      react: 18.1.0
+    dev: false
+
   /@tanstack/react-query@4.24.10(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-FY1DixytOcNNCydPQXLxuKEV7VSST32CAuJ55BjhDNqASnMLZn+6c30yQBMrODjmWMNwzfjMZnq0Vw7C62Fwow==}
     peerDependencies:
@@ -16426,6 +16460,18 @@ packages:
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
       use-sync-external-store: 1.2.0(react@18.1.0)
+    dev: false
+
+  /@tanstack/react-query@5.28.6(react@18.1.0):
+    resolution: {integrity: sha512-/DdYuDBSsA21Qbcder1R8Cr/3Nx0ZnA2lgtqKsLMvov8wL4+g0HBz/gWYZPlIsof7iyfQafyhg4wUVUsS3vWZw==}
+    peerDependencies:
+      react: ^18.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+    dependencies:
+      '@tanstack/query-core': 5.28.6
+      react: 18.1.0
     dev: false
 
   /@testing-library/dom@9.0.0:


### PR DESCRIPTION
1. 新增 react-query v5 使用 example

2. 补充更新 react-query 说明文档

3. 修复 react-query v5 在使用非打平的依赖结构时（如 pnpm ），类型无法索引到的问题

4. 新增 react-query 运行时配置的类型，使用时会有类型提示更友好

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added guidance on using `refetchOnWindowFocus` configuration option in React Query documentation.
	- Introduced integration examples and configuration for React Query v5 in UmiJS projects, including default query options and devtool setup.
	- Provided a new example component that fetches and displays UmiJS repository stars using React Query v5.
- **Documentation**
	- Updated React Query documentation to recommend setting `refetchOnWindowFocus: false` and to use version 4 by default.
- **Refactor**
	- Renamed `isLoading` to `isFetching` in the HomePage component for alignment with React Query's `useQuery` hook.
	- Updated import statements and removed specific logic in `layout.ts` related to npm client determination.
- **Chores**
	- Added utility function to determine if the `node_modules` directory is flattened, affecting project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->