### PR TITLE
fix: webpack version lose

### DIFF
--- a/packages/bundler-webpack/compiled/webpack/package.json
+++ b/packages/bundler-webpack/compiled/webpack/package.json
@@ -1,5 +1,6 @@
 {
   "name": "webpack",
+  "version": "5.88.2",
   "author": "Tobias Koppers @sokra",
   "types": "types.d.ts"
 }


### PR DESCRIPTION
一些插件会使用版本号判断兼容 webpack4 和 5，如

https://github.com/webpack-contrib/worker-loader/blob/a37f4b2caff11bb0bad5b54090a6de940504a3cb/src/index.js#L25
```ts
const useWebpack5 = require("webpack/package.json").version.startsWith("5.");
```

这里版本号丢失，会导致程序错误