### PR TITLE
feat: 支持htmlSuffix、dynamicRoot

### DIFF
--- a/examples/export-static/.umirc.ts
+++ b/examples/export-static/.umirc.ts
@@ -5,4 +5,10 @@ export default {
     dynamicRoot: true,
   },
   hash: true,
+  // 配置式路由
+  // routes: [
+  //   { path: '/', component: 'index'},
+  //   { path: '/page1', component: 'page1/index'},
+  //   { path: '/page1/page1_1', component: 'page1/page1_1/index'},
+  // ],
 };

--- a/examples/export-static/.umirc.ts
+++ b/examples/export-static/.umirc.ts
@@ -1,0 +1,8 @@
+export default {
+  runtimePublicPath: {},
+  exportStatic: {
+    htmlSuffix: true,
+    dynamicRoot: true,
+  },
+  hash: true,
+};

--- a/examples/export-static/package.json
+++ b/examples/export-static/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@example/export-static",
+  "private": true,
+  "scripts": {
+    "build": "umi build",
+    "dev": "umi dev",
+    "setup": "umi setup",
+    "start": "npm run dev"
+  },
+  "dependencies": {
+    "umi": "workspace:*"
+  }
+}

--- a/examples/export-static/src/pages/404.tsx
+++ b/examples/export-static/src/pages/404.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Page1() {
+  return <h1>404</h1>;
+}

--- a/examples/export-static/src/pages/bar.css
+++ b/examples/export-static/src/pages/bar.css
@@ -1,0 +1,3 @@
+.bar {
+  background: green;
+}

--- a/examples/export-static/src/pages/foo.less
+++ b/examples/export-static/src/pages/foo.less
@@ -1,0 +1,10 @@
+
+.foo {
+  color: red;
+}
+.foo2 {
+  font-size: 40px;
+}
+.foo3 {
+  font-weight: bold;
+}

--- a/examples/export-static/src/pages/index.tsx
+++ b/examples/export-static/src/pages/index.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+// @ts-ignore
+import { Helmet, Link } from 'umi';
+// @ts-ignore
+import fooStyles from './foo.less';
+// @ts-ignore
+import barStyles from './bar.css';
+
+export default function HomePage() {
+  return (
+    <div>
+      <Helmet>
+        <title>helmet title</title>
+      </Helmet>
+      <div
+        className={`${fooStyles.foo} ${fooStyles.foo2} ${fooStyles.foo3} ${barStyles.bar}`}
+      >
+        Home Page
+      </div>
+      <Link to="/page1">
+        <h2>Page 1(/page1)</h2>
+      </Link>
+      <Link to="/page1.html">
+        <h2>Page 1(/page1.html)</h2>
+      </Link>
+      <Link to="/page1/page1_1">
+        <h2>Page 1-1(/page1/page1_1)</h2>
+      </Link>
+      <Link to="/page1/page1_1.html">
+        <h2>Page 1-1(/page1/page1_1.html)</h2>
+      </Link>
+    </div>
+  );
+}

--- a/examples/export-static/src/pages/page1/index.tsx
+++ b/examples/export-static/src/pages/page1/index.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Page1() {
+  return <h1>Page 1</h1>;
+}

--- a/examples/export-static/src/pages/page1/page1_1/index.tsx
+++ b/examples/export-static/src/pages/page1/page1_1/index.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Page1() {
+  return <h1>Page 1-1</h1>;
+}

--- a/packages/preset-umi/src/features/exportStatic/exportStatic.ts
+++ b/packages/preset-umi/src/features/exportStatic/exportStatic.ts
@@ -322,7 +322,7 @@ export function modifyContextOpts(memo: any) {
       exportStatic: { htmlSuffix },
     } = api.config;
     // copy / to /index.html and /xxx to /xxx.html or /xxx/index.html
