### PR TITLE
feat: socket-server 根据 env.HOST 生成

### DIFF
--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -57,6 +57,8 @@ export interface IOpts {
   };
   pkg?: Record<string, any>;
   disableCopy?: boolean;
+  host?: string;
+  port?: number;
 }
 
 export async function getConfig(opts: IOpts): Promise<Configuration> {
@@ -84,6 +86,8 @@ export async function getConfig(opts: IOpts): Promise<Configuration> {
     useHash,
     staticPathPrefix:
       opts.staticPathPrefix !== undefined ? opts.staticPathPrefix : 'static/',
+    port: opts.port,
+    host: opts.host,
   };
 
   // name

--- a/packages/bundler-webpack/src/config/definePlugin.test.ts
+++ b/packages/bundler-webpack/src/config/definePlugin.test.ts
@@ -3,8 +3,10 @@ import { resolveDefine } from './definePlugin';
 test('normal', () => {
   expect(
     resolveDefine({
-      define: { foo: 'bar' },
-    }),
+      userConfig: {
+        define: { foo: 'bar' },
+      },
+    } as any),
   ).toEqual({
     foo: '"bar"',
     'process.env': {
@@ -19,8 +21,10 @@ test('env variables', () => {
   process.env.APP_FOO = 'BAR';
   expect(
     resolveDefine({
-      define: {},
-    }),
+      userConfig: {
+        define: {},
+      },
+    } as any),
   ).toEqual({
     'process.env': {
       NODE_ENV: '"test"',
@@ -32,32 +36,38 @@ test('env variables', () => {
 
 test('should get SOCKET_SERVER if SOCKET_SERVER exists', () => {
   process.env.SOCKET_SERVER = 'socket.server';
-  process.env.HOST = 'test.host';
   expect(
     resolveDefine({
-      define: {},
-    })['process.env']['SOCKET_SERVER'],
+      userConfig: {
+        define: {},
+      },
+      host: 'test.host',
+    } as any)['process.env']['SOCKET_SERVER'],
   ).toEqual('"socket.server"');
 });
 
 test('should get SOCKET_SERVER if HOST exists', () => {
   delete process.env.SOCKET_SERVER;
-  process.env.HOST = 'test.host';
   expect(
     resolveDefine({
-      define: {},
-    })['process.env']['SOCKET_SERVER'],
+      userConfig: {
+        define: {},
+      },
+      host: 'test.host',
+    } as any)['process.env']['SOCKET_SERVER'],
   ).toEqual('"http://test.host:8000"');
 });
 
 test('should get https SOCKET_SERVER if exists', () => {
   delete process.env.SOCKET_SERVER;
-  process.env.HOST = 'test.host';
-  process.env.PORT = '6666';
   expect(
     resolveDefine({
-      define: {},
-      https: true,
-    })['process.env']['SOCKET_SERVER'],
+      userConfig: {
+        define: {},
+        https: true,
+      },
+      host: 'test.host',
+      port: 6666,
+    } as any)['process.env']['SOCKET_SERVER'],
   ).toEqual('"https://test.host:6666"');
 });

--- a/packages/bundler-webpack/src/config/definePlugin.test.ts
+++ b/packages/bundler-webpack/src/config/definePlugin.test.ts
@@ -29,3 +29,35 @@ test('env variables', () => {
     },
   });
 });
+
+test('should get SOCKET_SERVER if SOCKET_SERVER exists', () => {
+  process.env.SOCKET_SERVER = 'socket.server';
+  process.env.HOST = 'test.host';
+  expect(
+    resolveDefine({
+      define: {},
+    })['process.env']['SOCKET_SERVER'],
+  ).toEqual('"socket.server"');
+});
+
+test('should get SOCKET_SERVER if HOST exists', () => {
+  delete process.env.SOCKET_SERVER;
+  process.env.HOST = 'test.host';
+  expect(
+    resolveDefine({
+      define: {},
+    })['process.env']['SOCKET_SERVER'],
+  ).toEqual('"http://test.host:8000"');
+});
+
+test('should get https SOCKET_SERVER if exists', () => {
+  delete process.env.SOCKET_SERVER;
+  process.env.HOST = 'test.host';
+  process.env.PORT = '6666';
+  expect(
+    resolveDefine({
+      define: {},
+      https: true,
+    })['process.env']['SOCKET_SERVER'],
+  ).toEqual('"https://test.host:6666"');
+});

--- a/packages/bundler-webpack/src/config/definePlugin.ts
+++ b/packages/bundler-webpack/src/config/definePlugin.ts
@@ -1,6 +1,7 @@
+import type { HttpsServerOptions } from '@umijs/bundler-utils';
 import { DefinePlugin } from '@umijs/bundler-webpack/compiled/webpack';
 import Config from '@umijs/bundler-webpack/compiled/webpack-5-chain';
