### PR TITLE
refactor: 🔥 remove deep clone

### DIFF
--- a/packages/core/src/service/service.ts
+++ b/packages/core/src/service/service.ts
@@ -52,7 +52,7 @@ export class Service {
     >;
     framework?: IFrameworkType;
     prepare?: {
-      buildResult: BuildResult;
+      buildResult: Omit<BuildResult, 'outputFiles'>;
       fileImports?: Record<string, Declaration[]>;
     };
     mpa?: {

--- a/packages/preset-umi/src/features/prepare/prepare.ts
+++ b/packages/preset-umi/src/features/prepare/prepare.ts
@@ -1,12 +1,6 @@
 import type { BuildResult } from '@umijs/bundler-utils/compiled/esbuild';
 import type { Declaration } from '@umijs/es-module-parser';
-import {
-  aliasUtils,
-  importLazy,
-  isJavaScriptFile,
-  lodash,
-  logger,
-} from '@umijs/utils';
+import { aliasUtils, importLazy, isJavaScriptFile, logger } from '@umijs/utils';
 import path from 'path';
 import { addUnWatch } from '../../commands/dev/watch';
 import { IApi, IOnGenerateFiles } from '../../types';
@@ -20,11 +14,12 @@ export default (api: IApi) => {
     buildResult: BuildResult;
     fileImports?: Record<string, Declaration[]>;
   }) {
-    const buildResult: BuildResult = lodash.cloneDeep(prepareData.buildResult);
-    (buildResult.outputFiles || []).forEach((file) => {
-      // @ts-ignore
-      delete file?.contents;
-    });
+    const buildResult: BuildResult = {
+      ...prepareData.buildResult,
+      // we don't need output file in prepare stage
+      outputFiles: [],
+    };
+
     const nextFileImports =
       prepareData.fileImports ?? api.appData.prepare?.fileImports;
     api.appData.prepare = {

--- a/packages/preset-umi/src/features/prepare/prepare.ts
+++ b/packages/preset-umi/src/features/prepare/prepare.ts
@@ -17,7 +17,7 @@ export default (api: IApi) => {
     const buildResult: BuildResult = {
       ...prepareData.buildResult,
       // we don't need output file in prepare stage
-      outputFiles: [],
+      outputFiles: undefined,
     };
 
     const nextFileImports =


### PR DESCRIPTION
目前 prepare 数据仅 msfu 消费，mfsu 只消费 buildResult#metafile#inputs
destruct 直接直接覆盖 空数组覆盖 outputfiles 

close https://github.com/umijs/umi/issues/12224 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Refactor**
	- Streamlined the preparation process by enhancing the handling of build results, improving efficiency.
- **Documentation**
	- Updated the `Service` class in `service.ts` to reflect changes in the `prepare` property declaration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->