### PR TITLE
fix: 约定式路由下使用routeProps导致以路由为分界拆分chunk失效

### DIFF
--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -405,7 +405,7 @@ export default function EmptyRoute() {
         '...$1',
       );
       // import: route props
-      headerImports.push(`import routeProps from './routeProps';`);
+      headerImports.push(`import routeProps from './routeProps.js';`);
       // prevent override internal route props
       headerImports.push(`
 if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
https://github.com/umijs/umi/issues/12953