### PR TITLE
fix: Fix process.env.SOCKET_SERVER port is NO_VALIDATE

### DIFF
--- a/packages/bundler-webpack/src/server/server.ts
+++ b/packages/bundler-webpack/src/server/server.ts
@@ -247,7 +247,7 @@ export async function createServer(opts: IOpts): Promise<any> {
       console.log(`[SOCKET_SERVER] hmr port changed from ${port} to ${basePort}`)
       return undefined;
     }
-    return Number(startPort) ===  basePort ? undefined : (Number(startPort) || undefined);
+    return startPort ===  basePort ? undefined : startPort;
   };
 
   ws = createWebSocketServer(server, await parseSocketServerAddress());

--- a/packages/bundler-webpack/src/server/server.ts
+++ b/packages/bundler-webpack/src/server/server.ts
@@ -4,7 +4,7 @@ import type { Stats } from '@umijs/bundler-webpack/compiled/webpack';
 import webpack, {
   Configuration,
 } from '@umijs/bundler-webpack/compiled/webpack';
-import { getDevBanner, lodash, logger } from '@umijs/utils';
+import { getDevBanner, lodash, logger, portfinder } from '@umijs/utils';
 import cors from 'cors';
 import { createReadStream, existsSync } from 'fs';
 import http from 'http';
@@ -235,7 +235,22 @@ export async function createServer(opts: IOpts): Promise<any> {
     return null;
   }
 
-  ws = createWebSocketServer(server);
+  const protocol = userConfig.https ? 'https:' : 'http:';
+  const basePort = opts.port || 8000;
+
+  const parseSocketServerAddress = async () => {
+    if (!process.env.SOCKET_SERVER) return basePort;
+    const {port} = new URL(process.env.SOCKET_SERVER);
+    const startPort = Number(port) || basePort;
+    if (port) {
+      const hmrPort = await portfinder.getPortPromise({ port: startPort, stopPort: startPort + 1 })
+      // 实际可用的hmr端口和设置的hmr端口不同
+      if (startPort !== hmrPort) console.log(`[SOCKET_SERVER] hmr port changed from ${port} to ${basePort}`)
+    }
+    return Number(startPort) ===  basePort ? undefined : (Number(startPort) || undefined);
+  };
+
+  ws = createWebSocketServer(server, await parseSocketServerAddress());
 
   ws.wss.on('connection', (socket) => {
     if (stats) {
@@ -243,11 +258,8 @@ export async function createServer(opts: IOpts): Promise<any> {
     }
   });
 
-  const protocol = userConfig.https ? 'https:' : 'http:';
-  const port = opts.port || 8000;
-
-  server.listen(port, () => {
-    const banner = getDevBanner(protocol, opts.host, port);
+  server.listen(basePort, () => {
+    const banner = getDevBanner(protocol, opts.host, basePort);
 
     console.log(banner.before);
     logger.ready(banner.main);

--- a/packages/bundler-webpack/src/server/server.ts
+++ b/packages/bundler-webpack/src/server/server.ts
@@ -242,10 +242,10 @@ export async function createServer(opts: IOpts): Promise<any> {
     if (!process.env.SOCKET_SERVER) return basePort;
     const {port} = new URL(process.env.SOCKET_SERVER);
     const startPort = Number(port) || basePort;
-    if (port) {
-      const hmrPort = await portfinder.getPortPromise({ port: startPort, stopPort: startPort + 1 })
-      // 实际可用的hmr端口和设置的hmr端口不同
-      if (startPort !== hmrPort) console.log(`[SOCKET_SERVER] hmr port changed from ${port} to ${basePort}`)
+    const hmrPort = await portfinder.getPortPromise({ port: startPort })
+    if (port && startPort !== hmrPort) {
+      console.log(`[SOCKET_SERVER] hmr port changed from ${port} to ${basePort}`)
+      return undefined;
     }
     return Number(startPort) ===  basePort ? undefined : (Number(startPort) || undefined);
   };

--- a/packages/bundler-webpack/src/server/ws.ts
+++ b/packages/bundler-webpack/src/server/ws.ts
@@ -7,10 +7,16 @@ import WebSocket from '../../compiled/ws';
 
 export function createWebSocketServer(
   server: HttpServer | HttpsServer | Http2Server | Server,
+  port?: number | undefined,
 ) {
-  const wss = new WebSocket.Server({
-    noServer: true,
-  });
+  let wss: WebSocket.Server;
+  if (port) {
+    wss = new WebSocket.Server({port});
+  } else {
+    wss = new WebSocket.Server({
+      noServer: true,
+    });
+  }
 
   server.on('upgrade', (req, socket, head) => {
     if (req.headers['sec-websocket-protocol'] === 'webpack-hmr') {


### PR DESCRIPTION
修复环境变量设置时候的process.env.SOCKET_SERVER 的指定hmr端口不生效
此处新增一个校验，如果指定端口可用，则使用指定端口。如不可用，则复用express的服务器端口，并抛出提示