### PR TITLE
chore: recommend using '@umijs/max' instead of 'umi' for better TS su…

### DIFF
--- a/docs/docs/docs/max/access.en-US.md
+++ b/docs/docs/docs/max/access.en-US.md
@@ -84,7 +84,7 @@ We provide a hook for obtaining permission-related information in components, as
 
 ```js
 import React from 'react';
-import { useAccess } from 'umi';
+import { useAccess } from '@umijs/max';
 
 const PageA = (props) => {
   const { foo } = props;
@@ -128,7 +128,7 @@ A complete example is as follows:
 
 ```js
 import React from 'react';
-import { useAccess, Access } from 'umi';
+import { useAccess, Access } from '@umijs/max';
 
 const PageA = (props) => {
   const { foo } = props;

--- a/docs/docs/docs/max/access.md
+++ b/docs/docs/docs/max/access.md
@@ -82,7 +82,7 @@ export const layout: RunTimeLayoutConfig = () => {
 
 ```js
 import React from 'react';
-import { useAccess } from 'umi';
+import { useAccess } from '@umijs/max';
 
 const PageA = (props) => {
   const { foo } = props;
@@ -126,7 +126,7 @@ export default PageA;
 
 ```js
 import React from 'react';
-import { useAccess, Access } from 'umi';
+import { useAccess, Access } from '@umijs/max';
 
 const PageA = (props) => {
   const { foo } = props;

--- a/docs/docs/docs/max/antd.en-US.md
+++ b/docs/docs/docs/max/antd.en-US.md
@@ -155,7 +155,7 @@ For example, to configure antd 5's theme preset algorithm and the maximum number
 
 ```ts
 // app.ts
-import { RuntimeAntdConfig } from 'umi';
+import { RuntimeAntdConfig } from '@umijs/max';
 import { theme } from 'antd';
 
 export const antd: RuntimeAntdConfig = (memo) => {
@@ -183,7 +183,7 @@ Note: This feature depends on `ConfigProvider`, please also enable `configProvid
 
 ```tsx
 import { Layout, Space, Button, version, theme, MappingAlgorithm } from 'antd';
-import { useAntdConfig, useAntdConfigSetter } from 'umi';
+import { useAntdConfig, useAntdConfigSetter } from ''@umijs/max'';
 const { darkAlgorithm, defaultAlgorithm } = theme;
 
 export default function Page() {

--- a/docs/docs/docs/max/antd.md
+++ b/docs/docs/docs/max/antd.md
@@ -153,7 +153,7 @@ export default {
 
 ```ts
 // app.ts
-import { RuntimeAntdConfig } from 'umi';
+import { RuntimeAntdConfig } from ''@umijs/max'';
 import { theme } from 'antd';
 
 export const antd: RuntimeAntdConfig = (memo) => {
@@ -181,7 +181,7 @@ export const antd: RuntimeAntdConfig = (memo) => {
 
 ```tsx
 import { Layout, Space, Button, version, theme, MappingAlgorithm } from 'antd';
-import { useAntdConfig, useAntdConfigSetter } from 'umi';
+import { useAntdConfig, useAntdConfigSetter } from ''@umijs/max'';
 const { darkAlgorithm, defaultAlgorithm } = theme;
 
 export default function Page() {

--- a/docs/docs/docs/max/data-flow.en-US.md
+++ b/docs/docs/docs/max/data-flow.en-US.md
@@ -142,7 +142,7 @@ Now, you want to use a global Model in a certain component. Taking the user info
 
 ```tsx
 // src/components/Username/index.tsx
-import { useModel } from 'umi';
+import { useModel } from '@umijs/max';
 
 export default function Page() {
   const { user, loading } = useModel('userModel');
@@ -167,7 +167,7 @@ The `useModel()` method can accept an optional second parameter. When a componen
 
 ```tsx
 // src/components/CounterActions/index.tsx
-import { useModel } from 'umi';
+import { useModel } from '@umijs/max';
 
 export default function Page() {
   const { add, minus } = useModel('counterModel', (model) => ({
@@ -209,7 +209,7 @@ export async function getInitialState() {
 Now, various plugins and your defined components can directly access this global initial state through `useModel('@@initialState')` as shown below:
 
 ```tsx
-import { useModel } from 'umi';
+import { useModel } from '@umijs/max';
 
 export default function Page() {
   const { initialState, loading, error, refresh, setInitialState } =
@@ -245,7 +245,7 @@ For specific usage, please refer to the [micro-frontend's parent-child communica
 
 ```tsx
 // src/components/AdminInfo/index.tsx
-import { useModel } from 'umi';
+import { useModel } from '@umijs/max';
 
 export default () => {
   const { user, fetchUser } = useModel('adminModel', (model) => ({

--- a/docs/docs/docs/max/data-flow.md
+++ b/docs/docs/docs/max/data-flow.md
@@ -141,7 +141,7 @@ export default function Page() {
 
 ```tsx
 // src/components/Username/index.tsx
-import { useModel } from 'umi';
+import { useModel } from '@umijs/max';
 
 export default function Page() {
   const { user, loading } = useModel('userModel');
@@ -166,7 +166,7 @@ export default function Page() {
 
 ```tsx
 // src/components/CounterActions/index.tsx
-import { useModel } from 'umi';
+import { useModel } from '@umijs/max';
 
 export default function Page() {
   const { add, minus } = useModel('counterModel', (model) => ({
@@ -208,7 +208,7 @@ export async function getInitialState() {
 现在，各种插件和您定义的组件都可以通过 `useModel('@@initialState')` 直接获取到这份全局的初始状态，如下所示：
 
 ```tsx
-import { useModel } from 'umi';
+import { useModel } from '@umijs/max';
 
 export default function Page() {
   const { initialState, loading, error, refresh, setInitialState } =
@@ -244,7 +244,7 @@ export default function Page() {
 
 ```tsx
 // src/components/AdminInfo/index.tsx
-import { useModel } from 'umi';
+import { useModel } from '@umijs/max';
 
 export default function Page() {
   const { user, fetchUser } = useModel('adminModel', (model) => ({

--- a/docs/docs/docs/max/dva.en-US.md
+++ b/docs/docs/docs/max/dva.en-US.md
@@ -75,7 +75,7 @@ Component example is as follows:
 
 ```javascript
 import React, { Component } from 'react';
-import { connect } from 'umi';
+import { connect } from ''@umijs/max'';
 
 @connect(({ user }) => ({
   user,
@@ -98,7 +98,7 @@ The connect method also adds `dispatch` to `this.props`, and you can call it to 
 
 ```javascript
 import React, { Component } from 'react';
-import { connect } from 'umi';
+import { connect } from ''@umijs/max'';
 
 @connect(({ user }) => ({
   user,
@@ -148,7 +148,7 @@ A model can define the following parts:
 
 ```jsx
 import React, { Component } from 'react';
-import { connect } from 'umi';
+import { connect } from ''@umijs/max'';
 
 const mapModelToProps = allModels => {
   return {

--- a/docs/docs/docs/max/dva.md
+++ b/docs/docs/docs/max/dva.md
@@ -73,7 +73,7 @@ export default {
 
 ```javascript
 import React, { Component } from 'react';
-import { connect } from 'umi';
+import { connect } from ''@umijs/max'';
 
 @connect(({ user }) => ({
   user,
@@ -96,7 +96,7 @@ connect 方法同时也会添加 `dispatch` 到 `this.props` 上，你可以在�
 
 ```javascript
 import React, { Component } from 'react';
-import { connect } from 'umi';
+import { connect } from ''@umijs/max'';
 
 @connect(({ user }) => ({
   user,
@@ -146,7 +146,7 @@ dispatch 一个 action 之后会按照 action 中的 type 找到定义在 model 
 
 ```jsx
 import React, { Component } from 'react';
-import { connect } from 'umi';
+import { connect } from ''@umijs/max'';
 
 const mapModelToProps = allModels => {
   return {

--- a/docs/docs/docs/max/i18n.en-US.md
+++ b/docs/docs/docs/max/i18n.en-US.md
@@ -71,7 +71,7 @@ You can also use `.json` files to store multilingual content:
 Everything is ready, now you can use multilingual content in Umi. Leave it to our `<FormattedMessage />` component, just pass in the previous `welcome` as the value of the parameter `id`:
 
 ```tsx
-import { FormattedMessage } from 'umi';
+import { FormattedMessage } from ''@umijs/max'';
 
 export default function Page() {
   return (
@@ -98,7 +98,7 @@ In some cases, you need to pass multilingual content as a parameter to a certain
 
 ```tsx
 import { Alert } from 'antd';
-import { useIntl } from 'umi';
+import { useIntl } from ''@umijs/max'';
 
 export default function Page() {
   const intl = useIntl();
@@ -139,7 +139,7 @@ export default {
 Above, we wrote special syntax `{name}`, which allows us to dynamically assign values at runtime:
 
 ```tsx
-import { FormattedMessage } from 'umi';
+import { FormattedMessage } from ''@umijs/max'';
 
 export default function Page() {
   return (
@@ -153,7 +153,7 @@ export default function Page() {
 If you wish to achieve this through the `intl` object, you can do so by assigning it like this:
 
 ```tsx
-import { useIntl } from 'umi';
+import { useIntl } from ''@umijs/max'';
 
 export default function Page() {
   const intl = useIntl();
@@ -187,7 +187,7 @@ The rendered result is as follows:
 The preset `<SelectLang />` component can help you quickly add the feature of switching languages to your project, just write it like this:
 
 ```tsx
-import { SelectLang } from 'umi';
+import { SelectLang } from ''@umijs/max'';
 
 export default function Page() {
   return <SelectLang />;
@@ -197,7 +197,7 @@ export default function Page() {
 In many cases, you may need to write your own language-switching component. This is where the `setLocale()` interface comes in handy:
 
 ```ts
-import { setLocale } from 'umi';
+import { setLocale } from ''@umijs/max'';
 
 // Refresh the page when switching
 setLocale('en-US');
@@ -246,7 +246,7 @@ With the following component:
 
 ```tsx
 import { Button } from 'antd';
-import { FormattedMessage } from 'umi';
+import { FormattedMessage } from ''@umijs/max'';
 
 export default function Page() {
   return (
@@ -271,7 +271,7 @@ Especially, if you need to give a default value without completing international
 
 ```tsx
 import { Button } from 'antd';
-import { FormattedMessage } from 'umi';
+import { FormattedMessage } from ''@umijs/max'';
 
 export default function Page() {
   return (
@@ -286,7 +286,7 @@ When using the `formatMessage()` method, you can do the same:
 
 ```tsx
 import { Button } from 'antd';
-import { useIntl } from 'umi';
+import { useIntl } from ''@umijs/max'';
 
 export default function Page() {
   const intl = useIntl();
@@ -316,7 +316,7 @@ Without creating and writing separate multilingual files, you can dynamically ad
 For example, if you want to dynamically introduce Traditional Chinese multilingual support, you can write code as follows:
 
 ```ts
-import { addLocale } from 'umi';
+import { addLocale } from ''@umijs/max'';
 import zhTW from 'antd/es/locale/zh_TW';
 
 addLocale(
@@ -336,7 +336,7 @@ addLocale(
 You can get an array of all current multilingual options through the `getAllLocales()` interface, including multilingual options added through the `addLocale()` method. This interface defaults to looking for files in the `src/locales` directory that are like `zh-CN.(js|json|ts)` and returns the Key of the multilingual.
 
 ```ts
-import { getAllLocales } from 'umi';
+import { getAllLocales } from ''@umijs/max'';
 
 getAllLocales();
 // [en-US, zh-CN, ...]
@@ -347,7 +347,7 @@ getAllLocales();
 You can get the currently selected language through the `getLocale()` interface:
 
 ```ts
-import { getLocale } from 'umi';
+import { getLocale } from ''@umijs/max'';
 
 getLocale();
 // zh-CN
@@ -365,7 +365,7 @@ getLocale();
 ```
 
 ```ts
-import { useIntl } from 'umi';
+import { useIntl } from ''@umijs/max'';
 
 const intl = useIntl();
 const msg = intl.formatMessage(
@@ -392,7 +392,7 @@ You can dynamically set the current language using the `setLocale()` interface t
 | `realReload` | `Boolean` | Whether to refresh the page when switching, default is `true` to refresh |
 
 ```ts
-import { setLocale } from 'umi';
+import { setLocale } from ''@umijs/max'';
 
 // Refresh the page when switching
 setLocale('en-US');

--- a/docs/docs/docs/max/i18n.md
+++ b/docs/docs/docs/max/i18n.md
@@ -70,7 +70,7 @@ export default {
 一切就绪，现在您可以在 Umi 中使用多语言内容。交给我们的 `<FormattedMessage />` 组件吧，只需要将前面的 `welcome` 作为参数 `id` 的值传入即可：
 
 ```tsx
-import { FormattedMessage } from 'umi';
+import { FormattedMessage } from ''@umijs/max'';
 
 export default function Page() {
   return (
@@ -97,7 +97,7 @@ export default function Page() {
 
 ```tsx
 import { Alert } from 'antd';
-import { useIntl } from 'umi';
+import { useIntl } from ''@umijs/max'';
 
 export default function Page() {
   const intl = useIntl();
@@ -138,7 +138,7 @@ export default {
 在上面，我们编写了特殊的语法 `{name}`，这允许我们在运行时动态赋值：
 
 ```tsx
-import { FormattedMessage } from 'umi';
+import { FormattedMessage } from ''@umijs/max'';
 
 export default function Page() {
   return (
@@ -152,7 +152,7 @@ export default function Page() {
 如果您希望通过 `intl` 对象来实现，那么可以这样对它赋值：
 
 ```tsx
-import { useIntl } from 'umi';
+import { useIntl } from ''@umijs/max'';
 
 export default function Page() {
   const intl = useIntl();
@@ -186,7 +186,7 @@ export default function Page() {
 通过预设的 `<SelectLang />` 组件可以帮助您快速地向项目中添加切换语言的功能，只需要像这样编写：
 
 ```tsx
-import { SelectLang } from 'umi';
+import { SelectLang } from ''@umijs/max'';
 
 export default function Page() {
   return <SelectLang />;
@@ -196,7 +196,7 @@ export default function Page() {
 更多情况下，您可能需要自己编写切换语言的组件。这时就轮到 `setLocale()` 接口大显身手了：
 
 ```ts
-import { setLocale } from 'umi';
+import { setLocale } from ''@umijs/max'';
 
 // 切换时刷新页面
 setLocale('en-US');
@@ -245,7 +245,7 @@ export default {
 
 ```tsx
 import { Button } from 'antd';
-import { FormattedMessage } from 'umi';
+import { FormattedMessage } from ''@umijs/max'';
 
 export default function Page() {
   return (
@@ -270,7 +270,7 @@ export default function Page() {
 
 ```tsx
 import { Button } from 'antd';
-import { FormattedMessage } from 'umi';
+import { FormattedMessage } from ''@umijs/max'';
 
 export default function Page() {
   return (
@@ -285,7 +285,7 @@ export default function Page() {
 
 ```tsx
 import { Button } from 'antd';
-import { useIntl } from 'umi';
+import { useIntl } from ''@umijs/max'';
 
 export default function Page() {
   const intl = useIntl();
@@ -315,7 +315,7 @@ export default function Page() {
 例如，您想要动态引入繁体中文的多语言支持，可以编写代码如下：
 
 ```ts
-import { addLocale } from 'umi';
+import { addLocale } from ''@umijs/max'';
 import zhTW from 'antd/es/locale/zh_TW';
 
 addLocale(
@@ -335,7 +335,7 @@ addLocale(
 通过 `getAllLocales()` 接口可以获取当前所有多语言选项的数组，包括通过 `addLocale()` 方法添加的多语言选项。该接口默认会在 `src/locales` 目录下寻找形如 `zh-CN.(js|json|ts)` 的文件，并返回多语言的 Key。
 
 ```ts
-import { getAllLocales } from 'umi';
+import { getAllLocales } from ''@umijs/max'';
 
 getAllLocales();
 // [en-US, zh-CN, ...]
@@ -346,7 +346,7 @@ getAllLocales();
 通过 `getLocale()` 接口可以获取当前选择的语言：
 
 ```ts
-import { getLocale } from 'umi';
+import { getLocale } from ''@umijs/max'';
 
 getLocale();
 // zh-CN
@@ -364,7 +364,7 @@ getLocale();
 ```
 
 ```ts
-import { useIntl } from 'umi';
+import { useIntl } from ''@umijs/max'';
 
 const intl = useIntl();
 const msg = intl.formatMessage(
@@ -391,7 +391,7 @@ console.log(msg);
 | `realReload` | `Boolean` | 切换时是否刷新页面，默认为 `true` 刷新页面 |
 
 ```ts
-import { setLocale } from 'umi';
+import { setLocale } from ''@umijs/max'';
 
 // 切换时刷新页面
 setLocale('en-US');

--- a/docs/docs/docs/max/layout-menu.en-US.md
+++ b/docs/docs/docs/max/layout-menu.en-US.md
@@ -38,7 +38,7 @@ To further reduce R&D costs, we have integrated the layout as a Umi plugin. With
 The plugin can be enabled through the `layout` property in the `config/config.ts` configuration file.
 
 ```ts
-import { defineConfig } from 'umi';
+import { defineConfig } from ''@umijs/max'';
 
 export default defineConfig({
   layout: {

--- a/docs/docs/docs/max/layout-menu.md
+++ b/docs/docs/docs/max/layout-menu.md
@@ -36,7 +36,7 @@ export default {
 可以通过配置文件 `config/config.ts` 中的 `layout` 属性开启插件。
 
 ```ts
-import { defineConfig } from 'umi';
+import { defineConfig } from ''@umijs/max'';
 
 export default defineConfig({
   layout: {

--- a/docs/docs/docs/max/mf.en-US.md
+++ b/docs/docs/docs/max/mf.en-US.md
@@ -55,7 +55,7 @@ Regular Umi projects
 
 ```ts
 // .umirc.ts
-import { defineConfig } from 'umi';
+import { defineConfig } from ''@umijs/max'';
 
 const shared = {
   react: {

--- a/docs/docs/docs/max/mf.md
+++ b/docs/docs/docs/max/mf.md
@@ -54,7 +54,7 @@ export default defineConfig({
 
 ```ts
 // .umirc.ts
-import { defineConfig } from 'umi';
+import { defineConfig } from ''@umijs/max'';
 
 const shared = {
   react: {

--- a/docs/docs/docs/max/micro-frontend.en-US.md
+++ b/docs/docs/docs/max/micro-frontend.en-US.md
@@ -179,7 +179,7 @@ Load (or unload) child applications through the `<MicroApp />` component. When t
 Now, if we want to introduce child application `app1` in a certain page of the parent application, we can write the code as follows:
 
 ```tsx
-import { MicroApp } from 'umi';
+import { MicroApp } from ''@umijs/max'';
 
 export default function Page() {
   return <MicroApp name="app1" />;
@@ -191,7 +191,7 @@ When using this method to introduce child applications, the routing of parent an
 If the parent application's route includes a prefix, you can configure the `base` attribute to ensure that the routing of the parent and child applications correspond correctly. For example, when the parent application's route is `/prefix/router-path/some/page`, if we want the child application's route to be `/some/page`, we can modify the code as follows:
 
 ```tsx
-import { MicroApp } from 'umi';
+import { MicroApp } from ''@umijs/max'';
 
 export default function Page() {
   return <MicroApp name="app1" base="/prefix/router-path" />;
@@ -210,7 +210,7 @@ The `<MicroAppWithMemoHistory />` component is a variant of the `<MicroApp />` c
 Now, if we want to introduce child application `app2` inside a certain component of the parent application, with the route of the child application being `/some/page`, we can write the code as follows:
 
 ```tsx
-import { MicroAppWithMemoHistory } from 'umi';
+import { MicroAppWithMemoHistory } from ''@umijs/max'';
 
 export default function Page() {
   return <MicroAppWithMemoHistory name="app2" url="/some/page" />;
@@ -223,7 +223,7 @@ If child applications are introduced **through the routing binding method**, ins
 
 ```tsx
 // In app1
-import { MicroAppLink } from 'umi';
+import { MicroAppLink } from ''@umijs/max'';
 
 export default function Page() {
   return (
@@ -241,7 +241,7 @@ In the above example, after clicking the button, the parent application's routin
 
 ```tsx
 // In app2
-import { MicroAppLink } from 'umi';
+import { MicroAppLink } from ''@umijs/max'';
 
 export default function Page() {
   return (
@@ -259,7 +259,7 @@ You can also jump from the child application to the specified route of the paren
 
 ```tsx
 // In the child application
-import { MicroAppLink } from 'umi';
+import { MicroAppLink } from ''@umijs/max'';
 
 export default function Page() {
   return (
@@ -294,7 +294,7 @@ You can refresh the child application manually like this:
 
 ```tsx
 import { useRef } from 'react';
-import { MicroApp } from 'umi';
+import { MicroApp } from ''@umijs/max'';
 
 export default function Page() {
   const microAppRef = useRef();
@@ -385,7 +385,7 @@ If child applications are introduced through the component method, directly pass
 
 ```tsx
 import { useState } from 'react';
-import { MicroApp } from 'umi';
+import { MicroApp } from ''@umijs/max'';
 
 export default function Page() {
   const [globalState, setGlobalState] = useState<any>({
@@ -407,7 +407,7 @@ export default function Page() {
 The child application will automatically generate a global Model, whose namespace is `@@qiankunStateFromMaster`. Through the `useModel()` method, child applications are allowed to get and consume the data passed by the parent application in any component, as follows:
 
 ```tsx
-import { useModel } from 'umi';
+import { useModel } from ''@umijs/max'';
 
 export default function Page() {
   const masterProps = useModel('@@qiankunStateFromMaster');
@@ -418,7 +418,7 @@ export default function Page() {
 Or you can obtain and consume the data passed by the parent application through the higher-order method `connectMaster()`, as shown below:
 
 ```tsx
-import { connectMaster } from 'umi';
+import { connectMaster } from ''@umijs/max'';
 
 function MyPage(props) {
   return <div>{JSON.stringify(props)}</div>;

--- a/docs/docs/docs/max/micro-frontend.md
+++ b/docs/docs/docs/max/micro-frontend.md
@@ -178,7 +178,7 @@ export default {
 现在，我们想在父应用的某个页面中引入子应用 `app1`，可以编写代码如下：
 
 ```tsx
-import { MicroApp } from 'umi';
+import { MicroApp } from ''@umijs/max'';
 
 export default function Page() {
   return <MicroApp name="app1" />;
@@ -190,7 +190,7 @@ export default function Page() {
 如果父应用的路由包含前缀，可以通过配置 `base` 属性保证父子应用的路由正确对应。例如，父应用路由为 `/prefix/router-path/some/page` 时，我们希望子应用的路由为 `/some/page`，可以修改代码如下：
 
 ```tsx
-import { MicroApp } from 'umi';
+import { MicroApp } from ''@umijs/max'';
 
 export default function Page() {
   return <MicroApp name="app1" base="/prefix/router-path" />;
@@ -209,7 +209,7 @@ export default function Page() {
 现在，我们想在父应用的某个组件内部引入 `app2` 子应用，子应用的路由为 `/some/page`，可以编写代码如下：
 
 ```tsx
-import { MicroAppWithMemoHistory } from 'umi';
+import { MicroAppWithMemoHistory } from ''@umijs/max'';
 
 export default function Page() {
   return <MicroAppWithMemoHistory name="app2" url="/some/page" />;
@@ -222,7 +222,7 @@ export default function Page() {
 
 ```tsx
 // 在 app1 中
-import { MicroAppLink } from 'umi';
+import { MicroAppLink } from ''@umijs/max'';
 
 export default function Page() {
   return (
@@ -240,7 +240,7 @@ export default function Page() {
 
 ```tsx
 // 在 app2 中
-import { MicroAppLink } from 'umi';
+import { MicroAppLink } from ''@umijs/max'';
 
 export default function Page() {
   return (
@@ -258,7 +258,7 @@ export default function Page() {
 
 ```tsx
 // 在子应用中
-import { MicroAppLink } from 'umi';
+import { MicroAppLink } from ''@umijs/max'';
 
 export default function Page() {
   return (
@@ -293,7 +293,7 @@ Qiankun 在 single-spa 的基础上实现了一些额外的生命钩子。按照
 
 ```tsx
 import { useRef } from 'react';
-import { MicroApp } from 'umi';
+import { MicroApp } from ''@umijs/max'';
 
 export default function Page() {
   const microAppRef = useRef();
@@ -384,7 +384,7 @@ export function useQiankunStateForSlave() {
 
 ```tsx
 import { useState } from 'react';
-import { MicroApp } from 'umi';
+import { MicroApp } from ''@umijs/max'';
 
 export default function Page() {
   const [globalState, setGlobalState] = useState<any>({
@@ -406,7 +406,7 @@ export default function Page() {
 子应用会自动生成一个全局的 Model，其命名空间为 `@@qiankunStateFromMaster`。通过 `useModel()` 方法，允许子应用在任意组件中获取并消费父应用透传的数据，如下所示：
 
 ```tsx
-import { useModel } from 'umi';
+import { useModel } from ''@umijs/max'';
 
 export default function Page() {
   const masterProps = useModel('@@qiankunStateFromMaster');
@@ -417,7 +417,7 @@ export default function Page() {
 或者可以通过高阶方法 `connectMaster()` 来获取并消费父应用透传的数据，如下所示：
 
 ```tsx
-import { connectMaster } from 'umi';
+import { connectMaster } from ''@umijs/max'';
 
 function MyPage(props) {
   return <div>{JSON.stringify(props)}</div>;
@@ -508,7 +508,7 @@ export default {
 如果通过组件的模式引入子应用，直接将 `autoSetLoading` 作为参数传入即可：
 
 ```tsx
-import { MicroApp } from 'umi';
+import { MicroApp } from ''@umijs/max'';
 
 export default function Page() {
   return <MicroApp name="app1" autoSetLoading />;
@@ -542,7 +542,7 @@ export const qiankun = () => ({
 
 ```tsx
 import CustomLoader from '@/components/CustomLoader';
-import { MicroApp } from 'umi';
+import { MicroApp } from ''@umijs/max'';
 
 export default function Page() {
   return (
@@ -612,7 +612,7 @@ export default {
 如果通过组件的模式引入子应用，直接将 `autoCaptureError` 作为参数传入即可：
 
 ```tsx
-import { MicroApp } from 'umi';
+import { MicroApp } from ''@umijs/max'';
 
 export default function Page() {
   return <MicroApp name="app1" autoCaptureError />;
@@ -646,7 +646,7 @@ export const qiankun = () => ({
 
 ```tsx
 import CustomErrorBoundary from '@/components/CustomErrorBoundary';
-import { MicroApp } from 'umi';
+import { MicroApp } from ''@umijs/max'';
 
 export default function Page() {
   return (

--- a/docs/docs/docs/max/moment2dayjs.mdd
+++ b/docs/docs/docs/max/moment2dayjs.mdd
@@ -1,4 +1,4 @@
-import { Message, Tabbed } from 'umi';
+import { Message, Tabbed } from ''@umijs/max'';
 
 # moment2dayjs 插件
 

--- a/docs/docs/docs/max/react-query.md
+++ b/docs/docs/docs/max/react-query.md
@@ -79,7 +79,7 @@ export default {
 ```ts
 // src/app.ts
 
-import { RuntimeReactQueryType } from 'umi';
+import { RuntimeReactQueryType } from ''@umijs/max'';
 
 export const reactQuery: RuntimeReactQueryType = {
   devtool: { 

--- a/docs/docs/docs/max/request.en-US.md
+++ b/docs/docs/docs/max/request.en-US.md
@@ -9,7 +9,7 @@ translated_at: '2024-03-17T08:46:03.932Z'
 `@umijs/max` has built-in plugin solution. It offers a unified network request and error handling solution based on [axios](https://axios-http.com/) and ahooks' `useRequest` from [ahooks](https://ahooks-v2.surge.sh).
 
 ```js
-import { request, useRequest } from 'umi';
+import { request, useRequest } from ''@umijs/max'';
 
 request;
 useRequest;
@@ -44,7 +44,7 @@ Then useRequest can directly consume the `data`, which would be 123, instead of 
 In `src/app.ts`, you can customize the request settings for your project by configuring the request item.
 
 ```ts
-import type { RequestConfig } from 'umi';
+import type { RequestConfig } from ''@umijs/max'';
 
 export const request: RequestConfig = {
   timeout: 1000,
@@ -141,7 +141,7 @@ const request: RequestConfig = {
 ### useRequest
 The plugin has built-in [@ahooksjs/useRequest](https://ahooks-v2.js.org/hooks/async), allowing you to consume data simply and conveniently within components. The example is as follows:
 ```typescript
-import { useRequest } from 'umi';
+import { useRequest } from ''@umijs/max'';
 
 export default function Page() {
   const { data, error, loading } = useRequest(() => {
@@ -190,7 +190,7 @@ request returns the data from your backend by default, if you wish to receive th
 ### RequestConfig
 This is an interface definition that can help you better configure runtime settings.
 ```typescript
-import type { RequestConfig } from 'umi';
+import type { RequestConfig } from ''@umijs/max'';
 
 export const request:RequestConfig = {};
 ```
@@ -296,7 +296,7 @@ async function middleware(ctx, next) {
 
 ```tsx
 // Umi@3
-import { useRequest } from 'umi';
+import { useRequest } from ''@umijs/max'';
 // a: [1,2,3] => a=1&a=2&a=3
 
 // Umi@4

--- a/docs/docs/docs/max/request.md
+++ b/docs/docs/docs/max/request.md
@@ -8,7 +8,7 @@ toc: content
 `@umijs/max` 内置了插件方案。它基于 [axios](https://axios-http.com/) 和 [ahooks](https://ahooks-v2.surge.sh) 的 `useRequest` 提供了一套统一的网络请求和错误处理方案。
 
 ```js
-import { request, useRequest } from 'umi';
+import { request, useRequest } from ''@umijs/max'';
 
 request;
 useRequest;
@@ -43,7 +43,7 @@ export default {
 在 `src/app.ts` 中你可以通过配置 request 项，来为你的项目进行统一的个性化的请求设定。
 
 ```ts
-import type { RequestConfig } from 'umi';
+import type { RequestConfig } from ''@umijs/max'';
 
 export const request: RequestConfig = {
   timeout: 1000,
@@ -140,7 +140,7 @@ const request: RequestConfig = {
 ### useRequest
 插件内置了 [@ahooksjs/useRequest](https://ahooks-v2.js.org/hooks/async) ，你可以在组件内通过该 Hook 简单便捷的消费数据。示例如下：
 ```typescript
-import { useRequest } from 'umi';
+import { useRequest } from ''@umijs/max'';
 
 export default function Page() {
   const { data, error, loading } = useRequest(() => {
@@ -189,7 +189,7 @@ request 默认返回的是你后端的数据，如果你想要拿到 axios 完�
 ### RequestConfig
 这是一个接口的定义，可以帮助你更好地配置运行时配置。
 ```typescript
-import type { RequestConfig } from 'umi';
+import type { RequestConfig } from ''@umijs/max'';
 
 export const request:RequestConfig = {};
 ```
@@ -295,7 +295,7 @@ async function middleware(ctx, next) {
 
 ```tsx
 // Umi@3
-import { useRequest } from 'umi';
+import { useRequest } from ''@umijs/max'';
 // a: [1,2,3] => a=1&a=2&a=3
 
 // Umi@4

--- a/docs/docs/docs/max/valtio.en-US.md
+++ b/docs/docs/docs/max/valtio.en-US.md
@@ -25,7 +25,7 @@ export default {
 Extremely simple.
 
 ```ts
-import { proxy, useSnapshot } from 'umi';
+import { proxy, useSnapshot } from ''@umijs/max'';
 
 // 1. Define data
 const state = proxy({ count: 0 });
@@ -41,7 +41,7 @@ state.count += 1;
 Naturally supported.
 
 ```ts
-import { proxy } from 'umi';
+import { proxy } from ''@umijs/max'';
 
 const state = proxy({ count: 0 });
 state.count;
@@ -51,7 +51,7 @@ state.count += 1;
 ### Data Deduction
 
 ```ts
-import { proxyWithComputed } from 'umi';
+import { proxyWithComputed } from ''@umijs/max'';
 
 const state = proxyWithComputed({
   count: 0,
@@ -65,7 +65,7 @@ const state = proxyWithComputed({
 Two ways to use, can be combined with state or separated.
 
 ```ts
-import { proxy } from 'umi';
+import { proxy } from ''@umijs/max'';
 
 // Method one: Combine
 const state = proxy({
@@ -93,7 +93,7 @@ const actions = {
 ### Splitting and Combining Data Structures
 
 ```ts
-import { proxy } from 'umi';
+import { proxy } from ''@umijs/max'';
 
 // For example, as follows defined
 // state.foo and state.bar are both proxies, can be split and used
@@ -113,7 +113,7 @@ const state = proxy({ foo, bar });
 If the content of props is unrelated to state, it can be left unhandled; if related, wrap it with context as follows, while synchronizing props to state data.
 
 ```ts
-import { proxy } from 'umi';
+import { proxy } from ''@umijs/max'';
 
 // 1. createContext
 const MyContext = createContext();
@@ -127,7 +127,7 @@ useContext(MyContext);
 ### Redux DevTools Support
 
 ```ts
-import { proxy, proxyWithDevtools } from 'umi';
+import { proxy, proxyWithDevtools } from ''@umijs/max'';
 
 const state = proxy({ count: 0 });
 proxyWithDevtools(state, { name: 'count', enabled: true });
@@ -136,7 +136,7 @@ proxyWithDevtools(state, { name: 'count', enabled: true });
 ### Redo & Undo Support
 
 ```ts
-import { proxyWithHistory } from 'umi';
+import { proxyWithHistory } from ''@umijs/max'';
 
 const state = proxyWithHistory({
   count: 0,
@@ -153,7 +153,7 @@ state.history;
 To be implemented.
 
 ```ts
-import { proxyWithPersistent } from 'umi';
+import { proxyWithPersistent } from ''@umijs/max'';
 
 const state = proxyWithPersistent({
   count: 0,
@@ -185,7 +185,7 @@ export function proxyWithPersist<V>(val: V, opts: {
 1) Requires React 16.8 or above, 2) Does not support IE 11, 3) map and set cannot be used directly, need to use the valtio provided proxyMap and proxySet instead.
 
 ```ts
-import { proxy, proxyMap } from 'umi';
+import { proxy, proxyMap } from ''@umijs/max'';
 
 const state = proxy({
   todos: proxyMap<number, Todo>([[1, {id:1,text:'Learn Umi'}]]),

--- a/docs/docs/docs/max/valtio.md
+++ b/docs/docs/docs/max/valtio.md
@@ -23,7 +23,7 @@ export default {
 极其简单。
 
 ```ts
-import { proxy, useSnapshot } from 'umi';
+import { proxy, useSnapshot } from ''@umijs/max'';
 
 // 1、定义数据
 const state = proxy({ count: 0 });
@@ -39,7 +39,7 @@ state.count += 1;
 天然支持。
 
 ```ts
-import { proxy } from 'umi';
+import { proxy } from ''@umijs/max'';
 
 const state = proxy({ count: 0 });
 state.count;
@@ -49,7 +49,7 @@ state.count += 1;
 ### 数据推导
 
 ```ts
-import { proxyWithComputed } from 'umi';
+import { proxyWithComputed } from ''@umijs/max'';
 
 const state = proxyWithComputed({
   count: 0,
@@ -63,7 +63,7 @@ const state = proxyWithComputed({
 两种用法，可以和 state 放一起，也可以分开。
 
 ```ts
-import { proxy } from 'umi';
+import { proxy } from ''@umijs/max'';
 
 // 方法一：放一起
 const state = proxy({
@@ -91,7 +91,7 @@ const actions = {
 ### 数据结构的拆分与组合
 
 ```ts
-import { proxy } from 'umi';
+import { proxy } from ''@umijs/max'';
 
 // 比如如下定义
 // state.foo 和 state.bar 都是 proxy，可拆分使用
@@ -111,7 +111,7 @@ const state = proxy({ foo, bar });
 如果 props 内容和 state 无关，可以不处理；如果有关，按以下方式用 context 包一下，同时做 props 到 state 的数据同步即可。
 
 ```ts
-import { proxy } from 'umi';
+import { proxy } from ''@umijs/max'';
 
 // 1、createContext
 const MyContext = createContext();
@@ -125,7 +125,7 @@ useContext(MyContext);
 ### Redux DevTools 支持
 
 ```ts
-import { proxy, proxyWithDevtools } from 'umi';
+import { proxy, proxyWithDevtools } from ''@umijs/max'';
 
 const state = proxy({ count: 0 });
 proxyWithDevtools(state, { name: 'count', enabled: true });
@@ -134,7 +134,7 @@ proxyWithDevtools(state, { name: 'count', enabled: true });
 ### Redo & Undo 支持
 
 ```ts
-import { proxyWithHistory } from 'umi';
+import { proxyWithHistory } from ''@umijs/max'';
 
 const state = proxyWithHistory({
   count: 0,
@@ -151,7 +151,7 @@ state.history;
 待实现。
 
 ```ts
-import { proxyWithPersistant } from 'umi';
+import { proxyWithPersistant } from ''@umijs/max'';
 
 const state = proxyWithPersistant({
   count: 0,
@@ -183,7 +183,7 @@ export function proxyWithPersist<V>(val: V, opts: {
 1）需要 React 16.8 或以上，2）不支持 IE 11，3）map 和 set 不能直接用，需改用 valtio 提供的 proxyMap 和 proxySet。
 
 ```ts
-import { proxy, proxyMap } from 'umi';
+import { proxy, proxyMap } from ''@umijs/max'';
 
 const state = proxy({
   todos: proxyMap<number, Todo>([[1, {id:1,text:'Learn Umi'}]]),


### PR DESCRIPTION
Umi Max has already re-exported all content from 'umi', so project code should not directly depend on 'umi'. It's recommended to use `from '@umijs/max'` instead of `from 'umi'` to ensure better TypeScript support and avoid potential type resolution issues.
