### PR TITLE
feat: skip invalid ssr middleware in dev for worker mode

### DIFF
--- a/packages/preset-umi/src/features/ssr/ssr.ts
+++ b/packages/preset-umi/src/features/ssr/ssr.ts
@@ -103,6 +103,10 @@ export default (api: IApi) => {
 
   api.addMiddlewares(() => [
     async (req, res, next) => {
+      if (serverBuildTarget === 'worker') {
+        return next();
+      }
+
       const modulePath = absServerBuildPath(api);
       if (existsSync(modulePath)) {
         delete require.cache[modulePath];


### PR DESCRIPTION
ssr + worker 模式下，本地开发时的 middleware 是无效的，暂时也不支持本地预览，所以先跳过