### PR TITLE
refactor(preset-umi): handle illegal route absPath in route preload

### DIFF
--- a/packages/preset-umi/src/features/routePreloadOnLoad/routePreloadOnLoad.ts
+++ b/packages/preset-umi/src/features/routePreloadOnLoad/routePreloadOnLoad.ts
@@ -93,14 +93,6 @@ async function getRouteChunkFilesMap(
     // skip entry chunk
     if (chunk.entry) continue;
 
-    // skip illegal absPath route
-    if (!route.absPath?.startsWith('/')) {
-      logger.error(
-        `[routePreloadOnLoad]: route absPath error, cannot preload for ${route.absPath}`,
-      );
-      continue;
-    }
-
     // pick js and css files
     const pickedFiles = pickPreloadFiles(chunk.files!);
     const routeOrigins = chunk.origins!.filter((origin) =>
@@ -160,6 +152,14 @@ async function getRoutePathFilesMap(
   for (const route of Object.values<IRoute>(routes)) {
     // skip redirect route
     if (!route.file) continue;
+
+    // skip illegal absPath route
+    if (!route.absPath?.startsWith('/')) {
+      logger.error(
+        `[routePreloadOnLoad]: route absPath error, cannot preload for ${route.absPath}`,
+      );
+      continue;
+    }
 
     let current: IRoute | undefined = route;
     const files: string[] = [];

--- a/packages/preset-umi/src/features/routePreloadOnLoad/routePreloadOnLoad.ts
+++ b/packages/preset-umi/src/features/routePreloadOnLoad/routePreloadOnLoad.ts
@@ -93,6 +93,14 @@ async function getRouteChunkFilesMap(
     // skip entry chunk
     if (chunk.entry) continue;
 
+    // skip illegal absPath route
+    if (!route.absPath?.startsWith('/')) {
+      logger.error(
+        `[routePreloadOnLoad]: route absPath error, cannot preload for ${route.absPath}`,
+      );
+      continue;
+    }
+
     // pick js and css files
     const pickedFiles = pickPreloadFiles(chunk.files!);
     const routeOrigins = chunk.origins!.filter((origin) =>


### PR DESCRIPTION
子路由资源预加载时跳过 absPath 不合法的路由，避免在匹配时出现问题，比如 `*` 会导致正则实例化报错