### PR TITLE
fix: received props on qiankun slave update

### DIFF
--- a/packages/plugins/libs/qiankun/master/MicroApp.tsx
+++ b/packages/plugins/libs/qiankun/master/MicroApp.tsx
@@ -167,6 +167,13 @@ export const MicroApp = forwardRef(
       props: { settings: settingsFromConfig = {}, ...propsFromConfig } = {},
     } = appConfig || {};
 
+    const __globalRoutesInfo = {
+      appNameKeyAlias,
+      masterHistoryType,
+      base: globalSettings.base,
+      microAppRoutes: globalSettings.microAppRoutes,
+    };
+
     useEffect(() => {
       setComponentError(null);
       setLoading(true);
@@ -185,12 +192,7 @@ export const MicroApp = forwardRef(
             ...propsFromConfig,
             ...stateForSlave,
             ...propsFromParams,
-            __globalRoutesInfo: {
-              appNameKeyAlias,
-              masterHistoryType,
-              base: globalSettings.base,
-              microAppRoutes: globalSettings.microAppRoutes,
-            },
+            __globalRoutesInfo,
             setLoading,
           },
         },
@@ -263,6 +265,7 @@ export const MicroApp = forwardRef(
                 ...propsFromConfig,
                 ...stateForSlave,
                 ...propsFromParams,
+                __globalRoutesInfo,
                 setLoading,
               };
 


### PR DESCRIPTION
fix #12306

修复 qiankun 子应用更新时漏传了 routes info 对象，这会导致 `<MicroAppLink />` 后续收不到这个字段失效。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the route management in the `MicroApp` component for simplified configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->