-    for (const key of Object.keys(routes)) {
+    for (let key of Object.keys(routes)) {
       const route = routes[key];
       if (isHtmlRoute(route)) {
         key = `${key}.html`;

--- a/packages/preset-umi/src/features/exportStatic/exportStatic.ts
+++ b/packages/preset-umi/src/features/exportStatic/exportStatic.ts
@@ -24,7 +24,7 @@ function isHtmlRoute(route: IRoute): boolean {
     // skip layout
     !route.isLayout &&
     // skip duplicate route
-    !route.path.endsWith('.html') &&
+    !route.noHtml &&
     // skip dynamic route for win, because `:` is not allowed in file name
     (!IS_WIN || !route.path.includes('/:')) &&
     // skip `*` route, because `*` is not working for most site serve services
@@ -324,6 +324,7 @@ export function modifyContextOpts(memo: any) {
         routes[key] = {
           ...route,
           path: getHtmlPath(route.path, htmlSuffix),
+          noHtml: true,
         };
       }
     }

--- a/packages/preset-umi/src/features/exportStatic/exportStatic.ts
+++ b/packages/preset-umi/src/features/exportStatic/exportStatic.ts
@@ -19,26 +19,47 @@ interface IExportHtmlItem {
 
 type IUserExtraRoute = string | { path: string; prerender: boolean };
 
+function isHtmlRoute(route: IRoute): boolean {
+  const is404 = route.absPath === '/*';
+
+  if (
+    // skip layout
+    !route.isLayout &&
+    // skip duplicate route
+    !route.path.endsWith('.html') &&
+    // skip dynamic route for win, because `:` is not allowed in file name
+    (!IS_WIN || !route.path.includes('/:')) &&
+    // skip `*` route, because `*` is not working for most site serve services
+    (!route.path.includes('*') ||
+      // except `404.html`
+      is404)
+  ) {
+    return true;
+  }
+  return false;
+}
+function getHtmlPath(path: string, htmlSuffix: boolean): string {
+  if (!path) return path;
+  if (path === '/*') return '/404.html';
+  if (path === '/') return '/index.html';
+
+  if (path.endsWith('/')) path = path.slice(0, -1);
+  return htmlSuffix ? `${path}.html` : `${path}/index.html`;
+}
 /**
  * get export html data from routes
  */
-function getExportHtmlData(routes: Record<string, IRoute>): IExportHtmlItem[] {
+function getExportHtmlData(
+  routes: Record<string, IRoute>,
+  htmlSuffix: boolean,
+): IExportHtmlItem[] {
   const map = new Map<string, IExportHtmlItem>();
 
-  Object.values(routes).forEach((route) => {
+  for (const route of Object.values(routes)) {
     const is404 = route.absPath === '/*';
 
-    if (
-      // skip layout
-      !route.isLayout &&
-      // skip dynamic route for win, because `:` is not allowed in file name
-      (!IS_WIN || !route.path.includes('/:')) &&
-      // skip `*` route, because `*` is not working for most site serve services
-      (!route.path.includes('*') ||
-        // except `404.html`
-        is404)
-    ) {
-      const file = is404 ? '404.html' : join('.', route.absPath, 'index.html');
+    if (isHtmlRoute(route)) {
+      const file = join('.', getHtmlPath(route.absPath, htmlSuffix));
 
       map.set(file, {
         route: {
@@ -49,7 +70,7 @@ function getExportHtmlData(routes: Record<string, IRoute>): IExportHtmlItem[] {
         file,
       });
     }
-  });
+  }
 
   return Array.from(map.values());
 }
@@ -128,6 +149,8 @@ export default (api: IApi) => {
       schema: ({ zod }) =>
         zod
           .object({
+            htmlSuffix: zod.boolean(),
+            dynamicRoot: zod.boolean(),
             extraRoutePaths: zod.union([
               zod.function(),
               zod.array(zod.string()),
@@ -145,7 +168,11 @@ export default (api: IApi) => {
 
   // export routes to html files
   api.modifyExportHTMLFiles(async (_defaultFiles, opts) => {
-    const { publicPath } = api.config;
+    const {
+      publicPath,
+      base,
+      exportStatic: { htmlSuffix, dynamicRoot },
+    } = api.config;
     const htmlData = api.appData.exportHtmlData;
     const htmlFiles: { path: string; content: string }[] = [];
     const { markupArgs: defaultMarkupArgs } = opts;
@@ -164,65 +191,93 @@ export default (api: IApi) => {
           ),
         };
       }
-
-      // handle relative publicPath, such as `./`
-      if (publicPath.startsWith('.')) {
+      let routerBaseStr = JSON.stringify(base || '/');
+      let publicPathStr = JSON.stringify(publicPath || '/');
+      // handle relative publicPath, such as `./`, same with dynamicRoot
+      if (publicPath.startsWith('.') || dynamicRoot) {
         assert(
           api.config.runtimePublicPath,
-          '`runtimePublicPath` should be enable when `publicPath` is relative!',
+          '`runtimePublicPath` should be enable when `publicPath` is relative or `exportStatic.dynamicRoot` is true!',
         );
 
-        const rltPrefix = relative(dirname(file), '.');
-
-        // prefix for all assets
-        if (rltPrefix) {
-          // HINT: clone for keep original markupArgs unmodified
-          const picked = lodash.cloneDeep(
-            lodash.pick(markupArgs, [
-              'favicons',
-              'links',
-              'styles',
-              'headScripts',
-              'scripts',
-            ]),
-          );
-
-          // handle favicons
-          picked.favicons.forEach((item: string, i: number) => {
-            if (item.startsWith(publicPath)) {
-              picked.favicons[i] = winPath(join(rltPrefix, item));
-            }
-          });
-
-          // handle links
-          picked.links.forEach((link: { href: string }) => {
-            if (link.href?.startsWith(publicPath)) {
-              link.href = winPath(join(rltPrefix, link.href));
-            }
-          });
-
-          // handle scripts
-          [picked.headScripts, picked.scripts, picked.styles].forEach(
-            (group: ({ src: string } | string)[]) => {
-              group.forEach((script, i) => {
-                if (
-                  typeof script === 'string' &&
-                  script.startsWith(publicPath)
-                ) {
-                  group[i] = winPath(join(rltPrefix, script));
-                } else if (
-                  typeof script === 'object' &&
-                  script.src?.startsWith(publicPath)
-                ) {
-                  script.src = winPath(join(rltPrefix, script.src));
-                }
-              });
-            },
-          );
-
-          // update markupArgs
-          markupArgs = Object.assign({}, markupArgs, picked);
+        let pathS = route.path;
+        const isSlash = pathS.endsWith('/');
+        if (pathS === '/404') {
+          //do nothing
         }
+        // keep the relative path same for route /xxx and /xxx.html
+        else if (htmlSuffix && isSlash) {
+          pathS = pathS.slice(0, -1);
+        }
+        // keep the relative path same for route /xxx/ and /xxx/index.html
+        else if (!htmlSuffix && !isSlash) {
+          pathS = pathS + '/';
+        }
+
+        const pathN = Math.max(pathS.split('/').length - 1, 1);
+        routerBaseStr = `location.pathname.split('/').slice(0, -${pathN}).concat('').join('/')`;
+        publicPathStr = `location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '') + window.routerBase`;
+
+        const rltPrefix = relative(dirname(file), '.');
+        const joinRltPrefix = (path: string) => {
+          if (!rltPrefix || rltPrefix == '.') {
+            return `.${path.startsWith('/') ? '' : '/'}${path}`;
+          }
+          return winPath(join(rltPrefix, path));
+        };
+        // prefix for all assets
+        // HINT: clone for keep original markupArgs unmodified
+        const picked = lodash.cloneDeep(
+          lodash.pick(markupArgs, [
+            'favicons',
+            'links',
+            'styles',
+            'headScripts',
+            'scripts',
+          ]),
+        );
+
+        // handle favicons
+        picked.favicons.forEach((item: string, i: number) => {
+          if (item.startsWith(publicPath)) {
+            picked.favicons[i] = joinRltPrefix(item);
+          }
+        });
+
+        // handle links
+        picked.links.forEach((link: { href: string }) => {
+          if (link.href?.startsWith(publicPath)) {
+            link.href = joinRltPrefix(link.href);
+          }
+        });
+
+        // handle scripts
+        [picked.headScripts, picked.scripts, picked.styles].forEach(
+          (group: ({ src: string } | string)[]) => {
+            group.forEach((script, i) => {
+              if (typeof script === 'string' && script.startsWith(publicPath)) {
+                group[i] = joinRltPrefix(script);
+              } else if (
+                typeof script === 'object' &&
+                script.src?.startsWith(publicPath)
+              ) {
+                script.src = joinRltPrefix(script.src);
+              }
+            });
+          },
+        );
+
+        picked.headScripts.unshift(
+          `window.routerBase = ${routerBaseStr};`,
+          `
+if(!window.publicPath) {
+window.publicPath = ${publicPathStr};
+}
+          `,
+        );
+
+        // update markupArgs
+        markupArgs = Object.assign({}, markupArgs, picked);
       }
 
       // append html file
@@ -246,12 +301,13 @@ export default (api: IApi) => {
 
   api.onGenerateFiles(async () => {
     const {
-      exportStatic: { extraRoutePaths = [] },
+      exportStatic: { extraRoutePaths = [], htmlSuffix },
     } = api.config;
     const extraHtmlData = getExportHtmlData(
       await getRoutesFromUserExtraPaths(extraRoutePaths),
+      htmlSuffix,
     );
-    const htmlData = getExportHtmlData(api.appData.routes).concat(
+    const htmlData = getExportHtmlData(api.appData.routes, htmlSuffix).concat(
       extraHtmlData,
     );
 
@@ -269,6 +325,13 @@ export function modifyClientRenderOpts(memo: any) {
     hydrate: hydrate && !{{{ ignorePaths }}}.includes(history.location.pathname),
   };
 }
+
+export function modifyContextOpts(memo: any) {
+  return {
+    ...memo,
+    basename: window.routerBase || memo.basename,
+  }
+}
       `.trim(),
         {
           ignorePaths: JSON.stringify(
@@ -281,7 +344,22 @@ export function modifyClientRenderOpts(memo: any) {
       noPluginDir: true,
     });
   });
-
+  api.modifyRoutes((routes: Record<string, IRoute>) => {
+    const {
+      exportStatic: { htmlSuffix },
+    } = api.config;
+    // copy / to /index.html and /xxx to /xxx.html or /xxx/index.html
+    for (const key of Object.keys(routes)) {
+      const route = routes[key];
+      if (isHtmlRoute(route)) {
+        key = `${key}.html`;
+        routes[key] = {
+          ...route,
+          path: getHtmlPath(route.path, htmlSuffix),
+        };
+      }
+    }
+  });
   api.addRuntimePlugin(() => {
     return [`@@/core/exportStaticRuntimePlugin.ts`];
   });

--- a/packages/preset-umi/src/features/exportStatic/exportStatic.ts
+++ b/packages/preset-umi/src/features/exportStatic/exportStatic.ts
@@ -327,6 +327,7 @@ export function modifyContextOpts(memo: any) {
         };
       }
     }
+    return routes;
   });
   api.addRuntimePlugin(() => {
     return [`@@/core/exportStaticRuntimePlugin.ts`];

--- a/packages/preset-umi/src/features/exportStatic/exportStatic.ts
+++ b/packages/preset-umi/src/features/exportStatic/exportStatic.ts
@@ -20,9 +20,7 @@ interface IExportHtmlItem {
 type IUserExtraRoute = string | { path: string; prerender: boolean };
 
 function isHtmlRoute(route: IRoute): boolean {
-  const is404 = route.absPath === '/*';
-
-  if (
+  return (
     // skip layout
     !route.isLayout &&
     // skip duplicate route
@@ -31,12 +29,9 @@ function isHtmlRoute(route: IRoute): boolean {
     (!IS_WIN || !route.path.includes('/:')) &&
     // skip `*` route, because `*` is not working for most site serve services
     (!route.path.includes('*') ||
-      // except `404.html`
-      is404)
-  ) {
-    return true;
-  }
-  return false;
+      // skip `404.html`
+      route.absPath === '/*')
+  );
 }
 function getHtmlPath(path: string, htmlSuffix: boolean): string {
   if (!path) return path;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -658,6 +658,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/umi
 
+  examples/export-static:
+    dependencies:
+      umi:
+        specifier: workspace:*
+        version: link:../../packages/umi
+
   examples/legacy:
     dependencies:
       umi:


### PR DESCRIPTION
公司好几个项目升级umi4.x需要用到，希望能支持 https://github.com/umijs/umi/issues/12301
1. htmlSuffix: 会生成 xxx.html静态文件及路由，非xxx/index.html
2. dynamicRoot: 可不用做任何修改部署在任意目录下

**有一点需要说明的是**  
dynamicRoot 为新增配置，原publicPath: './'相对路径的方式也是有问题的，使用当前规则没问题。  
对于`dynamicRoot:true, htmlSuffix: false`的场景，由于/page1 和 /page1/index.html 得到的相对路径不一样，但是又是同一个文件，对于headScripts等脚本路径是编译时确定的，没办法对前面两个路由同时生效。  

- `{ dynamicRoot:true, htmlSuffix: true }`使用 /page1、/page1.html 访问

- `{ dynamicRoot:true, htmlSuffix: false }`使用 /page1/、/page1/index.html 访问


**已添加examples/export-static项目，且测试以下场景都正常：**  
① 约定式路由，不开启 dynamicRoot 、不开启 htmlSuffix 。
② 约定式路由，开启 dynamicRoot 、不开启 htmlSuffix 。
③ 约定式路由，不开启 dynamicRoot 、开启 htmlSuffix 。
④ 约定式路由，开启 dynamicRoot 、开启 htmlSuffix 。
⑤ 配置式路由，不开启 dynamicRoot 、不开启 htmlSuffix 。
⑥ 配置式路由，开启 dynamicRoot 、不开启 htmlSuffix 。
⑦ 配置式路由，不开启 dynamicRoot 、开启 htmlSuffix 。
⑧ 配置式路由，开启 dynamicRoot 、开启 htmlSuffix 。

使用Whistle测试，对应`htmlSuffix: true`配置：
```
^export-static.local/x/y/page1$ file:///home/user1/projects/umi/examples/export-static/dist/page1.html resCors://enable
^export-static.local/x/y/page1/page1_1$ file:///home/user1/projects/umi/examples/export-static/dist/page1/page1_1.html resCors://enable
export-static.local/x/y file:///home/user1/projects/umi/examples/export-static/dist resCors://enable

^export-static.local/page1$ file:///home/user1/projects/umi/examples/export-static/dist/page1.html resCors://enable
^export-static.local/page1/page1_1$ file:///home/user1/projects/umi/examples/export-static/dist/page1/page1_1.html resCors://enable
export-static.local file:///home/user1/projects/umi/examples/export-static/dist resCors://enable
```

`htmlSuffix: false`配置：
```
^export-static.local/x/y/page1/$ file:///home/user1/projects/umi/examples/export-static/dist/page1/index.html resCors://enable
^export-static.local/x/y/page1/page1_1$ file:///home/user1/projects/umi/examples/export-static/dist/page1/page1_1/index.html resCors://enable
export-static.local/x/y file:///home/user1/projects/umi/examples/export-static/dist resCors://enable

^export-static.local/page1/$ file:///home/user1/projects/umi/examples/export-static/dist/page1/index.html resCors://enable
^export-static.local/page1/page1_1$ file:///home/user1/projects/umi/examples/export-static/dist/page1/page1_1/index.html resCors://enable
export-static.local file:///home/user1/projects/umi/examples/export-static/dist resCors://enable
```

之前的PR已关闭，感谢  @fz6m 的修改意见，详见：https://github.com/umijs/umi/pull/12400 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 添加了导出静态文件的配置，支持 HTML 后缀、动态根路径和哈希处理。
  - 新增了 404 页面和其他示例页面，包括主页、Page 1、Page 1-1。

- **样式**
  - 增加了 `.bar` 类的绿色背景样式。
  - 添加了 `.foo`、`.foo2` 和 `.foo3` 类的颜色、字体大小和字体粗细样式。

- **文档**
  - 更新了 `package.json` 文件，增加了构建、开发、设置和启动项目的脚本配置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->