### PR TITLE
fix: Fix webworker not working

### DIFF
--- a/packages/bundler-webpack/src/plugins/RuntimePublicPathPlugin.ts
+++ b/packages/bundler-webpack/src/plugins/RuntimePublicPathPlugin.ts
@@ -1,6 +1,6 @@
 import type {
-  Compiler,
   Compilation,
+  Compiler,
   RuntimeModule,
 } from '@umijs/bundler-webpack/compiled/webpack';
 
@@ -24,7 +24,23 @@ export class RuntimePublicPathPlugin {
             )
               return;
             // @ts-ignore
-            module._cachedGeneratedCode = `__webpack_require__.p = (typeof globalThis !== 'undefined' ? globalThis : window).publicPath || '/';`;
+            module._cachedGeneratedCode = `__webpack_require__.p = (function(){
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis
+function __check(it) {
+  return it && it.Math === Math && it;
+};
+
+var __global =(
+  __check(typeof globalThis == 'object' && globalThis) ||
+  __check(typeof window == 'object' && window) ||
+  __check(typeof self == 'object' && self)
+);
+
+if(__global && __global.publicPath) return __global.publicPath;
+
+// fix: https://github.com/umijs/umi/issues/12781
+return ${JSON.stringify(compilation.outputOptions.publicPath || '/')};
+})();`;
           }
         },
       );


### PR DESCRIPTION
fix https://github.com/umijs/umi/issues/12781

原因是 worker 环境中， globalThis 和 宿主的不是同一个，不能直接使用。多加一层判断。