### PR TITLE
fix: antd config setter conflict with model plugin

### DIFF
--- a/packages/plugins/templates/antd/runtime.ts.tpl
+++ b/packages/plugins/templates/antd/runtime.ts.tpl
@@ -44,6 +44,11 @@ const getAntdConfig = () => {
   {{/appConfig}}
       },
     });
+    {{#modelPluginCompat}}
+    if (!cacheAntdConfig.theme) {
+      cacheAntdConfig.theme = {};
+    }
+    {{/modelPluginCompat}}
   }
   return cacheAntdConfig;
 }


### PR DESCRIPTION
close #12394

修复使用 `useAntdConfigSetter` 方法更改主题时，和 model 插件逻辑发生的冲突。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 增加了对 `modelPluginCompat` 的支持，增强了插件的兼容性。
  - 优化了 `getAntdConfig` 函数，确保 `cacheAntdConfig.theme` 在不存在时能被初始化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->