### PR TITLE
chore(react-query): skip get pkg path when plugin is disabled

### DIFF
--- a/packages/plugins/src/react-query.ts
+++ b/packages/plugins/src/react-query.ts
@@ -125,9 +125,6 @@ const getReactQueryPkgInfo = (api: IApi) => {
     useV5,
     corePath,
   };
-
-  console.log('reactQueryInfo: ', reactQueryInfo);
-
   return reactQueryInfo;
 };
 

--- a/packages/plugins/src/react-query.ts
+++ b/packages/plugins/src/react-query.ts
@@ -266,7 +266,7 @@ export {
       `,
     });
 
-    const exportTypes: string[] = [
+    const exportTypes = [
       // from @tanstack/query-core
       'Query',
       'QueryState',


### PR DESCRIPTION
我今天发现 RQ 的获取包信息的逻辑即使不开启这个插件也会运行，由于 RQ 插件用的人不多，所以是浪费成本。

改为如果不开启该插件，则不获取这些信息。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced package information retrieval and caching for React Query to optimize performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->