### PR TITLE
docs: image max-width and height

### DIFF
--- a/docs/.dumi/components/Contributing/index.less
+++ b/docs/.dumi/components/Contributing/index.less
@@ -13,5 +13,9 @@
       color: #0273dc;
       text-decoration: none;
     }
+
+    img {
+      max-width: 100%;
+    }
   }
 }

--- a/docs/.dumi/components/Contributing/index.tsx
+++ b/docs/.dumi/components/Contributing/index.tsx
@@ -16,7 +16,6 @@ export const Contributing = () => {
             <img
               src="https://opencollective.com/umi/contributors.svg?width=1200&button=false"
               width="1200"
-              height="184"
             />
           </a>
         </div>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/013751cc-b045-4556-945d-fdc5c99e7ae2)
目前贡献者图被压扁了