### PR TITLE
docs: 修复 routes.md 的文本错误

### DIFF
--- a/docs/docs/docs/guides/routes.md
+++ b/docs/docs/docs/guides/routes.md
@@ -428,7 +428,7 @@ export default function Page() {
 
 ## 路由组件参数
 
-Umi 4 使用 [react-router@6](https://reactrouter.com/en/main) 作为路由组件，路由参数的获取使其 hooks。
+Umi 4 使用 [react-router@6](https://reactrouter.com/en/main) 作为路由组件，路由参数的获取使用其 hooks。
 
 ### match 信息
 


### PR DESCRIPTION
修复“[路由组件参数](https://umijs.org/docs/guides/routes#%E8%B7%AF%E7%94%B1%E7%BB%84%E4%BB%B6%E5%8F%82%E6%95%B0)”小节下文本中“使用”一词丢失的“用”字
![20250814214952](https://github.com/user-attachments/assets/27a98054-ca6f-42f9-8eb8-0da13a6a804b)