### PR TITLE
修复一个三方依赖exports导出__esModule=true引起的导入问题

### DIFF
--- a/packages/mfsu/src/depBuilder/getESBuildEntry.ts
+++ b/packages/mfsu/src/depBuilder/getESBuildEntry.ts
@@ -6,10 +6,10 @@ const ES_INTEROP_FUNC = `__exportStar`;
 const ES_INTEROP_HELPER = `
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
   if (k2 === undefined) k2 = k;
-  Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+  if (k !== '__esModule') Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
 }) : (function(o, m, k, k2) {
   if (k2 === undefined) k2 = k;
-  o[k2] = m[k];
+  if (k !== '__esModule') o[k2] = m[k];
 }));
 var ${ES_INTEROP_FUNC} = (this && this.__exportStar) || function(m, exports) {
   for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);


### PR DESCRIPTION
webpack本来可以正常处理模块，因为依赖导出带有__esModule.webpack导入的时候当成es模块处理去取default，结果模块里没有default，已经被esbuild导出的时候处理了，结果导致webpack 默认导入失败，
起因是旧项目升级打包工具webpack5.91.0。顺便用umijs mfsu优化开发体验，结果遇到一些问题。在启用mfsu时 项目代码在导入import locale from 'element-ui/lib/locale' 版本是2.15.14 的时候提示locale不存在.后来发现其代码中有exports.__esModule = true;去掉之后就正常了。所以希望这里兼容一下，就不要将模块里的__esModule这个字段给合并了

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复**
  - 修改了 ES 互操作辅助函数，以避免在定义属性时包含 `__esModule` 键。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->