### PR TITLE
fix(preset-umi): dev start error when using vite mode on windows

### DIFF
--- a/packages/preset-umi/src/utils/transformIEAR.ts
+++ b/packages/preset-umi/src/utils/transformIEAR.ts
@@ -70,7 +70,7 @@ export const IEAR_REG_EXP = new RegExp(
     // match quotes ($2)
     `('|")`,
     // match absolute file path ($3)
-    `((?:[a-zA-Z]:|\\/).*[^\\\\])\\2`,
+    `((?:[a-zA-Z]:|\\/).*[^\\\\])` + `\\2`,
     ')',
   ].join(''),
   // match full-content


### PR DESCRIPTION
修复windows系统umi dev启动时，未将.umi下文件的绝对路径转化成@fs开头的相对路径问题。

((?:[a-zA-Z]:|\\/).*[^\\\\])\\2 中的 \\2 被包含在第3个捕获组内部
这意味着第3个捕获组期望匹配：路径 + 结束引号
但实际上第3个捕获组应该只匹配路径，\\2 应该在外面匹配结束引号

复现文件可以参考[issue](https://github.com/umijs/umi/issues/13128#issue-3417470143)