### PR TITLE
refactor: getConventionRoutes

### DIFF
--- a/packages/core/src/route/routesConvention.ts
+++ b/packages/core/src/route/routesConvention.ts
@@ -39,7 +39,7 @@ export function getConventionRoutes(opts: {
   });
   function defineNestedRoutes(defineRoute: any, parentId?: string) {
     const childRouteIds = parentId
-      ? parentToChildrenMap.get(parentId)
+      ? parentToChildrenMap.get(parentId) || []
       : routeIds;
     for (let routeId of childRouteIds) {
       let routePath = createRoutePath(

--- a/packages/core/src/route/routesConvention.ts
+++ b/packages/core/src/route/routesConvention.ts
@@ -2,12 +2,7 @@ import { winPath } from '@umijs/utils';
 import { existsSync, lstatSync, readdirSync, statSync } from 'fs';
 import { extname, relative, resolve } from 'path';
 import { defineRoutes } from './defineRoutes';
-import {
-  byLongestFirst,
-  createRouteId,
-  findParentRouteId,
-  isRouteModuleFile,
-} from './utils';
+import { byLongestFirst, createRouteId, isRouteModuleFile } from './utils';
 
 // opts.base: path of pages
 export function getConventionRoutes(opts: {
@@ -30,11 +25,22 @@ export function getConventionRoutes(opts: {
   });
 
   const routeIds = Object.keys(files).sort(byLongestFirst);
-
+  const parentToChildrenMap = new Map();
+  routeIds.forEach((id) => {
+    const prefix = `${id}/`;
+    routeIds
+      .filter((childId) => childId.startsWith(prefix) && childId !== id)
+      .forEach((childId) => {
+        if (!parentToChildrenMap.has(id)) {
+          parentToChildrenMap.set(id, []);
+        }
+        parentToChildrenMap.get(id).push(childId);
+      });
+  });
   function defineNestedRoutes(defineRoute: any, parentId?: string) {
-    const childRouteIds = routeIds.filter(
-      (id) => findParentRouteId(routeIds, id) === parentId,
-    );
+    const childRouteIds = parentId
+      ? parentToChildrenMap.get(parentId)
+      : routeIds;
     for (let routeId of childRouteIds) {
       let routePath = createRoutePath(
         parentId ? routeId.slice(parentId.length + 1) : routeId,

--- a/packages/core/src/route/utils.ts
+++ b/packages/core/src/route/utils.ts
@@ -13,13 +13,6 @@ export function byLongestFirst(a: string, b: string): number {
   return b.length - a.length;
 }
 
-export function findParentRouteId(
-  routeIds: string[],
-  childRouteId: string,
-): string | undefined {
-  return routeIds.find((id) => childRouteId.startsWith(`${id}/`));
-}
-
 const routeModuleExts = ['.js', '.jsx', '.ts', '.tsx', '.md', '.mdx', '.vue'];
 export function isRouteModuleFile(opts: { file: string; exclude?: RegExp[] }) {
   // TODO: add cache strategy


### PR DESCRIPTION
时间复杂度太高, antv 场景会卡死接近 20 min.

const childRouteIds = routeIds.filter(
      (id) => findParentRouteId(routeIds, id) === parentId,
);

这段代码在有 2700 个路由时, 执行时间为 400ms ~ 500ms, 循环百万次, 这里用空间换时间新建 Map 来解决.
