### PR TITLE
fix(webpack-5-chain): assetModuleFilename key typo  in Output Type

### DIFF
--- a/packages/bundler-webpack/compiled/webpack-5-chain/types/index.d.ts
+++ b/packages/bundler-webpack/compiled/webpack-5-chain/types/index.d.ts
@@ -200,7 +200,7 @@ declare namespace Config {
     ): this;
     devtoolNamespace(value: WebpackOutput['devtoolNamespace']): this;
     filename(value: WebpackOutput['filename']): this;
-    assetModuleFilenamet(value: WebpackOutput['assetModuleFilename']): this;
+    assetModuleFilename(value: WebpackOutput['assetModuleFilename']): this;
     globalObject(value: WebpackOutput['globalObject']): this;
     uniqueName(value: WebpackOutput['uniqueName']): this;
     hashDigest(value: WebpackOutput['hashDigest']): this;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 修正了配置命名空间中 `assetModuleFilename` 方法的错别字。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->