### PR TITLE
fix(mfsu): 修复windows下配置更新导致文件变化后，mfsu 缓存不更新的问题

### DIFF
--- a/packages/mfsu/src/mfsu/strategyStaticAnalyze.ts
+++ b/packages/mfsu/src/mfsu/strategyStaticAnalyze.ts
@@ -192,7 +192,7 @@ function extractJSCodeFiles(folderBase: string, files: ReadonlySet<string>) {
 
   for (let file of files.values()) {
     if (
-      winPath(file.startsWith(winPath(folderBase))) &&
+      winPath(file).startsWith(winPath(folderBase)) &&
       REG_CODE_EXT.test(file) &&
       file.indexOf('node_modules') === -1
     ) {


### PR DESCRIPTION
windows 下，比如更新 routes 里面的 icon，会更新 src/.umi/plugin-layout/icon.tsx 中的内容，理论上需要更新 mfsu 缓存，但因为路径格式不一致（D:/xx 和 D:\\xx 的区别），导致 mfsu 虽然监听到文件内容的更改，但没有触发相应的更新逻辑。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **修复**
  - 修改了路径比较方法以提高跨平台兼容性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->