### PR TITLE
fix(did-you-know): 修复mkdirSync可能的报错

### DIFF
--- a/did-you-know/src/plugin.ts
+++ b/did-you-know/src/plugin.ts
@@ -69,7 +69,7 @@ export default (api: any) => {
 
     const cacheDir = path.join(api.paths.absNodeModulesPath, '.cache');
     if (!fs.existsSync(cacheDir)) {
-      fs.mkdirSync(cacheDir);
+      fs.mkdirSync(cacheDir, { recursive: true });
     }
     fs.writeFileSync(recordJSONPath, JSON.stringify(records), 'utf-8');
   });


### PR DESCRIPTION
当指定APP_ROOT，did-you-know插件在创建cacheDir目录时，会抛出异常`No such file or directory`