### PR TITLE
fix: 更新dva文档中官网url地址

### DIFF
--- a/docs/docs/docs/max/dva.en-US.md
+++ b/docs/docs/docs/max/dva.en-US.md
@@ -340,4 +340,4 @@ Since the underlying layer of dva is based on redux, you can install redux's [de
 
 ## References
 
-- [dva official website](https://dvajs.com/)
+- [dva official website](https://dva.mxlab.top/)

--- a/docs/docs/docs/max/dva.md
+++ b/docs/docs/docs/max/dva.md
@@ -338,4 +338,4 @@ dva 的底层是基于 redux，所以你可以安装 redux 的[开发者工具](
 
 ## 参考文章
 
-- [dva 官网](https://dvajs.com/)
+- [dva 官网](https://dva.mxlab.top/)


### PR DESCRIPTION
https://dvajs.com/变更为https://dva.mxlab.top/