### PR TITLE
fix: 兼容一下部分库的浏览器入口配置

### DIFF
--- a/packages/mfsu/src/utils/resolveUtils.ts
+++ b/packages/mfsu/src/utils/resolveUtils.ts
@@ -12,6 +12,8 @@ const browserResolver = enhancedResolve.create({
   exportsFields: EXPORTS_FIELDS,
   conditionNames: ['browser', 'import'],
   symlinks: false,
+  // 兼容一下部分库的地址解析，比如qrcode库，package.json里配置了browser的入口地址
+  aliasFields: ["browser"] 
 });
 
 const esmResolver = enhancedResolve.create({


### PR DESCRIPTION
具体表现为qrcode这种node环境和浏览器环境不同代码的，且在package.json中配置了browser的库。升级项目采用mfsu时遇到打包依赖报错，入口选择node版本的。也希望官方给出更好的方案，遇到问题的库时 qrcode@1.5.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 增加了对某些库（如 `qrcode`）的兼容性，这些库在其 `package.json` 中配置了 `browser` 入口点。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->