### PR TITLE
fix(preset-umi): tmp umi tsconfig includes add .umirc.*.ts

### DIFF
--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -94,6 +94,7 @@ export default (api: IApi) => {
       },
       include: [
         `${baseUrl}.${frameworkName}rc.ts`,
+        `${baseUrl}.${frameworkName}rc.*.ts`,
         `${baseUrl}**/*.d.ts`,
         `${baseUrl}**/*.ts`,
         `${baseUrl}**/*.tsx`,


### PR DESCRIPTION
修复 `.umi/tsconfig.json`  中 `include`  字段没有包含 `.umirc.*.ts` 导致额外创建的配置文件如 `.umirc.local.ts`等 无法获得类型补全的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Enhanced file matching capabilities with wildcard support for configuration file lookup.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->