### PR TITLE
fix: build error when using vite mode on windows

### DIFF
--- a/packages/preset-umi/src/utils/transformIEAR.ts
+++ b/packages/preset-umi/src/utils/transformIEAR.ts
@@ -70,7 +70,7 @@ export const IEAR_REG_EXP = new RegExp(
     // match quotes ($2)
     `('|")`,
     // match absolute file path ($3)
-    `(\\/.*[^\\\\])\\2`,
+    `(\([a-zA-Z]:|\/).*[^\\\\])\\2`,
     ')',
   ].join(''),
   // match full-content

--- a/packages/preset-umi/src/utils/transformIEAR.ts
+++ b/packages/preset-umi/src/utils/transformIEAR.ts
@@ -70,7 +70,7 @@ export const IEAR_REG_EXP = new RegExp(
     // match quotes ($2)
     `('|")`,
     // match absolute file path ($3)
-    `(\([a-zA-Z]:|\/).*[^\\\\])\\2`,
+    `((?:[a-zA-Z]:|\\/).*[^\\\\])\\2`,
     ')',
   ].join(''),
   // match full-content


### PR DESCRIPTION
#10212 
原因是绝对路径匹配时只匹配了mac 或者linux的/ 开头，而windows 路径开始都是盘符开头（C: D:）等。