### PR TITLE
feat: add transformRuntime config for babel

### DIFF
--- a/docs/docs/docs/api/config.en-US.md
+++ b/docs/docs/docs/api/config.en-US.md
@@ -1470,6 +1470,27 @@ theme: { '@primary-color': '#1DA57A' }
 
 Configure global page title, currently only supports static Title.
 
+## transformRuntime
+
+- Type: `{ absoluteRuntime: string, version: string }`
+- Default: `{}`
+
+Configure transform-runtime plugin.
+
+For example, if you want to use the latest @babel/runtime version. You can first configure it as follows:
+
+```js
+transformRuntime: {
+  absoluteRuntime: process.cwd(),
+}
+```
+
+Then install @babel/runtime to the project:
+
+```bash
+$ npm install @babel/runtime --save-dev
+```
+
 ## verifyCommit
 
 - Type: `{ scope: string[]; allowEmoji: boolean }`

--- a/docs/docs/docs/api/config.md
+++ b/docs/docs/docs/api/config.md
@@ -1507,6 +1507,27 @@ theme: { '@primary-color': '#1DA57A' }
 
 配置全局页面 title，暂时只支持静态的 Title。
 
+## transformRuntime
+
+- 类型：`{ absoluteRuntime: string, version: string }`
+- 默认值：`{}`
+
+配置 transform-runtime 插件的部分功能。
+
+比如，如果你想用最新的 @babel/runtime 版本。可先配置如下：
+
+```js
+transformRuntime: {
+  absoluteRuntime: process.cwd(),
+}
+```
+
+再安装 @babel/runtime 到项目中：
+
+```bash
+$ npm install @babel/runtime --save-dev
+```
+
 ## verifyCommit
 
 - 类型：`{ scope: string[]; allowEmoji: boolean }`

--- a/packages/bundler-webpack/src/schema.ts
+++ b/packages/bundler-webpack/src/schema.ts
@@ -178,6 +178,7 @@ export function getSchemas(): Record<string, (arg: { zod: typeof z }) => any> {
     svgr: ({ zod }) => zod.record(zod.string(), zod.any()),
     targets: ({ zod }) => zod.record(zod.string(), zod.any()),
     theme: ({ zod }) => zod.record(zod.string(), zod.any()),
+    transformRuntime: ({ zod }) => zod.record(zod.string(), zod.any()),
     writeToDisk: ({ zod }) => zod.boolean(),
   };
 }

--- a/packages/preset-umi/src/commands/dev/getBabelOpts.ts
+++ b/packages/preset-umi/src/commands/dev/getBabelOpts.ts
@@ -2,8 +2,15 @@ import { semver } from '@umijs/utils';
 import { IApi } from '../../types';
 
 export async function getBabelOpts(opts: { api: IApi }) {
+  console.log(
+    'opts.api.config.transformRuntime',
+    opts.api.config.transformRuntime,
+  );
   // TODO: 支持用户自定义
-  const shouldUseAutomaticRuntime = semver.gte(opts.api.appData.react.version, '17.0.0');
+  const shouldUseAutomaticRuntime = semver.gte(
+    opts.api.appData.react.version,
+    '17.0.0',
+  );
   const babelPresetOpts = await opts.api.applyPlugins({
     key: 'modifyBabelPresetOpts',
     initialValue: {
@@ -14,7 +21,7 @@ export async function getBabelOpts(opts: { api: IApi }) {
         ...(shouldUseAutomaticRuntime ? {} : { importSource: undefined }),
       },
       presetTypeScript: {},
-      pluginTransformRuntime: {},
+      pluginTransformRuntime: opts.api.config.transformRuntime || {},
       pluginLockCoreJS: {},
       pluginDynamicImportNode: false,
       pluginAutoCSSModules: opts.api.config.autoCSSModules,


### PR DESCRIPTION
Close https://github.com/umijs/umi/issues/12803

---

比如，如果你想用最新的 @babel/runtime 版本。可先配置如下：

```js
transformRuntime: {
  absoluteRuntime: process.cwd(),
}
```

再安装 @babel/runtime 到项目中：

```bash
$ npm install @babel/runtime --save-dev
```

---

本地测试效果。

<img width="1203" alt="image" src="https://github.com/user-attachments/assets/a4266efa-8c4d-45b4-bac9-2739185e3831" />
