### PR TITLE
fix #12777 failed to start unocss with mako

### DIFF
--- a/examples/with-unocss/.umirc.ts
+++ b/examples/with-unocss/.umirc.ts
@@ -1,4 +1,5 @@
 export default {
+  mako: {},
   plugins: [require.resolve('@umijs/plugins/dist/unocss')],
   unocss: {
     watch: ['pages/**/*.tsx'],

--- a/packages/plugins/src/unocss.ts
+++ b/packages/plugins/src/unocss.ts
@@ -46,7 +46,19 @@ export default (api: IApi) => {
       cwd: api.cwd,
       stdio: isDev ? 'pipe' : 'inherit',
     });
-    if (!isDev) {
+
+    if (isDev) {
+      await new Promise<void>((resolve) => {
+        const { stdout } = execaRes;
+        function dataHandler() {
+          resolve();
+          stdout?.off('data', dataHandler);
+        }
+        stdout?.on('data', dataHandler);
+      });
+
+      api.logger.info('unocss watch mode is running!');
+    } else {
       await execaRes;
     }
   });


### PR DESCRIPTION
问题如 #12777  描述, 开发模式下，unocss插件并没有等待unocss进程完全启动，导致.umi/uno.css文件还没有生成，而在.umi/umi.ts中已经写了 uno.css的导入，导致启动时报错

![image](https://github.com/user-attachments/assets/70c83955-c8e0-4410-a51a-03b89a2ba244)