-import { Env, IConfig } from '../types';
+import type { Env, IConfig } from '../types';
 
 interface IOpts {
   config: Config;
@@ -9,15 +10,49 @@ interface IOpts {
   env: Env;
 }
 
+interface IResolveDefineOpts {
+  define: any;
+  publicPath?: string;
+  https?: HttpsServerOptions;
+}
+
 const prefixRE = /^UMI_APP_/;
 const ENV_SHOULD_PASS = ['NODE_ENV', 'HMR', 'SOCKET_SERVER', 'ERROR_OVERLAY'];
 
-export function resolveDefine(opts: { define: any; publicPath?: string }) {
-  const env: Record<string, any> = {};
-  Object.keys(process.env).forEach((key) => {
-    if (prefixRE.test(key) || ENV_SHOULD_PASS.includes(key)) {
-      env[key] = process.env[key];
+// 环境变量传递自定义逻辑，默认直接透传
+const EnvGetter: Record<
+  string,
+  (opts: IResolveDefineOpts) => string | undefined
+> = {
+  SOCKET_SERVER: (opts: IResolveDefineOpts) => {
+    // 如果当前有 process.env.SOCKET_SERVER，则使用当前值
+    if (process.env.SOCKET_SERVER) {
+      return process.env.SOCKET_SERVER;
     }
+    // 如果当前无 process.env.SOCKET_SERVER
+    // 则判断是否有 process.env.HOST 且不为 0.0.0.0/127.0.0.1/localhost
+    if (
+      process.env.HOST &&
+      !['0.0.0.0', '127.0.0.1', 'localhost'].includes(process.env.HOST)
+    ) {
+      const protocol = opts.https ? 'https:' : 'http:';
+      return `${protocol}//${process.env.HOST}:${process.env.PORT || 8000}`;
+    }
+    return;
+  },
+};
+
+export function resolveDefine(opts: IResolveDefineOpts) {
+  const env: Record<string, any> = {};
+  // 带 UMI_APP_ 前缀的和 ENV_SHOULD_PASS 定义的环境变量需要透传
+  ENV_SHOULD_PASS.concat(
+    Object.keys(process.env).filter((k) => prefixRE.test(k)),
+  ).forEach((key: string) => {
+    const envValue = EnvGetter[key] ? EnvGetter[key](opts) : process.env[key];
+    if (typeof envValue === 'undefined') {
+      return;
+    }
+    env[key] = envValue;
   });
 
   // Useful for resolving the correct path to static assets in `public`.
@@ -47,6 +82,7 @@ export async function addDefinePlugin(opts: IOpts) {
     resolveDefine({
       define: userConfig.define || {},
       publicPath: userConfig.publicPath,
+      https: userConfig.https,
     }),
   ] as any);
 }

--- a/packages/bundler-webpack/src/config/definePlugin.ts
+++ b/packages/bundler-webpack/src/config/definePlugin.ts
@@ -15,7 +15,7 @@ const prefixRE = /^UMI_APP_/;
 const ENV_SHOULD_PASS = ['NODE_ENV', 'HMR', 'SOCKET_SERVER', 'ERROR_OVERLAY'];
 const SOCKET_IGNORE_HOSTS = ['0.0.0.0', '127.0.0.1', 'localhost'];
 // 环境变量传递自定义逻辑，默认直接透传
-const EVN_GETTER: Record<string, (opts: IOpts) => string | undefined> = {
+const CUSTOM_ENV_GETTER: Record<string, (opts: IOpts) => string | undefined> = {
   SOCKET_SERVER: (opts: IOpts) => {
     const { userConfig, host, port } = opts;
     const socketServer = process.env.SOCKET_SERVER;
@@ -40,7 +40,9 @@ export function resolveDefine(opts: IOpts) {
   ENV_SHOULD_PASS.concat(
     Object.keys(process.env).filter((k) => prefixRE.test(k)),
   ).forEach((key: string) => {
-    const envValue = EVN_GETTER[key] ? EVN_GETTER[key](opts) : process.env[key];
+    const envValue = CUSTOM_ENV_GETTER[key]
+      ? CUSTOM_ENV_GETTER[key](opts)
+      : process.env[key];
     if (typeof envValue === 'undefined') {
       return;
     }

--- a/packages/bundler-webpack/src/config/definePlugin.ts
+++ b/packages/bundler-webpack/src/config/definePlugin.ts
@@ -1,4 +1,3 @@
-import type { HttpsServerOptions } from '@umijs/bundler-utils';
 import { DefinePlugin } from '@umijs/bundler-webpack/compiled/webpack';
 import Config from '@umijs/bundler-webpack/compiled/webpack-5-chain';
 import type { Env, IConfig } from '../types';
@@ -8,47 +7,40 @@ interface IOpts {
   userConfig: IConfig;
   cwd: string;
   env: Env;
-}
-
-interface IResolveDefineOpts {
-  define: any;
-  publicPath?: string;
-  https?: HttpsServerOptions;
+  host?: string;
+  port?: number;
 }
 
 const prefixRE = /^UMI_APP_/;
 const ENV_SHOULD_PASS = ['NODE_ENV', 'HMR', 'SOCKET_SERVER', 'ERROR_OVERLAY'];
-
+const SOCKET_IGNORE_HOSTS = ['0.0.0.0', '127.0.0.1', 'localhost'];
 // 环境变量传递自定义逻辑，默认直接透传
-const EnvGetter: Record<
-  string,
-  (opts: IResolveDefineOpts) => string | undefined
-> = {
-  SOCKET_SERVER: (opts: IResolveDefineOpts) => {
+const EVN_GETTER: Record<string, (opts: IOpts) => string | undefined> = {
+  SOCKET_SERVER: (opts: IOpts) => {
+    const { userConfig, host, port } = opts;
+    const socketServer = process.env.SOCKET_SERVER;
     // 如果当前有 process.env.SOCKET_SERVER，则使用当前值
-    if (process.env.SOCKET_SERVER) {
-      return process.env.SOCKET_SERVER;
+    if (socketServer) {
+      return socketServer;
     }
     // 如果当前无 process.env.SOCKET_SERVER
     // 则判断是否有 process.env.HOST 且不为 0.0.0.0/127.0.0.1/localhost
-    if (
-      process.env.HOST &&
-      !['0.0.0.0', '127.0.0.1', 'localhost'].includes(process.env.HOST)
-    ) {
-      const protocol = opts.https ? 'https:' : 'http:';
-      return `${protocol}//${process.env.HOST}:${process.env.PORT || 8000}`;
+    if (host && !SOCKET_IGNORE_HOSTS.includes(host)) {
+      const protocol = userConfig.https ? 'https:' : 'http:';
+      return `${protocol}//${host}:${port || 8000}`;
     }
     return;
   },
 };
 
-export function resolveDefine(opts: IResolveDefineOpts) {
+export function resolveDefine(opts: IOpts) {
+  const { userConfig } = opts;
   const env: Record<string, any> = {};
   // 带 UMI_APP_ 前缀的和 ENV_SHOULD_PASS 定义的环境变量需要透传
   ENV_SHOULD_PASS.concat(
     Object.keys(process.env).filter((k) => prefixRE.test(k)),
   ).forEach((key: string) => {
-    const envValue = EnvGetter[key] ? EnvGetter[key](opts) : process.env[key];
+    const envValue = EVN_GETTER[key] ? EVN_GETTER[key](opts) : process.env[key];
     if (typeof envValue === 'undefined') {
       return;
     }
@@ -57,16 +49,16 @@ export function resolveDefine(opts: IResolveDefineOpts) {
 
   // Useful for resolving the correct path to static assets in `public`.
   // For example, <img src={process.env.PUBLIC_PATH + '/img/logo.png'} />.
-  env.PUBLIC_PATH = opts.publicPath || '/';
+  env.PUBLIC_PATH = userConfig.publicPath || '/';
 
   for (const key in env) {
     env[key] = JSON.stringify(env[key]);
   }
 
   const define: Record<string, any> = {};
-  if (opts.define) {
-    for (const key in opts.define) {
-      define[key] = JSON.stringify(opts.define[key]);
+  if (userConfig.define) {
+    for (const key in userConfig.define) {
+      define[key] = JSON.stringify(userConfig.define[key]);
     }
   }
 
@@ -77,12 +69,6 @@ export function resolveDefine(opts: IResolveDefineOpts) {
 }
 
 export async function addDefinePlugin(opts: IOpts) {
-  const { config, userConfig } = opts;
-  config.plugin('define').use(DefinePlugin, [
-    resolveDefine({
-      define: userConfig.define || {},
-      publicPath: userConfig.publicPath,
-      https: userConfig.https,
-    }),
-  ] as any);
+  const { config } = opts;
+  config.plugin('define').use(DefinePlugin, [resolveDefine(opts)] as any);
 }

--- a/packages/bundler-webpack/src/dev.ts
+++ b/packages/bundler-webpack/src/dev.ts
@@ -156,6 +156,8 @@ export async function setup(opts: IOpts) {
       : undefined,
     pkg: opts.pkg,
     disableCopy: opts.disableCopy,
+    port: opts.port,
+    host: opts.host,
   });
 
   const depConfig = await configModule.getConfig({
@@ -175,6 +177,8 @@ export async function setup(opts: IOpts) {
       cacheDirectory: join(cacheDirectoryPath, 'mfsu-deps'),
     },
     pkg: opts.pkg,
+    port: opts.port,
+    host: opts.host,
   });
 
   webpackConfig.resolve!.alias ||= {};


### PR DESCRIPTION
HMR 的 WS 地址在没直接配置 SOCKET_SERVER 环境变量时，优先与 HOST 环境变量保持一致，兜底才是当前访问地址

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced environment variable resolution in the application configuration settings.
- **Refactor**
	- Improved internal handling of configuration types and definitions.
- **Tests**
	- Added tests to ensure accurate environment variable resolution based on specific conditions.
- **Documentation**
	- Updated documentation for the new `host` and `port` options in the configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->