### PR TITLE
fix: html plugin for mako

### DIFF
--- a/packages/preset-umi/src/features/mako/mako.ts
+++ b/packages/preset-umi/src/features/mako/mako.ts
@@ -70,7 +70,7 @@ export default (api: IApi) => {
         generateEnd: ({ stats }: any) => {
           const entryPointFiles = new Set<string>();
 
-          for (const chunk of stats.entrypoints['umi'].chunks) {
+          for (const chunk of stats.entrypoints['umi']?.chunks || []) {
             const files = stats.chunks.find((c: any) => c.id === chunk).files;
             for (const file of files) {
               entryPointFiles.add(file);


### PR DESCRIPTION
When building SSR server side, the entry is "umi.server".