### PR TITLE
chore: stylelint-value-no-vendor-prefix

### DIFF
--- a/packages/lint/src/config/stylelint/index.ts
+++ b/packages/lint/src/config/stylelint/index.ts
@@ -20,6 +20,8 @@ module.exports = {
     'font-family-no-missing-generic-family-keyword': null, // iconfont
     'plugin/declaration-block-no-ignored-properties': true,
     'unit-no-unknown': [true, { ignoreUnits: ['rpx'] }],
+    // https://stylelint.io/user-guide/rules/value-no-vendor-prefix/
+    'value-no-vendor-prefix': [true, { ignoreValues: ['box'] }],
     // webcomponent
     'selector-type-no-unknown': null,
     'value-keyword-case': ['lower', { ignoreProperties: ['composes'] }],


### PR DESCRIPTION
某些用户需要在网页端实现多行文本溢出显示省略号的要求，但在stylelint中被禁止使用供应商前缀。针对该问题，框架层默认禁用该规则。

- 修改前报错效果：
![image](https://github.com/user-attachments/assets/d4d0d488-6855-4165-9e15-b893ec0e576c)
- 复现项目包：
[no-vendor-prefix.zip](https://github.com/user-attachments/files/18408620/no-vendor-prefix.zip)
