### PR TITLE
feat: remove NODE_ENV in npmClient

### DIFF
--- a/packages/utils/src/npmClient.ts
+++ b/packages/utils/src/npmClient.ts
@@ -58,9 +58,7 @@ export const installWithNpmClient = ({
   cwd?: string;
 }): void => {
   const { sync } = require('../compiled/cross-spawn');
-  // pnpm install will not install devDependencies when NODE_ENV === 'production'
-  // we should remove NODE_ENV to make sure devDependencies can be installed
-  const { NODE_ENV: _, ...env } = process.env;
+  const { ...env } = process.env;
   const npm = sync(npmClient, [npmClient === 'yarn' ? '' : 'install'], {
     stdio: 'inherit',
     cwd,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复**
  - 现在在使用 `pnpm` 进行依赖安装时，`NODE_ENV` 不再被排除，允许安装开发依赖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->