### PR TITLE
docs: 测试教程中文件名多余s去掉

### DIFF
--- a/docs/docs/docs/guides/test.md
+++ b/docs/docs/docs/guides/test.md
@@ -58,7 +58,7 @@ export default async () => {
 ```txt
 .
 └── utils
-    ├── reverseApiData.test.tss
+    ├── reverseApiData.test.ts
     └── reverseApiData.ts
 ```
 


### PR DESCRIPTION
在学习umi文档中测试这一章的时候，发现文件名好像多打了个s