### PR TITLE
fix(preset-vue): yarn mode webpack require hook is invalid

### DIFF
--- a/examples/mf-v2-host/package.json
+++ b/examples/mf-v2-host/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@example/mf-v2-host",
+  "name": "@example/mfv2-host",
   "private": true,
   "scripts": {
     "build": "max build",

--- a/examples/mf-v2-remote/package.json
+++ b/examples/mf-v2-remote/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@example/mf-v2-remote",
+  "name": "@example/mfv2-remote",
   "private": true,
   "scripts": {
     "build": "max build",

--- a/examples/qiankun-master/package.json
+++ b/examples/qiankun-master/package.json
@@ -2,8 +2,8 @@
   "name": "@example/qiankun-master",
   "private": true,
   "scripts": {
-    "dev": "cross-env PORT=9002 max dev",
-    "preview": "max preview --port 9002",
+    "dev": "cross-env PORT=8889 max dev",
+    "preview": "max preview --port 8889",
     "setup": "max setup",
     "start": "npm run dev"
   },

--- a/examples/qiankun-master/package.json
+++ b/examples/qiankun-master/package.json
@@ -2,8 +2,8 @@
   "name": "@example/qiankun-master",
   "private": true,
   "scripts": {
-    "dev": "cross-env PORT=8889 max dev",
-    "preview": "max preview --port 8889",
+    "dev": "cross-env PORT=9002 max dev",
+    "preview": "max preview --port 9002",
     "setup": "max setup",
     "start": "npm run dev"
   },

--- a/packages/preset-vue/src/features/config/config.ts
+++ b/packages/preset-vue/src/features/config/config.ts
@@ -1,6 +1,5 @@
 import Config from '@umijs/bundler-webpack/compiled/webpack-5-chain';
 import { IApi } from 'umi';
-import VueLoaderPlugin from 'vue-loader/dist/pluginWebpack5.js';
 import { addAssetRules } from './assetRules';
 
 export function getConfig(config: Config, api: IApi) {
@@ -23,7 +22,9 @@ export function getConfig(config: Config, api: IApi) {
       babelParserPlugins: ['jsx', 'classProperties', 'decorators-legacy'],
     });
 
-  config.plugin('vue-loader-plugin').use(VueLoaderPlugin);
+  const VueLoaderPlugin = require('vue-loader/dist/pluginWebpack5');
+
+  config.plugin('vue-loader-plugin').use(VueLoaderPlugin.default);
 
   // https://github.com/vuejs/vue-loader/issues/1435#issuecomment-869074949
   config.module


### PR DESCRIPTION
修复社区反馈的 requireHook 调整导致的 yarn 安装依赖 vue webpack requireHook 失败
![image](https://github.com/umijs/umi/assets/7599351/ecc91ecb-9651-41b7-9638-21496a6fe272)
