### PR TITLE
fix(mako): enable mako on windows failed

### DIFF
--- a/packages/preset-umi/src/features/mako/mako.ts
+++ b/packages/preset-umi/src/features/mako/mako.ts
@@ -62,6 +62,7 @@ export default (api: IApi) => {
     if (isWindows) {
       memo.mako = false;
       process.env.OKAM = '';
+      return memo;
     }
     const makoPlugins = memo.mako?.plugins || [];
     if (!api.config.mpa) {


### PR DESCRIPTION
error:  Error: Cannot find module '@umijs/mako-win32-x64-msvc'