### PR TITLE
fix: use jsx/runtime only for react 17 and above

### DIFF
--- a/packages/preset-umi/src/commands/build.ts
+++ b/packages/preset-umi/src/commands/build.ts
@@ -99,7 +99,10 @@ umi build --clean
       });
       const shouldUseAutomaticRuntime =
         api.appData.react?.version &&
-        semver.gte(api.appData.react.version, '16.14.0');
+        // why not 16.14.0 ?
+        // it will break the config of externals, when externals
+        // does not handle the react/runtime
+        semver.gte(api.appData.react.version, '17.0.0');
       const opts = {
         react: {
           runtime: shouldUseAutomaticRuntime ? 'automatic' : 'classic',

--- a/packages/preset-umi/src/commands/dev/dev.ts
+++ b/packages/preset-umi/src/commands/dev/dev.ts
@@ -350,7 +350,7 @@ PORT=8888 umi dev
 
       const shouldUseAutomaticRuntime =
         api.appData.react?.version &&
-        semver.gte(api.appData.react.version, '16.14.0');
+        semver.gte(api.appData.react.version, '17.0.0');
       const opts: any = {
         react: {
           runtime: shouldUseAutomaticRuntime ? 'automatic' : 'classic',


### PR DESCRIPTION
https://github.com/umijs/umi/pull/12219 引入的问题，针对 16.14 调整了 react 的转移方式，之前没考虑到的场景是「会影响到 externals」，会导致「externals 只处理了 react 而没有处理 react/runtime」的场景会出问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the logic for determining the React runtime version to '17.0.0' for better compatibility and performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->