### PR TITLE
fix: 🐛 test browser template use wrong loadingComponent value

### DIFF
--- a/packages/preset-umi/src/features/test/test.ts
+++ b/packages/preset-umi/src/features/test/test.ts
@@ -1,6 +1,7 @@
 ﻿import { winPath } from '@umijs/utils';
 import { existsSync } from 'fs';
 import { dirname, join } from 'path';
+import { expandJSPaths } from '../../commands/dev/watch';
 import { TEMPLATES_DIR } from '../../constants';
 import { IApi } from '../../types';
 import { importsToStr } from '../tmpFiles/importsToStr';
@@ -27,6 +28,12 @@ export default (api: IApi) => {
         ),
       }),
     );
+
+    const loadingFile = expandJSPaths(
+      join(api.paths.absSrcPath, 'loading'),
+    ).find(existsSync);
+    const globalLoading = loadingFile ? winPath(loadingFile) : undefined;
+
     // testBrowser.tsx
     api.writeTmpFile({
       noPluginDir: true,
@@ -66,10 +73,7 @@ export default (api: IApi) => {
         historyType: api.config.history.type,
         reactRouter5Compat: !!api.config.reactRouter5Compat,
         hydrate: !!api.config.ssr,
-        loadingComponent:
-          existsSync(join(api.paths.absSrcPath, 'loading.tsx')) ||
-          existsSync(join(api.paths.absSrcPath, 'loading.jsx')) ||
-          existsSync(join(api.paths.absSrcPath, 'loading.js')),
+        loadingComponent: globalLoading,
       },
     });
   });


### PR DESCRIPTION
## problem

```text
error - Can not resolve dependence : 'true', please install it
```


loadingComponent should be a path of a component  other than a boolean.