### PR TITLE
fix: handle dumi file path

### DIFF
--- a/packages/preset-umi/src/features/tmpFiles/routes.ts
+++ b/packages/preset-umi/src/features/tmpFiles/routes.ts
@@ -17,7 +17,7 @@ export async function getApiRoutes(opts: { api: IApi }) {
   });
 
   function localPath(path: string) {
-    if (path.charAt(0) !== '.') {
+    if (path.charAt(0) !== '.' || path.charAt(1) !== '/') {
       return `./${path}`;
     }
     {
@@ -79,7 +79,7 @@ export async function getRoutes(opts: {
   }
 
   function localPath(path: string) {
-    if (path.charAt(0) !== '.') {
+    if (path.charAt(0) !== '.' || path.charAt(1) !== '/') {
       return `./${path}`;
     } else {
       return path;


### PR DESCRIPTION
# Description
Fixed an error that occurred when running `pnpm umi plugin list`

# Motivation
`.dumi` file path is not handled correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了路径处理功能，现在可以更准确地识别和处理以 `'.'` 或 `'/'` 开头的路径字符串。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->