### PR TITLE
fix: wrong react-dom server api for worker ssr mode

### DIFF
--- a/packages/preset-umi/src/features/ssr/ssr.ts
+++ b/packages/preset-umi/src/features/ssr/ssr.ts
@@ -25,7 +25,7 @@ export default (api: IApi) => {
         return zod
           .object({
             serverBuildPath: zod.string(),
-            serverBuildMode: zod.enum(['express', 'worker']),
+            serverBuildTarget: zod.enum(['express', 'worker']),
             platform: zod.string(),
             builder: zod.enum(['esbuild', 'webpack']),
             renderFromRoot: zod.boolean(),
@@ -51,11 +51,12 @@ export default (api: IApi) => {
   });
 
   api.modifyConfig((memo) => {
-    // define SSR_BUILD_MODE to strip useless logic
+    // define SSR_BUILD_TARGET to strip useless logic
     memo.define ??= {};
-    memo.define.SSR_BUILD_MODE = api.config.ssr.serverBuildMode || 'express';
+    memo.define.SSR_BUILD_TARGET =
+      api.config.ssr.serverBuildTarget || 'express';
 
-    if (api.config.serverBuildMode === 'worker') {
+    if (api.config.serverBuildTarget === 'worker') {
       // use browser version of react-dom/server for worker mode
       // ref: https://github.com/facebook/react/blob/f86afca090b668d8be10b642750844759768d1ad/packages/react-server-dom-webpack/package.json#L52
       memo.alias['react-dom/server$'] = winPath(

--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -288,10 +288,17 @@ export default function createRequestHandler(
 
     const replaceServerHTMLScript = `<script>!function(){var e=document.getElementById("${SERVER_INSERTED_HTML}");e&&(Array.from(e.children).forEach(e=>{document.head.appendChild(e)}),e.remove())}();</script>`;
 
-    if (typeof FetchEvent !== 'undefined' && args[0] instanceof FetchEvent) {
+    if (process.env.SSR_BUILD_MODE === 'worker') {
       // worker mode
       const [ev, workerOpts] = args as IWorkerRequestHandlerArgs;
       const { pathname, searchParams } = new URL(ev.request.url);
+      let asyncRespondWith: (
+        v: Parameters<FetchEvent['respondWith']>[0],
+      ) => void;
+
+      // respondWith must be called synchronously
+      // ref: https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent/respondWith
+      ev.respondWith(new Promise((r) => (asyncRespondWith = r)));
 
       ret = {
         req: {
@@ -316,7 +323,7 @@ export default function createRequestHandler(
             res = await workerOpts.modifyResponse(res);
           }
 
-          ev.respondWith(res);
+          asyncRespondWith(res);
         },
         async sendPage(jsx) {
           const [JSXProvider, serverInsertedHTMLCallbacks] = createJSXProvider(
@@ -360,7 +367,7 @@ export default function createRequestHandler(
             res = await workerOpts.modifyResponse(res);
           }
 
-          ev.respondWith(res);
+          asyncRespondWith(res);
         },
         otherwise() {
           throw new Error('no page resource');

--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -288,7 +288,7 @@ export default function createRequestHandler(
 
     const replaceServerHTMLScript = `<script>!function(){var e=document.getElementById("${SERVER_INSERTED_HTML}");e&&(Array.from(e.children).forEach(e=>{document.head.appendChild(e)}),e.remove())}();</script>`;
 
-    if (process.env.SSR_BUILD_MODE === 'worker') {
+    if (process.env.SSR_BUILD_TARGET === 'worker') {
       // worker mode
       const [ev, workerOpts] = args as IWorkerRequestHandlerArgs;
       const { pathname, searchParams } = new URL(ev.request.url);


### PR DESCRIPTION
在 #12229 的基础上做了两处调整：
1. 修复 worker 模式下的 `react-dom/server` 产物，worker 环境需要使用 `server.browser` 否则 `renderToReadableStream` API 是不可用的
2. 由于 1 的关系，server 产物在构建时就决定了 ReactDOM 的运行环境（`server.browser` 还是 `server.node`），所以提供 `serverBuildTarget` 配置项并用 define 告知构建器把用不到的逻辑删掉