### PR TITLE
fix(prepare): esbuild should respect tsconfig.json

### DIFF
--- a/packages/preset-umi/fixtures/prepare-build/normal/index.ts
+++ b/packages/preset-umi/fixtures/prepare-build/normal/index.ts
@@ -8,8 +8,12 @@ import './a.ext-must-not-exist';
 import './a.html';
 // relative imports
 import { bar } from './bar/bar';
+import { load } from './context/context';
+import { UseDecorator } from './paramDecorator/jsDecorator.js';
+import { TsUseDecorator } from './paramDecorator/tsDecorator.ts';
 import { foo } from './foo';
-import { load } from './context/context'
+
 console.log(foo);
 console.log(bar);
-console.log(load)
+console.log(load);
+console.log(UseDecorator, TsUseDecorator);

--- a/packages/preset-umi/fixtures/prepare-build/normal/paramDecorator/jsDecorator.js
+++ b/packages/preset-umi/fixtures/prepare-build/normal/paramDecorator/jsDecorator.js
@@ -1,0 +1,13 @@
+function prop() {}
+
+export class UseDecorator {
+  @prop()
+  a = 1;
+
+  fn(
+    @prop()
+    jsParam,
+  ) {
+    console.log(a);
+  }
+}

--- a/packages/preset-umi/fixtures/prepare-build/normal/paramDecorator/tsDecorator.ts
+++ b/packages/preset-umi/fixtures/prepare-build/normal/paramDecorator/tsDecorator.ts
@@ -1,0 +1,15 @@
+function tsProp(): any {}
+
+@tsProp()
+export class TsUseDecorator {
+  @tsProp()
+  a = 1;
+
+  @tsProp()
+  test(
+    @tsProp()
+    param: string,
+  ) {
+    console.log(param);
+  }
+}

--- a/packages/preset-umi/fixtures/prepare-build/normal/tsconfig.json
+++ b/packages/preset-umi/fixtures/prepare-build/normal/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
+}

--- a/packages/preset-umi/src/features/prepare/build.test.ts
+++ b/packages/preset-umi/src/features/prepare/build.test.ts
@@ -18,6 +18,9 @@ test('build', async () => {
   expect(text).toContain(`import "./a.html"`);
   expect(text).toContain(`var bar = "bar"`);
   expect(text).toContain(`var foo = "foo"`);
+
+  expect(text).toContain(`__decorateParam(0, tsProp())`);
+  expect(text).toContain(`__decorateParam(0, prop())`);
 });
 
 test('build with alias', async () => {

--- a/packages/preset-umi/src/features/prepare/build.ts
+++ b/packages/preset-umi/src/features/prepare/build.ts
@@ -5,6 +5,7 @@ import esbuild, {
   BuildResult,
 } from '@umijs/bundler-utils/compiled/esbuild';
 import { logger } from '@umijs/utils';
+import { existsSync } from 'fs';
 import path from 'path';
 import { esbuildAliasPlugin } from './esbuildPlugins/esbuildAliasPlugin';
 import { esbuildExternalPlugin } from './esbuildPlugins/esbuildExternalPlugin';
@@ -22,6 +23,10 @@ export async function build(opts: {
 }): Promise<[BuildResult, BuildContext | undefined]> {
   const outdir = path.join(path.dirname(opts.entryPoints[0]), 'out');
   const alias = opts.config?.alias || {};
+  const tsconfig = existsSync(path.join(opts.config.cwd, 'tsconfig.json'))
+    ? 'tsconfig.json'
+    : undefined;
+
   const buildOptions: BuildOptions = {
     // 需要指定 absWorkingDir 兼容 APP_ROOT 的情况
     absWorkingDir: opts.config.cwd,
@@ -30,13 +35,14 @@ export async function build(opts: {
     target: 'esnext',
     loader: {
       // use tsx loader for js/jsx/ts/tsx files
-      // since only ts support decorator
+      // since only ts support paramDecorator
       ...possibleExtUsingEmptyLoader,
       '.js': 'tsx',
       '.jsx': 'tsx',
       '.ts': 'ts',
       '.tsx': 'tsx',
     },
+    tsconfig,
     // do I need this?
     // incremental: true,
     bundle: true,


### PR DESCRIPTION
![image](https://github.com/umijs/umi/assets/415655/865956f9-d8d9-4f64-9423-bdd7e788b2ce)

实际 prepare 被有传 tsconfig 给 esbuild，用户根据提示改也不生效。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 添加了装饰器功能支持，包括 `UseDecorator` 和 `TsUseDecorator` 类，允许在属性和方法参数上使用装饰器。
  - 引入了 `tsconfig.json` 文件，启用了 `experimentalDecorators` 设置以支持实验性的装饰器功能。

- **测试**
  - 更新了构建测试，增加了对参数装饰器相关文本片段的断言。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->