### PR TITLE
docs: hero link in homepage

### DIFF
--- a/docs/.dumi/components/Hero/index.tsx
+++ b/docs/.dumi/components/Hero/index.tsx
@@ -11,7 +11,7 @@ export const Hero = () => {
         <div className="left">
           <div className="bigLogo" />
           <div className="actions">
-            <Link to="/docs/tutorials/getting-started">
+            <Link to="/docs/guides/getting-started">
               <div className="button">快速上手 →</div>
             </Link>
             <div className="githubStar">


### PR DESCRIPTION
首页跳转逻辑有误，手动点击快速上手按钮时，路由会进入/docs/tutorials/getting-started，但页面仍然停留在首页。
修复方案为直接把快速上手按钮的跳转路由改为/docs/guides/getting-started。
tutorials 改为 guides。