### PR TITLE
fix: 文档-当指定 `UMI_ENV` 时，会额外加载指定值的配置文件，优先级 应该是 .umirc文件，而不是 config

### DIFF
--- a/docs/docs/docs/guides/env-variables.en-US.md
+++ b/docs/docs/docs/guides/env-variables.en-US.md
@@ -177,15 +177,15 @@ $ SPEED_MEASURE=JSON umi dev
 
 When `UMI_ENV` is specified, it will additionally load the configuration file with the specified value, with priority as:
 
- - `config.ts`
+ - `.umirc.ts`
 
- - `config.${UMI_ENV}.ts`
+ - `.umirc.${UMI_ENV}.ts`
 
- - `config.${dev | prod | test}.ts`
+ - `.umirc.${dev | prod | test}.ts`
 
- - `config.${dev | prod | test}.${UMI_ENV}.ts`
+ - `.umirc.${dev | prod | test}.${UMI_ENV}.ts`
 
- - `config.local.ts`
+ - `.umirc.local.ts`
 
 If `UMI_ENV` is not specified, only the configuration file corresponding to the current environment will be loaded, the more specific down the list, the higher the priority, higher priority configurations can be moved down.
 

--- a/docs/docs/docs/guides/env-variables.md
+++ b/docs/docs/docs/guides/env-variables.md
@@ -176,15 +176,15 @@ $ SPEED_MEASURE=JSON umi dev
 
 当指定 `UMI_ENV` 时，会额外加载指定值的配置文件，优先级为：
 
- - `config.ts`
+ - `.umirc.ts`
 
- - `config.${UMI_ENV}.ts`
+ - `.umirc.${UMI_ENV}.ts`
 
- - `config.${dev | prod | test}.ts`
+ - `.umirc.${dev | prod | test}.ts`
 
- - `config.${dev | prod | test}.${UMI_ENV}.ts`
+ - `.umirc.${dev | prod | test}.${UMI_ENV}.ts`
 
- - `config.local.ts`
+ - `.umirc.local.ts`
 
 若不指定 `UMI_ENV` ，则只会加载当前环境对应的配置文件，越向下的越具体，优先级更高，高优的配置可以往下移动。
 


### PR DESCRIPTION
我发现 实际使用时，文档标注与实际表现不一致，这里做了文档的修复，请查看