### PR TITLE
fix: ProLayout filtering routing exceptions,when plugin are inserted into other layouts before ProLayout

### DIFF
--- a/packages/plugins/src/layout.ts
+++ b/packages/plugins/src/layout.ts
@@ -216,6 +216,21 @@ const mapRoutes = (routes: IRoute[]) => {
   })
 }
 
+// 如果通过plugin插入其他layout，会导致路由层级变更
+const deepFilter = (routes: IRoute[]) => {
+  if (!routes || routes.length === 0) {
+    return []
+  }
+  for (const route of routes) {
+    const newRoues = deepFilter(route.children)
+
+    if (newRoues && newRoues.length > 0) {
+      return newRoues
+    }
+  }
+  return routes.filter(route => route.id === 'ant-design-pro-layout')
+}
+
 export default (props: any) => {
   const location = useLocation();
   const navigate = useNavigate();
@@ -244,7 +259,7 @@ const { formatMessage } = useIntl();
 
 
   // 现在的 layout 及 wrapper 实现是通过父路由的形式实现的, 会导致路由数据多了冗余层级, proLayout 消费时, 无法正确展示菜单, 这里对冗余数据进行过滤操作
-  const newRoutes = filterRoutes(clientRoutes.filter(route => route.id === 'ant-design-pro-layout'), (route) => {
+  const newRoutes = filterRoutes(deepFilter(clientRoutes), (route) => {
     return (!!route.isLayout && route.id !== 'ant-design-pro-layout') || !!route.isWrapper;
   })
   const [route] = useAccessMarkedRoutes(mapRoutes(newRoutes));


### PR DESCRIPTION
# 问题描述
当我想在 ProLayout前通过插件插入其他容器，用来注册我需要上下文时，发现无法支持，只能在@umijs/plugins/dist/layout后进行插入
随后发现，生成的 Layout.tsx 中只对 clientRoutes 的第一次进行过滤，导致在 ProLayout 前进行插入容器操作，会导致 Layout.tsx 无法获取到正确的路由数据，导致报错[如下图]。
![image](https://github.com/umijs/umi/assets/61722999/e0f5abf2-8528-4c86-860a-05ebb7ee0964)
![image](https://github.com/umijs/umi/assets/61722999/0cc9d8cd-b3a6-4930-bb75-672ff21a9c2f)
# 解决
递归去寻找 id 为 ant-design-pro-layout 的元素


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 引入了新的 `deepFilter` 功能，用于根据特定条件过滤路由，优化了 `proLayout` 组件的路由层次结构和菜单显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->