### PR TITLE
fix(jest): ts error

### DIFF
--- a/packages/preset-umi/src/commands/generators/jest.ts
+++ b/packages/preset-umi/src/commands/generators/jest.ts
@@ -60,10 +60,7 @@ export default (api: IApi) => {
           }
         : basicDeps;
       h.addDevDeps(packageToInstall);
-      h.addScript(
-        'test',
-        'cross-env TS_NODE_TRANSPILE_ONLY=yes jest --passWithNoTests',
-      );
+      h.addScript('test', 'cross-env jest --passWithNoTests');
 
       const setupImports = res.willUseTLR
         ? [


### PR DESCRIPTION
fix jest error when using typescript 5
```
Error: Jest: Failed to parse the TypeScript config file jest.config.ts
  TSError: ⨯ Unable to compile TypeScript:
error TS5095: Option 'bundler' can only be used when 'module' is set to 'preserve' or to 'es2015' or later.
```