### PR TITLE
access插件开启方式文档错误

### DIFF
--- a/docs/docs/docs/max/access.en-US.md
+++ b/docs/docs/docs/max/access.en-US.md
@@ -13,8 +13,8 @@ Configuring activation. Requires `src/access.ts` to provide permission configura
 ```ts
 export default {
   access: {},
-  // access plugin depends on the initial State so it needs to be enabled at the same time
-  initialState: {},
+  // access plugin depends on the plugin-model so it needs to be enabled at the same time
+  model: {},
 };
 ```
 

--- a/docs/docs/docs/max/access.md
+++ b/docs/docs/docs/max/access.md
@@ -11,8 +11,8 @@ toc: content
 ```ts
 export default {
   access: {},
-  // access 插件依赖 initial State 所以需要同时开启
-  initialState: {},
+  // access 插件依赖 plugin-model 所以需要同时开启
+  model: {},
 };
 ```
 


### PR DESCRIPTION
在我尝试项目从umi3升级到4.4.11时，遇到的使用文档中的
initialState: {} -> max setup会报错
.umi/plugin-access/runtime.tsx 中依赖了@@/plugin-model