### PR TITLE
feat(preset-umi): unify request handler for ssr and always use stream

### DIFF
--- a/packages/preset-umi/templates/server.tpl
+++ b/packages/preset-umi/templates/server.tpl
@@ -53,7 +53,13 @@ const createOpts = {
   ServerInsertedHTMLContext,
 };
 const requestHandler = createRequestHandler(createOpts);
+/**
+ * @deprecated  Please use `requestHandler` instead.
+ */
 export const renderRoot = createUmiHandler(createOpts);
+/**
+ * @deprecated  Please use `requestHandler` instead.
+ */
 export const serverLoader = createUmiServerLoader(createOpts);
 
 export const _markupGenerator = createMarkupGenerator(createOpts);

--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -306,7 +306,12 @@ export default function createRequestHandler(
               },
             },
           );
-          let res = new Response(stream, { status: 200 });
+          let res = new Response(stream, {
+            headers: {
+              'content-type': 'text/html; charset=utf-8',
+            },
+            status: 200,
+          });
 
           // allow modify response
           if (opts?.modifyResponse) {
@@ -338,6 +343,8 @@ export default function createRequestHandler(
         },
         async sendPage(jsx) {
           const writable = new Writable();
+
+          res.type('html');
 
           writable._write = (chunk, _encoding, cb) => {
             res.write(chunk);

--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -268,7 +268,7 @@ export default function createRequestHandler(
 
     if (typeof FetchEvent !== 'undefined' && args[0] instanceof FetchEvent) {
       // worker mode
-      const [ev, opts] = args;
+      const [ev, opts] = args as IWorkerRequestHandlerArgs;
       const { pathname, searchParams } = new URL(ev.request.url);
 
       ret = {
@@ -327,7 +327,7 @@ export default function createRequestHandler(
       };
     } else {
       // express mode
-      const [req, res, next] = args;
+      const [req, res, next] = args as IExpressRequestHandlerArgs;
 
       ret = {
         req: {

--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -266,7 +266,7 @@ export default function createRequestHandler(
       otherwise(): Promise<void> | void;
     };
 
-    if (args.length !== 3) {
+    if (typeof FetchEvent !== 'undefined' && args[0] instanceof FetchEvent) {
       // worker mode
       const [ev, opts] = args;
       const { pathname, searchParams } = new URL(ev.request.url);

--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -1,3 +1,4 @@
+/// <reference lib="webworker" />
 import type { RequestHandler } from '@umijs/bundler-utils/compiled/express';
 import React, { ReactElement } from 'react';
 import * as ReactDomServer from 'react-dom/server';

--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -416,7 +416,7 @@ export default function createRequestHandler(
 
 // 新增的给CDN worker用的SSR请求handle
 /**
- * @deprecated  Please use `createRequestHandler({ ..., mode: 'worker' })` instead
+ * @deprecated  Please use `createRequestHandler` instead
  */
 export function createUmiHandler(opts: CreateRequestHandlerOptions) {
   return async function (
@@ -444,7 +444,7 @@ export function createUmiHandler(opts: CreateRequestHandlerOptions) {
 }
 
 /**
- * @deprecated  Please use `createRequestHandler({ ..., mode: 'worker' })` instead
+ * @deprecated  Please use `createRequestHandler` instead
  */
 export function createUmiServerLoader(opts: CreateRequestHandlerOptions) {
   return async function (req: UmiRequest) {

--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -415,14 +415,20 @@ export default function createRequestHandler(
 }
 
 // 新增的给CDN worker用的SSR请求handle
-/**
- * @deprecated  Please use `createRequestHandler` instead
- */
 export function createUmiHandler(opts: CreateRequestHandlerOptions) {
+  let isWarned = false;
+
   return async function (
     req: UmiRequest,
     params?: CreateRequestHandlerOptions,
   ) {
+    if (!isWarned) {
+      console.warn(
+        '[umi] `renderRoot` is deprecated, please use `requestHandler` instead',
+      );
+      isWarned = true;
+    }
+
     const jsxGeneratorDeferrer = createJSXGenerator({
       ...opts,
       ...params,
@@ -443,11 +449,17 @@ export function createUmiHandler(opts: CreateRequestHandlerOptions) {
   };
 }
 
-/**
- * @deprecated  Please use `createRequestHandler` instead
- */
 export function createUmiServerLoader(opts: CreateRequestHandlerOptions) {
+  let isWarned = false;
+
   return async function (req: UmiRequest) {
+    if (!isWarned) {
+      console.warn(
+        '[umi] `serverLoader` is deprecated, please use `requestHandler` instead',
+      );
+      isWarned = true;
+    }
+
     const query = Object.fromEntries(new URL(req.url).searchParams);
     // 切换路由场景下，会通过此 API 执行 server loader
     const serverLoaderRequest = new Request(query.url, {

--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -242,7 +242,7 @@ export function createMarkupGenerator(opts: CreateRequestHandlerOptions) {
 type IExpressRequestHandlerArgs = Parameters<RequestHandler>;
 type IWorkerRequestHandlerArgs = [
   ev: FetchEvent,
-  opts?: { modifyResponse?: (res: Response) => Response },
+  opts?: { modifyResponse?: (res: Response) => Promise<Response> | Response },
 ];
 
 export default function createRequestHandler(
@@ -281,7 +281,7 @@ export default function createRequestHandler(
             url: searchParams.get('url'),
           },
         },
-        sendServerLoader(data) {
+        async sendServerLoader(data) {
           let res = new Response(JSON.stringify(data), {
             headers: {
               'content-type': 'application/json; charset=utf-8',
@@ -291,7 +291,7 @@ export default function createRequestHandler(
 
           // allow modify response
           if (opts?.modifyResponse) {
-            res = opts.modifyResponse(res);
+            res = await opts.modifyResponse(res);
           }
 
           ev.respondWith(res);
@@ -316,7 +316,7 @@ export default function createRequestHandler(
 
           // allow modify response
           if (opts?.modifyResponse) {
-            res = opts.modifyResponse(res);
+            res = await opts.modifyResponse(res);
           }
 
           ev.respondWith(res);

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
-    "lib": ["WebWorker"]
+    "rootDir": "./src"
   },
   "include": ["src"]
 }

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "lib": ["WebWorker"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
主要做了 3 处改动：
1. 合并 `createUmiHandler`、`createUmiServerLoader` 的逻辑到 `createRequestHandler`，对外统一使用 `requestHandler` 进行调用，目前支持响应 `worker` 和 `express` 两种 request
2. 将原有 `createUmiHandler` 复制为 `worker` 逻辑的同时，改用 Stream 响应请求，降低 `TTFB`
3. 原有的 `renderRoot`、`severLoader` 导出均加上了 `deprecated`，现在都可以用 `requestHandler` 替代

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced server-side rendering capabilities with a unified request handling mechanism suitable for both worker and express modes.
- **Refactor**
	- Deprecated older server rendering functions in favor of a more streamlined, unified approach.
- **Documentation**
	- Updated guidance on server-side rendering functions, advising the transition to the new `requestHandler` for improved performance and flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->