### PR TITLE
fix: disableDayjsAlias should be default value of antd.momentPicker

### DIFF
--- a/packages/plugins/src/antd.ts
+++ b/packages/plugins/src/antd.ts
@@ -225,7 +225,7 @@ export default (api: IApi) => {
   api.chainWebpack((memo) => {
     if (api.config.antd.momentPicker) {
       if (day2MomentAvailable) {
-        memo.plugin('antd-moment-webpack-plugin').use(new AntdMomentWebpackPlugin({ disableDayjsAlias: true }));
+        memo.plugin('antd-moment-webpack-plugin').use(AntdMomentWebpackPlugin, [{ disableDayjsAlias: true }]);
       } else {
         api.logger.warn(
           `MomentPicker is only available in version 5.0.0 and above, but you are using version ${antdVersion}`,

--- a/packages/plugins/src/antd.ts
+++ b/packages/plugins/src/antd.ts
@@ -225,7 +225,7 @@ export default (api: IApi) => {
   api.chainWebpack((memo) => {
     if (api.config.antd.momentPicker) {
       if (day2MomentAvailable) {
-        memo.plugin('antd-moment-webpack-plugin').use(AntdMomentWebpackPlugin);
+        memo.plugin('antd-moment-webpack-plugin').use(new AntdMomentWebpackPlugin({ disableDayjsAlias: true }));
       } else {
         api.logger.warn(
           `MomentPicker is only available in version 5.0.0 and above, but you are using version ${antdVersion}`,


### PR DESCRIPTION
see https://github.com/ant-design/antd-moment-webpack-plugin/pull/4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **优化**
  - 修改 `AntdMomentWebpackPlugin` 的使用方式，添加 `disableDayjsAlias: true` 配置，以提高插件兼容性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->