### PR TITLE
feat: support onExit hook for plugins

### DIFF
--- a/packages/core/src/service/service.ts
+++ b/packages/core/src/service/service.ts
@@ -698,6 +698,7 @@ export interface IServicePluginAPI {
 
   onCheck: IEvent<null>;
   onStart: IEvent<null>;
+  onExit: IEvent<null>;
   modifyAppData: IModify<typeof Service.prototype.appData, null>;
   modifyConfig: IModify<
     typeof Service.prototype.config,

--- a/packages/core/src/service/servicePlugin.ts
+++ b/packages/core/src/service/servicePlugin.ts
@@ -4,6 +4,7 @@ export default (api: PluginAPI) => {
   [
     'onCheck',
     'onStart',
+    'onExit',
     'modifyAppData',
     'modifyConfig',
     'modifyDefaultConfig',

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -30,6 +30,7 @@ export enum ServiceStage {
   onCheck,
   onStart,
   runCommand,
+  onExit,
 }
 
 export enum ConfigChangeType {


### PR DESCRIPTION
# Intro
- Plugin 支持 onExit Hook

# Changes
注意到 umi@3.x 支持 onExit，4.x 不支持。不确定是漏了还是故意干掉了。如果是故意干掉了，但没找到替代方法，并且 forkedDev 里还是会 applyPlugin。