### PR TITLE
feat: use prerender html directly in ssg

### DIFF
--- a/examples/ssr-demo/.umirc.ts
+++ b/examples/ssr-demo/.umirc.ts
@@ -11,6 +11,7 @@ export default {
     builder: 'webpack',
     renderFromRoot: false,
   },
+  exportStatic: {},
   styles: [`body { color: red; }`, `https://a.com/b.css`],
 
   metas: [

--- a/examples/ssr-demo/src/pages/index.tsx
+++ b/examples/ssr-demo/src/pages/index.tsx
@@ -65,7 +65,7 @@ export async function clientLoader() {
 }
 
 export const serverLoader: ServerLoader = async (req) => {
-  const url = req!.request.url;
+  const url = req?.request.url;
   await new Promise((resolve) => setTimeout(resolve, Math.random() * 1000));
   return { message: `data from server loader of index.tsx, url: ${url}` };
 };


### PR DESCRIPTION
1. 按照 https://github.com/umijs/umi/discussions/12060 的结论，SSG 应当直接使用 SSR 的产物（之前是由 htmlTpl 拼接的）
2. 看起来直接将 serverInsertedHtml 拼接到 head 里后也不需要 modifyExportStaticHTML 这个 hook 来处理什么了