### PR TITLE
fix(mako): add default plugin key when mako is enabled

### DIFF
--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -446,6 +446,9 @@ if (process.env.NODE_ENV === 'development') {
     const validKeys = await api.applyPlugins({
       key: 'addRuntimePluginKey',
       initialValue: [
+        // why add default?
+        // ref: https://github.com/umijs/mako/issues/1026
+        ...(process.env.OKAM ? ['default'] : []),
         'patchRoutes',
         'patchClientRoutes',
         'modifyContextOpts',


### PR DESCRIPTION
临时解。

ref: https://github.com/umijs/mako/issues/1026


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Introduced a conditional feature that adjusts configuration options based on environment settings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->