### PR TITLE
fix: route 可能通过 pacthRoutes 把 id 修改掉

### DIFF
--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -117,9 +117,15 @@ function createJSXGenerator(opts: CreateRequestHandlerOptions) {
 
     const loaderData: Record<string, any> = {};
     // let metadata: Record<string, any> = {};
+
     await Promise.all(
       matches
-        .filter((id: string) => routes[id].hasServerLoader)
+        .filter(
+          (id: string) =>
+            routes[
+              Object.keys(routes).find((key) => routes[key].id == id) as string
+            ]?.hasServerLoader,
+        )
         .map(
           (id: string) =>
             new Promise<void>(async (resolve) => {

--- a/packages/server/src/ssr.ts
+++ b/packages/server/src/ssr.ts
@@ -117,7 +117,6 @@ function createJSXGenerator(opts: CreateRequestHandlerOptions) {
 
     const loaderData: Record<string, any> = {};
     // let metadata: Record<string, any> = {};
-
     await Promise.all(
       matches
         .filter(


### PR DESCRIPTION
比如说原本的 routes 结构是
```
cons routes = {
  index: {
    id: 'index',
    path: '/'
  }
}
```

经过 patchRoutes 之后
```
export const patchRoutes = ({ routes }) => {
   Object.keys(routes).forEach((key) => {
      if (routes[key].parentId) {
        routes[key].parentId = `theme-${routes[key].parentId}`;
      }
      routes[key].id = `theme-${routes[key].id}`;
    });
};
```

会变成
```
cons routes = {
  index: {
    id: 'theme-index',
    path: '/'
  }
}
```