### PR TITLE
feat: SSR support useServerInsertedHTML

### DIFF
--- a/examples/ssr-demo/package.json
+++ b/examples/ssr-demo/package.json
@@ -9,6 +9,8 @@
     "start:prod": "node ./production-server.js"
   },
   "dependencies": {
+    "@ant-design/cssinjs": "^1.18.5",
+    "antd": "^5",
     "express": "4.18.2",
     "umi": "workspace:*"
   }

--- a/examples/ssr-demo/src/layouts/index.tsx
+++ b/examples/ssr-demo/src/layouts/index.tsx
@@ -1,0 +1,23 @@
+import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
+import { useState } from 'react';
+import { Outlet, useServerInsertedHTML } from 'umi';
+
+export default function Layout() {
+  const [cssCache] = useState(() => createCache());
+
+  useServerInsertedHTML(() => {
+    const style = extractStyle(cssCache, { plain: true });
+    return (
+      <style
+        id="antd-cssinjs"
+        dangerouslySetInnerHTML={{ __html: style }}
+      ></style>
+    );
+  });
+
+  return (
+    <StyleProvider cache={cssCache}>
+      <Outlet />
+    </StyleProvider>
+  );
+}

--- a/examples/ssr-demo/src/pages/index.tsx
+++ b/examples/ssr-demo/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import { Input } from 'antd';
-import { useId, useState } from 'react';
+import { useId } from 'react';
 import {
   Link,
   MetadataLoader,
@@ -17,14 +17,11 @@ import './index.less';
 // @ts-ignore
 import styles from './index.less';
 // @ts-ignore
-import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
 import umiLogo from './umi.png';
 
 export default function HomePage() {
   const clientLoaderData = useClientLoaderData();
   const serverLoaderData = useServerLoaderData<typeof serverLoader>();
-
-  const [cssCache] = useState(() => createCache());
 
   useServerInsertedHTML(() => {
     return (
@@ -36,41 +33,29 @@ export default function HomePage() {
     );
   });
 
-  useServerInsertedHTML(() => {
-    const style = extractStyle(cssCache, { plain: true });
-    return (
-      <style
-        id="antd-cssinjs"
-        dangerouslySetInnerHTML={{ __html: style }}
-      ></style>
-    );
-  });
-
   const id = useId();
 
   return (
-    <StyleProvider cache={cssCache}>
-      <div>
-        <h1 className="title">Hello~</h1>
-        <p className="server_inserted_style">id: {id}</p>
-        <p className={styles.blue}>This is index.tsx</p>
-        <p className={cssStyle.title}>I should be pink</p>
-        <p className={cssStyle.blue}>I should be cyan</p>
-        <Button />
-        <Input placeholder="这个样式不应该闪烁" />
-        <img src={bigImage} alt="" />
-        <img src={umiLogo} alt="umi" />
-        <Link to="/users/user">/users/user</Link>
-        <div style={{ backgroundColor: '#eee', padding: 12 }}>
-          <p>
-            点击这个按钮以后，需要加载 users, user2, info 三个路由组件需要的数据
-          </p>
-          <Link to="/users/user2/info">/users/user2/info</Link>
-        </div>
-        <p>client loader data: {JSON.stringify(clientLoaderData)}</p>
-        <p>server loader data: {JSON.stringify(serverLoaderData)}</p>
+    <div>
+      <h1 className="title">Hello~</h1>
+      <p className="server_inserted_style">id: {id}</p>
+      <p className={styles.blue}>This is index.tsx</p>
+      <p className={cssStyle.title}>I should be pink</p>
+      <p className={cssStyle.blue}>I should be cyan</p>
+      <Button />
+      <Input placeholder="这个样式不应该闪烁" />
+      <img src={bigImage} alt="" />
+      <img src={umiLogo} alt="umi" />
+      <Link to="/users/user">/users/user</Link>
+      <div style={{ backgroundColor: '#eee', padding: 12 }}>
+        <p>
+          点击这个按钮以后，需要加载 users, user2, info 三个路由组件需要的数据
+        </p>
+        <Link to="/users/user2/info">/users/user2/info</Link>
       </div>
-    </StyleProvider>
+      <p>client loader data: {JSON.stringify(clientLoaderData)}</p>
+      <p>server loader data: {JSON.stringify(serverLoaderData)}</p>
+    </div>
   );
 }
 

--- a/examples/ssr-demo/src/pages/index.tsx
+++ b/examples/ssr-demo/src/pages/index.tsx
@@ -1,3 +1,5 @@
+import { Input } from 'antd';
+import { useId, useState } from 'react';
 import {
   Link,
   MetadataLoader,
@@ -15,35 +17,60 @@ import './index.less';
 // @ts-ignore
 import styles from './index.less';
 // @ts-ignore
+import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
 import umiLogo from './umi.png';
 
 export default function HomePage() {
   const clientLoaderData = useClientLoaderData();
   const serverLoaderData = useServerLoaderData<typeof serverLoader>();
 
+  const [cssCache] = useState(() => createCache());
+
   useServerInsertedHTML(() => {
-    return <div>inserted html</div>;
+    return (
+      <style
+        dangerouslySetInnerHTML={{
+          __html: `.server_inserted_style { color: #1677ff }`,
+        }}
+      ></style>
+    );
   });
 
+  useServerInsertedHTML(() => {
+    const style = extractStyle(cssCache, { plain: true });
+    return (
+      <style
+        id="antd-cssinjs"
+        dangerouslySetInnerHTML={{ __html: style }}
+      ></style>
+    );
+  });
+
+  const id = useId();
+
   return (
-    <div>
-      <h1 className="title">Hello~</h1>
-      <p className={styles.blue}>This is index.tsx</p>
-      <p className={cssStyle.title}>I should be pink</p>
-      <p className={cssStyle.blue}>I should be cyan</p>
-      <Button />
-      <img src={bigImage} alt="" />
-      <img src={umiLogo} alt="umi" />
-      <Link to="/users/user">/users/user</Link>
-      <div style={{ backgroundColor: '#eee', padding: 12 }}>
-        <p>
-          点击这个按钮以后，需要加载 users, user2, info 三个路由组件需要的数据
-        </p>
-        <Link to="/users/user2/info">/users/user2/info</Link>
+    <StyleProvider cache={cssCache}>
+      <div>
+        <h1 className="title">Hello~</h1>
+        <p className="server_inserted_style">id: {id}</p>
+        <p className={styles.blue}>This is index.tsx</p>
+        <p className={cssStyle.title}>I should be pink</p>
+        <p className={cssStyle.blue}>I should be cyan</p>
+        <Button />
+        <Input placeholder="这个样式不应该闪烁" />
+        <img src={bigImage} alt="" />
+        <img src={umiLogo} alt="umi" />
+        <Link to="/users/user">/users/user</Link>
+        <div style={{ backgroundColor: '#eee', padding: 12 }}>
+          <p>
+            点击这个按钮以后，需要加载 users, user2, info 三个路由组件需要的数据
+          </p>
+          <Link to="/users/user2/info">/users/user2/info</Link>
+        </div>
+        <p>client loader data: {JSON.stringify(clientLoaderData)}</p>
+        <p>server loader data: {JSON.stringify(serverLoaderData)}</p>
       </div>
-      <p>client loader data: {JSON.stringify(clientLoaderData)}</p>
-      <p>server loader data: {JSON.stringify(serverLoaderData)}</p>
-    </div>
+    </StyleProvider>
   );
 }
 

--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -276,7 +276,7 @@ export default function createRequestHandler(
       otherwise(): Promise<void> | void;
     };
 
-    const replaceServerHTMLScript = `<script>!function(){var e=document.getElementById(SERVER_INSERTED_HTML);e&&(Array.from(e.children).forEach(e=>{document.head.appendChild(e)}),e.remove())}();</script>`;
+    const replaceServerHTMLScript = `<script>!function(){var e=document.getElementById("${SERVER_INSERTED_HTML}");e&&(Array.from(e.children).forEach(e=>{document.head.appendChild(e)}),e.remove())}();</script>`;
 
     if (typeof FetchEvent !== 'undefined' && args[0] instanceof FetchEvent) {
       // worker mode

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1123,6 +1123,12 @@ importers:
 
   examples/ssr-demo:
     dependencies:
+      '@ant-design/cssinjs':
+        specifier: ^1.18.5
+        version: 1.18.5(react-dom@18.1.0)(react@18.1.0)
+      antd:
+        specifier: ^5
+        version: 5.8.4(react-dom@18.1.0)(react@18.1.0)
       express:
         specifier: 4.18.2
         version: 4.18.2
@@ -3109,8 +3115,30 @@ packages:
       stylis: 4.1.4
     dev: false
 
-  /@ant-design/cssinjs@1.17.0(react-dom@18.1.0)(react@18.1.0):
-    resolution: {integrity: sha512-MgGCZ6sfD3yQB0XW0hN4jgixMxApTlDYyct+pc7fRZNO4CaqWWm/9iXkkljNR27lyWLZmm+XiDfcIOo1bnrnMA==}
+  /@ant-design/cssinjs@1.18.5(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-Ub4n3d+MAX/qtE5S9PM8iOn5ocU7GUAIC4Adc2X8UCMXnsRRfpJBHsBdtQ1qoAuaQ7lU2M1BTCuJ+fkv4fOWiw==}
+    peerDependencies:
+      react: '>=16.0.0'
+      react-dom: '>=16.0.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.6
+      '@emotion/hash': 0.8.0
+      '@emotion/unitless': 0.7.5
+      classnames: 2.3.2
+      csstype: 3.1.3
+      rc-util: 5.38.1(react-dom@17.0.2)(react@17.0.2)
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+      stylis: 4.3.0
+    dev: true
+
+  /@ant-design/cssinjs@1.18.5(react-dom@18.1.0)(react@18.1.0):
+    resolution: {integrity: sha512-Ub4n3d+MAX/qtE5S9PM8iOn5ocU7GUAIC4Adc2X8UCMXnsRRfpJBHsBdtQ1qoAuaQ7lU2M1BTCuJ+fkv4fOWiw==}
     peerDependencies:
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
@@ -3129,29 +3157,6 @@ packages:
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
       stylis: 4.3.0
-    dev: true
-
-  /@ant-design/cssinjs@1.18.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-1JURAPrsjK1GwpqByTq3bJ7nF7lbMKDZpehqeR2n8/IR5O58/W1U4VcOeaw5ZyTHri3tEMcom7dyP2tvxpW54g==}
-    peerDependencies:
-      react: '>=16.0.0'
-      react-dom: '>=16.0.0'
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.23.6
-      '@emotion/hash': 0.8.0
-      '@emotion/unitless': 0.7.5
-      classnames: 2.3.2
-      csstype: 3.1.2
-      rc-util: 5.38.1(react-dom@17.0.2)(react@17.0.2)
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      stylis: 4.3.0
-    dev: true
 
   /@ant-design/cssinjs@1.9.1(react-dom@18.1.0)(react@18.1.0):
     resolution: {integrity: sha512-CZt1vCMs/sY7RoacYuIkZwQmb8Bhp99ReNNE9Y8lnUzik8fmCdKAQA7ecvVOFwmNFdcBHga7ye/XIRrsbkiqWw==}
@@ -18615,7 +18620,7 @@ packages:
     dependencies:
       '@ahooksjs/use-request': 2.8.15(react@17.0.2)
       '@ant-design/antd-theme-variable': 1.0.0
-      '@ant-design/cssinjs': 1.18.1(react-dom@17.0.2)(react@17.0.2)
+      '@ant-design/cssinjs': 1.18.5(react-dom@17.0.2)(react@17.0.2)
       '@ant-design/icons': 4.7.0(react-dom@17.0.2)(react@17.0.2)
       '@ant-design/moment-webpack-plugin': 0.0.3
       '@ant-design/pro-components': 2.3.20(antd@4.23.6)(react-dom@17.0.2)(react@17.0.2)
@@ -20041,6 +20046,9 @@ packages:
 
   /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependenciesMeta:
+      ajv:
+        optional: true
     dependencies:
       ajv: 8.11.0
 
@@ -20618,7 +20626,7 @@ packages:
         optional: true
     dependencies:
       '@ant-design/colors': 7.0.0
-      '@ant-design/cssinjs': 1.17.0(react-dom@18.1.0)(react@18.1.0)
+      '@ant-design/cssinjs': 1.18.5(react-dom@18.1.0)(react@18.1.0)
       '@ant-design/icons': 5.0.1(react-dom@18.1.0)(react@18.1.0)
       '@ant-design/react-slick': 1.0.0(react@18.1.0)
       '@babel/runtime': 7.21.0
@@ -20817,7 +20825,7 @@ packages:
         optional: true
     dependencies:
       '@ant-design/colors': 7.0.0
-      '@ant-design/cssinjs': 1.16.0(react-dom@18.1.0)(react@18.1.0)
+      '@ant-design/cssinjs': 1.18.5(react-dom@18.1.0)(react@18.1.0)
       '@ant-design/icons': 5.2.5(react-dom@18.1.0)(react@18.1.0)
       '@ant-design/react-slick': 1.0.0(react@18.1.0)
       '@babel/runtime': 7.21.0
@@ -23736,6 +23744,7 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
     dev: false
+    bundledDependencies: false
 
   /create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -43169,6 +43178,7 @@ packages:
       react: 16.14.0
       scheduler: 0.19.1
     dev: false
+    bundledDependencies: false
 
   /react-dom@17.0.2(react@17.0.2):
     resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
@@ -43804,6 +43814,7 @@ packages:
       object-assign: 4.1.1
       prop-types: 15.8.1
     dev: false
+    bundledDependencies: false
 
   /react@17.0.2:
     resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
@@ -46850,6 +46861,9 @@ packages:
     resolution: {integrity: sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+    peerDependenciesMeta:
+      postcss:
+        optional: true
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1123,6 +1123,12 @@ importers:
 
   examples/ssr-demo:
     dependencies:
+      '@ant-design/cssinjs':
+        specifier: ^1.18.5
+        version: 1.18.5(react-dom@18.1.0)(react@18.1.0)
+      antd:
+        specifier: ^5
+        version: 5.8.4(react-dom@18.1.0)(react@18.1.0)
       express:
         specifier: 4.18.2
         version: 4.18.2
@@ -3112,8 +3118,30 @@ packages:
       stylis: 4.1.4
     dev: false
 
-  /@ant-design/cssinjs@1.17.0(react-dom@18.1.0)(react@18.1.0):
-    resolution: {integrity: sha512-MgGCZ6sfD3yQB0XW0hN4jgixMxApTlDYyct+pc7fRZNO4CaqWWm/9iXkkljNR27lyWLZmm+XiDfcIOo1bnrnMA==}
+  /@ant-design/cssinjs@1.18.5(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-Ub4n3d+MAX/qtE5S9PM8iOn5ocU7GUAIC4Adc2X8UCMXnsRRfpJBHsBdtQ1qoAuaQ7lU2M1BTCuJ+fkv4fOWiw==}
+    peerDependencies:
+      react: '>=16.0.0'
+      react-dom: '>=16.0.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.6
+      '@emotion/hash': 0.8.0
+      '@emotion/unitless': 0.7.5
+      classnames: 2.3.2
+      csstype: 3.1.3
+      rc-util: 5.38.1(react-dom@17.0.2)(react@17.0.2)
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+      stylis: 4.3.0
+    dev: true
+
+  /@ant-design/cssinjs@1.18.5(react-dom@18.1.0)(react@18.1.0):
+    resolution: {integrity: sha512-Ub4n3d+MAX/qtE5S9PM8iOn5ocU7GUAIC4Adc2X8UCMXnsRRfpJBHsBdtQ1qoAuaQ7lU2M1BTCuJ+fkv4fOWiw==}
     peerDependencies:
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
@@ -3132,29 +3160,6 @@ packages:
       react: 18.1.0
       react-dom: 18.1.0(react@18.1.0)
       stylis: 4.3.0
-    dev: true
-
-  /@ant-design/cssinjs@1.18.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-1JURAPrsjK1GwpqByTq3bJ7nF7lbMKDZpehqeR2n8/IR5O58/W1U4VcOeaw5ZyTHri3tEMcom7dyP2tvxpW54g==}
-    peerDependencies:
-      react: '>=16.0.0'
-      react-dom: '>=16.0.0'
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.23.6
-      '@emotion/hash': 0.8.0
-      '@emotion/unitless': 0.7.5
-      classnames: 2.3.2
-      csstype: 3.1.2
-      rc-util: 5.38.1(react-dom@17.0.2)(react@17.0.2)
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      stylis: 4.3.0
-    dev: true
 
   /@ant-design/cssinjs@1.9.1(react-dom@18.1.0)(react@18.1.0):
     resolution: {integrity: sha512-CZt1vCMs/sY7RoacYuIkZwQmb8Bhp99ReNNE9Y8lnUzik8fmCdKAQA7ecvVOFwmNFdcBHga7ye/XIRrsbkiqWw==}
@@ -17648,7 +17653,7 @@ packages:
     dependencies:
       '@ahooksjs/use-request': 2.8.15(react@17.0.2)
       '@ant-design/antd-theme-variable': 1.0.0
-      '@ant-design/cssinjs': 1.18.1(react-dom@17.0.2)(react@17.0.2)
+      '@ant-design/cssinjs': 1.18.5(react-dom@17.0.2)(react@17.0.2)
       '@ant-design/icons': 4.7.0(react-dom@17.0.2)(react@17.0.2)
       '@ant-design/moment-webpack-plugin': 0.0.3
       '@ant-design/pro-components': 2.3.20(antd@4.23.6)(react-dom@17.0.2)(react@17.0.2)
@@ -19548,7 +19553,7 @@ packages:
         optional: true
     dependencies:
       '@ant-design/colors': 7.0.0
-      '@ant-design/cssinjs': 1.17.0(react-dom@18.1.0)(react@18.1.0)
+      '@ant-design/cssinjs': 1.18.5(react-dom@18.1.0)(react@18.1.0)
       '@ant-design/icons': 5.0.1(react-dom@18.1.0)(react@18.1.0)
       '@ant-design/react-slick': 1.0.0(react@18.1.0)
       '@babel/runtime': 7.21.0
@@ -19747,7 +19752,7 @@ packages:
         optional: true
     dependencies:
       '@ant-design/colors': 7.0.0
-      '@ant-design/cssinjs': 1.16.0(react-dom@18.1.0)(react@18.1.0)
+      '@ant-design/cssinjs': 1.18.5(react-dom@18.1.0)(react@18.1.0)
       '@ant-design/icons': 5.2.5(react-dom@18.1.0)(react@18.1.0)
       '@ant-design/react-slick': 1.0.0(react@18.1.0)
       '@babel/runtime': 7.21.0
@@ -22496,6 +22501,7 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
+    bundledDependencies: false
 
   /create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -40724,6 +40730,7 @@ packages:
       react: 16.14.0
       scheduler: 0.19.1
     dev: false
+    bundledDependencies: false
 
   /react-dom@17.0.2(react@17.0.2):
     resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
@@ -41371,6 +41378,7 @@ packages:
       object-assign: 4.1.1
       prop-types: 15.8.1
     dev: false
+    bundledDependencies: false
 
   /react@17.0.2:
     resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}


### PR DESCRIPTION
## 概述

1. 在 SSR 渲染时加入 ServerInsertedHTML 上下文，并在流式输出的最后一并拼在末尾
2. 与 React 分段 SSR 处理一样，添加一段 script 把所有 serverInsertedHTML 移动到 head 末尾

测试了 antd 和多个 serverInsertedHTML，SSR 渲染未出现闪烁，可能需要更极端的情况测试。

## 为什么不在流中处理

由于需要将上下文里的内容放置在 head 标签中，当前 chunk 不包含 `</head>` 时就已经无法插入了，因此 Suspense 下的 useServerHTML 会失效，如果等流结束统一处理又会失去流的效果。