### PR TITLE
docs: fix getInitialState description

### DIFF
--- a/docs/docs/docs/api/runtime-config.en-US.md
+++ b/docs/docs/docs/api/runtime-config.en-US.md
@@ -100,7 +100,7 @@ The return value of `getInitialState()` will become the global initial state. Fo
 // src/app.ts
 import { fetchInitialData } from "@/services/initial";
 
-export async function () {
+export async function getInitialState() {
   const initialData = await fetchInitialData();
   return initialData;
 }

--- a/docs/docs/docs/api/runtime-config.md
+++ b/docs/docs/docs/api/runtime-config.md
@@ -98,7 +98,7 @@ export default {
 // src/app.ts
 import { fetchInitialData } from "@/services/initial";
 
-export async function () {
+export async function getInitialState() {
   const initialData = await fetchInitialData();
   return initialData;
 }

--- a/docs/docs/docs/max/data-flow.en-US.md
+++ b/docs/docs/docs/max/data-flow.en-US.md
@@ -220,7 +220,7 @@ For specific usage, please refer to the [micro-frontend's parent-child communica
 // src/components/AdminInfo/index.tsx
 import { useModel } from 'umi';
 
-export default function Page() {
+export default () => {
   const { user, fetchUser } = useModel('adminModel', (model) => ({
     user: model.admin,
     fetchUser: model.fetchAdmin,

--- a/docs/docs/docs/max/data-flow.md
+++ b/docs/docs/docs/max/data-flow.md
@@ -29,7 +29,7 @@ Model 文件允许使用 `.(tsx|ts|jsx|js)` 四种后缀格式，**命名空间�
 
 ```ts
 // src/models/userModel.ts
-export default function Page() {
+export default () => {
   const user = {
     username: 'umi',
   };


### PR DESCRIPTION
1、fix `getInitialState` description
2、named `useModel`  `Page` is inappropriate