### PR TITLE
feat: qiankun 插件支持 ssr

### DIFF
--- a/packages/plugins/libs/qiankun/master/masterRuntimePlugin.tsx
+++ b/packages/plugins/libs/qiankun/master/masterRuntimePlugin.tsx
@@ -138,6 +138,9 @@ export async function render(oldRender: typeof noop) {
 }
 
 export function patchClientRoutes({ routes }: { routes: any[] }) {
+  if (typeof window === 'undefined') {
+    return;
+  }
   const microAppRoutes = [].concat(
     deepFilterLeafRoutes(routes),
     deepFilterLeafRoutes(microAppRuntimeRoutes),

--- a/packages/plugins/src/qiankun/master.ts
+++ b/packages/plugins/src/qiankun/master.ts
@@ -210,4 +210,15 @@ export { MicroAppWithMemoHistory } from './MicroAppWithMemoHistory';
       `,
     });
   });
+
+  api.modifyConfig({
+    before: 'ssr',
+    fn: (memo) => {
+      if (memo.ssr) {
+        memo.externals ??= {};
+        memo.externals.qiankun = 'fs';
+      }
+      return memo;
+    },
+  });
 };

--- a/packages/plugins/src/qiankun/slave.ts
+++ b/packages/plugins/src/qiankun/slave.ts
@@ -180,7 +180,10 @@ export interface IRuntimeConfig {
         ];
   });
 
-  api.chainWebpack((config) => {
+  api.chainWebpack((config, { ssr }: any) => {
+    if (ssr) {
+      return;
+    }
     assert(api.pkg.name, 'You should have name in package.json.');
     // 默认不修改 library chunk 的 name，从而确保可以通过 window[appName] 访问到导出
     // mfsu 关闭的时候才可以修改，否则可能导致配合 mfsu 时，子应用的 umd chunk 无法被正确加载
@@ -223,11 +226,11 @@ export interface IRuntimeConfig {
 
   api.addEntryCode(() => [
     `
-export const bootstrap = qiankun_genBootstrap(render);
+export const bootstrap = qiankun_genBootstrap(typeof window !== 'undefined' ? render : () => {});
 export const mount = qiankun_genMount('${api.config.mountElementId}');
 export const unmount = qiankun_genUnmount('${api.config.mountElementId}');
 export const update = qiankun_genUpdate();
-if (!window.__POWERED_BY_QIANKUN__) {
+if (typeof window !== 'undefined' && !window.__POWERED_BY_QIANKUN__) {
   bootstrap().then(mount);
 }
     `,


### PR DESCRIPTION
1. 主应用
    external qiankun
    修改 patchClientRoutes
2. 子应用
    禁用 umd 构建
    生命周期处理