### PR TITLE
docs: fix css in md

### DIFF
--- a/docs/docs/blog/umi-4-rc.md
+++ b/docs/docs/blog/umi-4-rc.md
@@ -137,9 +137,9 @@ group:
 
 以上是 Umi 4 目前的新功能。
 
-除此之外，还有一些计划在正式版发布之前做的事情。包括 <span style={{color:'red'}}>api route、umi server and adapter、route loader、稳定的 lint、更多命令、组件研发 father 4、文档工具 dumi 2</span> 等，会在之后的 RC 版本中与大家见面。
+除此之外，还有一些计划在正式版发布之前做的事情。包括 <span style="color:red;">api route、umi server and adapter、route loader、稳定的 lint、更多命令、组件研发 father 4、文档工具 dumi 2</span> 等，会在之后的 RC 版本中与大家见面。
 
-欢迎大家尝鲜 Umi 4，官方文档有准备 ant-design-pro 从 Umi 3 到 4 的升级文档。同时 RC 阶段，还准备了一个<span style={{color:'red',fontWeight:'bold'}}>手把手升级的微信交流群</span>，欢迎 Umi 4 的先行者们加入，祝大家升级顺利，也提前祝大家新年快乐 🧨，🐯 年吉祥。
+欢迎大家尝鲜 Umi 4，官方文档有准备 ant-design-pro 从 Umi 3 到 4 的升级文档。同时 RC 阶段，还准备了一个<span style="color:red;fontWeight:bold;">手把手升级的微信交流群</span>，欢迎 Umi 4 的先行者们加入，祝大家升级顺利，也提前祝大家新年快乐 🧨，🐯 年吉祥。
 
 <p>
   <img


### PR DESCRIPTION
<img width="1090" alt="image" src="https://github.com/umijs/umi/assets/103993866/99095df2-67f4-4468-afec-f787c49538dd">

This is just one obvious aspect.

In fact, **none** of the style notation in the markdown of the docs path takes effect, and instead the react writing is used. 

I don't know if it will configure MDX or related things to adapt to the React writing.
Otherwise, it may be necessary to change the style writing in all tags under the markdown.