### PR TITLE
fix: webpack builder js error when use custom protocol

### DIFF
--- a/packages/preset-umi/src/features/webpack/webpack.ts
+++ b/packages/preset-umi/src/features/webpack/webpack.ts
@@ -63,7 +63,7 @@ export default (api: IApi) => {
     const displayPublicPath = publicPath === 'auto' ? '/' : publicPath;
 
     return assets.js.map((js) => {
-      return `${displayPublicPath}${js}`;
+      return { src: `${displayPublicPath}${js}` };
     });
   });
 };


### PR DESCRIPTION
使用自定义协议的 publicPath 时，判断 url 会发生错误，但是其实 webpack 构建的 assets 是文件，不需要到末端再判断
Closes: https://github.com/umijs/umi/issues/12670