### PR TITLE
fix: temporary fix for `node-spdy` error in Node.js >= v24

### DIFF
--- a/packages/bundler-utils/src/https.ts
+++ b/packages/bundler-utils/src/https.ts
@@ -3,8 +3,9 @@ import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { RequestListener } from 'http';
 import https from 'https';
 import { join } from 'path';
-import spdy from 'spdy';
 import { HttpsServerOptions } from './types';
+
+import type { createServer } from 'spdy';
 
 const defaultHttpsHosts: HttpsServerOptions['hosts'] = [
   'localhost',
@@ -102,9 +103,20 @@ export async function createHttpsServer(
   const { key, cert } = await resolveHttpsConfig(httpsConfig);
 
   // Create server
-  const createServer = (
-    httpsConfig.http2 === false ? https.createServer : spdy.createServer
-  ) as typeof spdy.createServer;
+  let createServer: typeof createServer;
+  if (httpsConfig.http2 === false) {
+    createServer = https.createServer;
+  } else {
+    try {
+      createServer = (await import('spdy')).createServer;
+    } catch (e) {
+      logger.error(
+        '[HTTPS] Error accrued when loading module spdy, maybe you should check your Node.js version, it requires Node.js < v24. See: https://github.com/spdy-http2/node-spdy/issues/397',
+      );
+      throw e;
+    }
+  }
+
   return createServer(
     {
       key: readFileSync(key, 'utf-8'),


### PR DESCRIPTION
When running the `max` script in a Node.js >= v24 environment it reports an error:

```
fatal - Error: Register plugin /project/node_modules/.pnpm/@umijs+preset-umi@4.4.11_@types+node@22.15.19_@types+react@18.3.21_lightningcss@1.22.1__9b20205c8c9c9f15081a9ea7104195c0/node_modules/@umijs/preset-umi/dist/features/esmi/esmi.js failed, since No such module: http_parser
    at Plugin.apply (/project/node_modules/.pnpm/@umijs+core@4.4.11/node_modules/@umijs/core/dist/service/plugin.js:76:15)
    at Service.initPlugin (/project/node_modules/.pnpm/@umijs+core@4.4.11/node_modules/@umijs/core/dist/service/service.js:463:33)
    at Service.run (/project/node_modules/.pnpm/@umijs+core@4.4.11/node_modules/@umijs/core/dist/service/service.js:259:18)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Service.run2 (/project/node_modules/.pnpm/umi@4.4.11_@babel+core@7.4.5_@types+node@22.15.19_@types+react@18.3.21_eslint@8.35.0_je_b3e3ee8efb31833b8e8afda8bbdef0b0/node_modules/umi/dist/service/service.js:65:12)
    at async run (/project/node_modules/.pnpm/umi@4.4.11_@babel+core@7.4.5_@types+node@22.15.19_@types+react@18.3.21_eslint@8.35.0_je_b3e3ee8efb31833b8e8afda8bbdef0b0/node_modules/umi/dist/cli/cli.js:56:7) {
  [cause]: Error: No such module: http_parser
      at process.binding (node:internal/bootstrap/realm:162:11)
      at Object.<anonymous> (/project/node_modules/.pnpm/http-deceiver@1.2.7/node_modules/http-deceiver/lib/deceiver.js:22:24)
      at Module._compile (node:internal/modules/cjs/loader:1734:14)
      at Object..js (node:internal/modules/cjs/loader:1899:10)
      at Module.load (node:internal/modules/cjs/loader:1469:32)
      at Module._load (node:internal/modules/cjs/loader:1286:12)
      at TracingChannel.traceSync (node:diagnostics_channel:322:14)
      at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
      at Module.require (node:internal/modules/cjs/loader:1491:12)
      at require (node:internal/modules/helpers:135:16)
}
fatal - A complete log of this run can be found in:
fatal - /project/node_modules/.cache/logger/umi.log
fatal - Consider reporting a GitHub issue on https://github.com/umijs/umi/issues
fatal - 如果你需要进交流群，请访问 https://fb.umijs.org 。
```

Inspection revealed that the error was coming from the `spdy` dependency package, whose internal dependency package `http-deceiver` used the deprecated method `process.binding`, which was completely removed in Node.js v24.

This change is intended to change the static import of the `spdy` dependency to a dynamic import on invocation, which may temporarily solve the problem of errors when running the `max` script. However, a better solution would be to remove the dependency on this package completely and use the `node:http2` module instead, which should be stable enough.

References:

- https://github.com/spdy-http2/node-spdy/issues/380
- https://github.com/spdy-http2/node-spdy/issues/397
- https://github.com/nodejs/TSC/issues/1482