### PR TITLE
feat: prioritize user installation of babel-plugin-react-compiler

### DIFF
--- a/packages/preset-umi/src/features/configPlugins/configPlugins.ts
+++ b/packages/preset-umi/src/features/configPlugins/configPlugins.ts
@@ -1,22 +1,9 @@
 import { getSchemas as getViteSchemas } from '@umijs/bundler-vite/dist/schema';
 import { getSchemas as getWebpackSchemas } from '@umijs/bundler-webpack/dist/schema';
-import { resolve } from '@umijs/utils';
 import { dirname, join } from 'path';
 import type { IApi } from '../../types';
+import { resolveProjectDep } from '../../utils/resolveProjectDep';
 import { getSchemas as getExtraSchemas } from './schema';
-
-function resolveProjectDep(opts: { pkg: any; cwd: string; dep: string }) {
-  if (
-    opts.pkg.dependencies?.[opts.dep] ||
-    opts.pkg.devDependencies?.[opts.dep]
-  ) {
-    return dirname(
-      resolve.sync(`${opts.dep}/package.json`, {
-        basedir: opts.cwd,
-      }),
-    );
-  }
-}
 
 export default (api: IApi) => {
   const { userConfig } = api;

--- a/packages/preset-umi/src/features/forget/forget.ts
+++ b/packages/preset-umi/src/features/forget/forget.ts
@@ -1,5 +1,15 @@
 import { IApi } from '../../types';
 
+const loadModule = (moduleName: string, path: string) => {
+  try {
+    return require.resolve(moduleName, {
+      paths: [path],
+    });
+  } catch (err) {
+    return require.resolve(moduleName);
+  }
+};
+
 export default (api: IApi) => {
   api.describe({
     key: 'forget',
@@ -42,7 +52,7 @@ export default (api: IApi) => {
       extraBabelPlugins: [
         ...(memo.extraBabelPlugins || []),
         [
-          require.resolve('babel-plugin-react-compiler', { paths: [api.cwd] }),
+          loadModule('babel-plugin-react-compiler', api.cwd),
           ReactCompilerConfig,
         ],
       ],

--- a/packages/preset-umi/src/features/forget/forget.ts
+++ b/packages/preset-umi/src/features/forget/forget.ts
@@ -54,7 +54,7 @@ export default (api: IApi) => {
       ...memo,
       extraBabelPlugins: [
         ...(memo.extraBabelPlugins || []),
-        [require.resolve(libPath), ReactCompilerConfig],
+        [libPath, ReactCompilerConfig],
       ],
     };
   });

--- a/packages/preset-umi/src/features/forget/forget.ts
+++ b/packages/preset-umi/src/features/forget/forget.ts
@@ -41,7 +41,10 @@ export default (api: IApi) => {
       ...memo,
       extraBabelPlugins: [
         ...(memo.extraBabelPlugins || []),
-        [require.resolve('babel-plugin-react-compiler'), ReactCompilerConfig],
+        [
+          require.resolve('babel-plugin-react-compiler', { paths: [api.cwd] }),
+          ReactCompilerConfig,
+        ],
       ],
     };
   });

--- a/packages/preset-umi/src/features/forget/forget.ts
+++ b/packages/preset-umi/src/features/forget/forget.ts
@@ -54,7 +54,7 @@ export default (api: IApi) => {
       ...memo,
       extraBabelPlugins: [
         ...(memo.extraBabelPlugins || []),
-        [[require.resolve(libPath), ReactCompilerConfig], ReactCompilerConfig],
+        [require.resolve(libPath), ReactCompilerConfig],
       ],
     };
   });

--- a/packages/preset-umi/src/utils/resolveProjectDep.ts
+++ b/packages/preset-umi/src/utils/resolveProjectDep.ts
@@ -1,0 +1,19 @@
+import { resolve } from '@umijs/utils';
+import { dirname } from 'path';
+
+export function resolveProjectDep(opts: {
+  pkg: any;
+  cwd: string;
+  dep: string;
+}) {
+  if (
+    opts.pkg.dependencies?.[opts.dep] ||
+    opts.pkg.devDependencies?.[opts.dep]
+  ) {
+    return dirname(
+      resolve.sync(`${opts.dep}/package.json`, {
+        basedir: opts.cwd,
+      }),
+    );
+  }
+}


### PR DESCRIPTION
优先使用用户安装的 `babel-plugin-react-compiler`

相关 [issue](https://github.com/umijs/umi/issues/12404)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 引入 `loadModule` 函数以动态加载模块，增强模块加载的灵活性。

- **重构**
  - 更新 `forget` 功能以使用 `loadModule` 函数代替 `require.resolve`，动态加载模块。
  - 将 `resolveProjectDep` 函数移动到 `utils` 目录，并在相关模块中引用。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->