### PR TITLE
fix(docs/example): replace unpkg w/ jsdelivr

### DIFF
--- a/docs/docs/docs/api/config.en-US.md
+++ b/docs/docs/docs/api/config.en-US.md
@@ -544,7 +544,7 @@ Example,
 ```
 // external react
 externals: { react: 'React' },
-headScripts: ['https://unpkg.com/react@17.0.1/umd/react.production.min.js'],
+headScripts: ['https://cdn.jsdelivr.net/npm/react@17.0.1/umd/react.production.min.js'],
 ```
 
 Note: Do not easily set antd’s externals, as due to its many dependencies and complicated usage, many problems could occur, and it’s hard to fully explain in one or two sentences.

--- a/docs/docs/docs/api/config.md
+++ b/docs/docs/docs/api/config.md
@@ -543,7 +543,7 @@ esbuildMinifyIIFE: true
 ```
 // external react
 externals: { react: 'React' },
-headScripts: ['https://unpkg.com/react@17.0.1/umd/react.production.min.js'],
+headScripts: ['https://cdn.jsdelivr.net/npm/react@17.0.1/umd/react.production.min.js'],
 ```
 
 注意：不要轻易设置 antd 的 externals，由于依赖较多，使用方式复杂，可能会遇到较多问题，并且一两句话很难解释清楚。

--- a/examples/libs/.umirc.ts
+++ b/examples/libs/.umirc.ts
@@ -3,9 +3,9 @@ export default {
     esbuild: true,
   },
   manifest: {},
-  styles: ['https://unpkg.com/@master/normal.css'],
+  styles: ['https://cdn.jsdelivr.net/npm/@master/normal.css'],
   scripts: [
-    'https://unpkg.com/@master/style',
-    'https://unpkg.com/@master/styles',
+    'https://cdn.jsdelivr.net/npm/@master/style',
+    'https://cdn.jsdelivr.net/npm/@master/styles',
   ],
 };


### PR DESCRIPTION
UNPKG has not been actively maintained and ~~has been down since `Mar 15, 2025`~~ was down from Mar 15, 2025, 2:00 AM and down for 18 hours (https://github.com/unpkg/unpkg/issues/412). Migrating to jsDelivr means a more stable and reliant service.

The PR replaces UNPKG in the docs and examples with jsDelivr.