### PR TITLE
fix(preset-vue): yarn mode webpack require hook is invalid

### DIFF
--- a/packages/bundler-vite/src/config/transformer/target.ts
+++ b/packages/bundler-vite/src/config/transformer/target.ts
@@ -25,7 +25,7 @@ export default (function target(userConfig) {
     return false;
   }
 
-  const isLegacy = isLegacyBrowser(userConfig.targets);
+  const isLegacy = isLegacyBrowser(userConfig.targets || {});
 
   // convert { ie: 11 } to ['ie11']
   // 低版本浏览器需要使用 legacy 插件 同时设置会有 warning

--- a/packages/preset-vue/src/features/config/config.ts
+++ b/packages/preset-vue/src/features/config/config.ts
@@ -24,7 +24,7 @@ export function getConfig(config: Config, api: IApi) {
 
   const VueLoaderPlugin = require('vue-loader/dist/pluginWebpack5');
 
-  config.plugin('vue-loader-plugin').use(VueLoaderPlugin);
+  config.plugin('vue-loader-plugin').use(VueLoaderPlugin.default);
 
   // https://github.com/vuejs/vue-loader/issues/1435#issuecomment-869074949
   config.module

--- a/packages/preset-vue/src/features/config/config.ts
+++ b/packages/preset-vue/src/features/config/config.ts
@@ -1,6 +1,5 @@
 import Config from '@umijs/bundler-webpack/compiled/webpack-5-chain';
 import { IApi } from 'umi';
-import VueLoaderPlugin from 'vue-loader/dist/pluginWebpack5.js';
 import { addAssetRules } from './assetRules';
 
 export function getConfig(config: Config, api: IApi) {
@@ -22,6 +21,8 @@ export function getConfig(config: Config, api: IApi) {
     .options({
       babelParserPlugins: ['jsx', 'classProperties', 'decorators-legacy'],
     });
+
+  const VueLoaderPlugin = require('vue-loader/dist/pluginWebpack5');
 
   config.plugin('vue-loader-plugin').use(VueLoaderPlugin);
 


### PR DESCRIPTION
修复社区反馈的 requireHook 调整导致的 yarn 安装依赖 vue webpack requireHook 失败
![image](https://github.com/user-attachments/assets/bbc18e40-3f75-4ea4-ba5c-8d2e73845b64)
同时修复 vite targets 为空的情况
<img width="879" alt="image" src="https://github.com/user-attachments/assets/f59676b9-d0d6-4bb1-84e6-160b3a7cd786">
