### PR TITLE
refactor(preset-umi): handle illegal route absPath in route preload

### DIFF
--- a/packages/preset-umi/src/features/routePreloadOnLoad/routePreloadOnLoad.ts
+++ b/packages/preset-umi/src/features/routePreloadOnLoad/routePreloadOnLoad.ts
@@ -154,6 +154,14 @@ async function getRoutePathFilesMap(
     // skip redirect route
     if (!route.file) continue;
 
+    // skip illegal absPath route
+    if (!route.absPath?.startsWith('/')) {
+      logger.error(
+        `[routePreloadOnLoad]: route absPath error, cannot preload for ${route.absPath}`,
+      );
+      continue;
+    }
+
     let current: IRoute | undefined = route;
     const files: string[] = [];
 


### PR DESCRIPTION
同 #12363 

由于前述 PR 只合并到 feature 分支，而 feature 分支暂时还不合并到 master，所以重新提个 PR 到 master 修复该问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复**
  - 添加了对非法绝对路径的检查，路径必须以 '/' 开头。遇到非法路径时，将记录错误信息并跳过该路径的处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->