### PR TITLE
feat(utoopack): support override utoopack config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,4 +4,3 @@ registry=https://registry.npmjs.org/
 # In the future, Vue 3 will fix this issue
 # See https://github.com/vuejs/core/blob/main/CHANGELOG.md#features-1
 auto-install-peers=false
-public-hoist-pattern[]=@utoo/pack

--- a/packages/bundler-utoopack/package.json
+++ b/packages/bundler-utoopack/package.json
@@ -22,11 +22,11 @@
     "express-http-proxy": "^2.1.1"
   },
   "devDependencies": {
-    "@utoo/pack": "^0.0.1-alpha.48",
+    "@utoo/pack": "^0.0.1-alpha.52",
     "father": "4.1.5"
   },
   "peerDependencies": {
-    "@utoo/pack": "^0.0.1-alpha.47"
+    "@utoo/pack": "^0.0.1-alpha.52"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/bundler-utoopack/src/config.ts
+++ b/packages/bundler-utoopack/src/config.ts
@@ -136,40 +136,39 @@ export async function getProdUtooPackConfig(
 
   utooBundlerOpts = {
     ...utooBundlerOpts,
-    config: {
-      ...utooBundlerOpts.config,
-      output: {
-        ...utooBundlerOpts.config.output,
-        clean: opts.clean,
-      },
-      optimization: {
-        ...utooBundlerOpts.config.optimization,
-        modularizeImports,
-        concatenateModules: true,
-        // minify: false,
-        // moduleIds: 'named',
-      },
-      resolve: {
-        ...utooBundlerOpts.config.resolve,
-        alias: getNormalizedAlias(
-          utooBundlerOpts.config.resolve?.alias as Record<string, string>,
-          opts.rootDir,
-        ),
-      },
-      styles: {
-        less: {
-          modifyVars: opts.config.theme,
-          javascriptEnabled: true,
-          ...opts.config.lessLoader,
+    config: lodash.merge(
+      utooBundlerOpts.config,
+      {
+        output: {
+          clean: opts.clean,
         },
-        sass: opts.config.sassLoader ?? undefined,
+        optimization: {
+          modularizeImports,
+          concatenateModules: true,
+          // minify: false,
+          // moduleIds: 'named',
+        },
+        resolve: {
+          alias: getNormalizedAlias(
+            utooBundlerOpts.config.resolve?.alias as Record<string, string>,
+            opts.rootDir,
+          ),
+        },
+        styles: {
+          less: {
+            modifyVars: opts.config.theme,
+            javascriptEnabled: true,
+            ...opts.config.lessLoader,
+          },
+          sass: opts.config.sassLoader ?? undefined,
+        },
+        // Override process.env for utoopack format
+        define: {
+          'process.env': JSON.stringify(processEnvForUtoopack),
+        },
       },
-      // Override process.env for utoopack format
-      define: {
-        ...utooBundlerOpts.config.define,
-        'process.env': JSON.stringify(processEnvForUtoopack),
-      },
-    },
+      opts.config.utoopack || {},
+    ),
   } as BundleOptions;
 
   return utooBundlerOpts;
@@ -248,38 +247,37 @@ export async function getDevUtooPackConfig(
 
   utooBundlerOpts = {
     ...utooBundlerOpts,
-    config: {
-      ...utooBundlerOpts.config,
-      output: {
-        ...utooBundlerOpts.config.output,
-        // utoopack 的 dev 需要默认清空产物目录
-        clean: opts.clean === undefined ? true : opts.clean,
-      },
-      resolve: {
-        ...utooBundlerOpts.config.resolve,
-        alias: getNormalizedAlias(
-          utooBundlerOpts.config.resolve?.alias as Record<string, string>,
-          opts.rootDir,
-        ),
-      },
-      optimization: {
-        ...utooBundlerOpts.config.optimization,
-        modularizeImports,
-      },
-      styles: {
-        less: {
-          modifyVars: opts.config.theme,
-          javascriptEnabled: true,
-          ...opts.config.lessLoader,
+    config: lodash.merge(
+      utooBundlerOpts.config,
+      {
+        output: {
+          // utoopack 的 dev 需要默认清空产物目录
+          clean: opts.clean === undefined ? true : opts.clean,
         },
-        sass: opts.config.sassLoader ?? undefined,
+        resolve: {
+          alias: getNormalizedAlias(
+            utooBundlerOpts.config.resolve?.alias as Record<string, string>,
+            opts.rootDir,
+          ),
+        },
+        optimization: {
+          modularizeImports,
+        },
+        styles: {
+          less: {
+            modifyVars: opts.config.theme,
+            javascriptEnabled: true,
+            ...opts.config.lessLoader,
+          },
+          sass: opts.config.sassLoader ?? undefined,
+        },
+        // Override process.env for utoopack format
+        define: {
+          'process.env': JSON.stringify(processEnvForUtoopack),
+        },
       },
-      // Override process.env for utoopack format
-      define: {
-        ...utooBundlerOpts.config.define,
-        'process.env': JSON.stringify(processEnvForUtoopack),
-      },
-    },
+      opts.config.utoopack || {},
+    ),
     watch: {
       enable: true,
     },

--- a/packages/bundler-utoopack/src/index.ts
+++ b/packages/bundler-utoopack/src/index.ts
@@ -13,7 +13,6 @@ import {
 import type { IOpts } from './types';
 
 export async function build(opts: IOpts) {
-  // @ts-ignore
   const { cwd, onBuildComplete } = opts;
   const { build: utooPackBuild, findRootDir } = require('@utoo/pack');
   const rootDir = findRootDir(cwd);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1934,8 +1934,8 @@ importers:
         version: 2.1.1
     devDependencies:
       '@utoo/pack':
-        specifier: ^0.0.1-alpha.48
-        version: 0.0.1-alpha.48
+        specifier: ^0.0.1-alpha.52
+        version: 0.0.1-alpha.53
       father:
         specifier: 4.1.5
         version: 4.1.5(@types/node@18.19.39)
@@ -19774,8 +19774,8 @@ packages:
       react: 18.3.1
     dev: false
 
-  /@utoo/pack-darwin-arm64@0.0.1-alpha.48:
-    resolution: {integrity: sha512-58rFKao0dfBNPwDRsW6TcHZrDNCYV6XzMAKv08YwpnE5Vxh1Nu9rrI2ggh0TRX+59ntPERfpBzBFOg00PkxX8g==}
+  /@utoo/pack-darwin-arm64@0.0.1-alpha.53:
+    resolution: {integrity: sha512-Ypx/l9DW7cO4lChnvKLZCLCdrrzu7gQsL2qPm/zkFey1P6M8XRjxByTsaZrfjugeUDg21g0W/UZ0ti4h/skguw==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
@@ -19783,8 +19783,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-darwin-x64@0.0.1-alpha.48:
-    resolution: {integrity: sha512-AxECr0G2O/EWWnxo0SHK0xllwEazmiifbERNX/s9mIEctfS2CrQi2Uof/YrI3WC3A+/p+pUAW1uxMb1fC8C0ng==}
+  /@utoo/pack-darwin-x64@0.0.1-alpha.53:
+    resolution: {integrity: sha512-m1pS99yvARJYwn3qSkU77ViURIyCZ8H+nLwQZfC3fj3maZGqXbi1311wKtSTvyaCHlpyOhhaPDf0EW63sHVtfg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
@@ -19792,8 +19792,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-linux-arm64-gnu@0.0.1-alpha.48:
-    resolution: {integrity: sha512-j2Eb7Gi7rNx8+LENcrieMXiMpi1BuYlFwGmYIflcVUCOlTzy3Z0KnxvJQUBaTUe54lWPlW5uGc0O6sl7Piqmmg==}
+  /@utoo/pack-linux-arm64-gnu@0.0.1-alpha.53:
+    resolution: {integrity: sha512-B1/BUAj+Ty9YGz8V3UeTa8kA0cszNqDeKCbMWTuhxQtliIGNBQHMeLUOG+7vUIgRhkeRoJPZdRLbA5YiSse14A==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -19801,8 +19801,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-linux-arm64-musl@0.0.1-alpha.48:
-    resolution: {integrity: sha512-RNJJKVwdSw9sdWMb9QLYlxQF4VPUgcCB4EU2urZuYBUJP6hyu192CDO2/IKSvdGiIvfysxpy4xEP5VW/QGKRZA==}
+  /@utoo/pack-linux-arm64-musl@0.0.1-alpha.53:
+    resolution: {integrity: sha512-QFjW703jGZtGDJLiq6Curs+Dx7fb+noGUUwmWNsuHH3fGVoaFVTv43ZzXMMS4nbVJ6ER1MuhVPH3ye2Rpp8rzQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -19810,8 +19810,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-linux-x64-gnu@0.0.1-alpha.48:
-    resolution: {integrity: sha512-NmPPq4DdFuuHGLhmTurU42fF+DcAwiJOSAa9+kiPyej92y6ZP+jWjxAXz6zEOPZV6qdP+5IFOdXPpfkscAcm/w==}
+  /@utoo/pack-linux-x64-gnu@0.0.1-alpha.53:
+    resolution: {integrity: sha512-xycqEZXKV7De89WdtSnLn8CYMbPGsX4itPn79rDKDdusckQvt13yCB5u5xeoBforvgMfMD6m6D7jXEcJwXC3kw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -19819,8 +19819,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-linux-x64-musl@0.0.1-alpha.48:
-    resolution: {integrity: sha512-vxzq/J8dAUD/1JpbWU9Dax+/E/vGhvCngkPL+P5odX4UH0mF0P0t7Z7izMrhvg0fTOSQQRYhsbo9VgVsqLweIA==}
+  /@utoo/pack-linux-x64-musl@0.0.1-alpha.53:
+    resolution: {integrity: sha512-iAH60h+DoNwt5lp3k+4jpJOWiYafBNakBFEpTPPm/8lB6A8gzjuHpOeA7IJqEyoHAdo993qJmRTWQPgBfq5edQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -19828,8 +19828,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-win32-x64-msvc@0.0.1-alpha.48:
-    resolution: {integrity: sha512-aj6uBVGBX/bbnuXpFomOVVQFxQXR3TEf4ZQLd8s2VbFAjhtJ3Inzd5+eoT1IUd3kH/f14CgQ6CSuVhzjrVsoMg==}
+  /@utoo/pack-win32-x64-msvc@0.0.1-alpha.53:
+    resolution: {integrity: sha512-hjnLumaiVTFRP9caEKkkqmjqNczVdfR3m2VMrjkee97yXBWU9SqsbeAJUjiUhKaHkiE9hZvXhvuBkmhaJ1KE6w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
@@ -19837,8 +19837,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack@0.0.1-alpha.48:
-    resolution: {integrity: sha512-REaBP+OE/US7xZcK4nd4hnV6kFk7aA73X0yWAK1vcnAHG+rRRiiLm3XcXXY8vi6SvUOFwWcEAU9NJPVEBRFrww==}
+  /@utoo/pack@0.0.1-alpha.53:
+    resolution: {integrity: sha512-tg1yCF1o6oZvfYcKy4MtLxn1FgCbhfiqS+IohriPFKy2pZ9TYLA6Gk5kHrU4XZkTtPvp+TQ8BFZMbZwLvUyk3w==}
     engines: {node: '>= 20'}
     peerDependencies:
       '@types/webpack': ^5.28.5
@@ -19860,13 +19860,13 @@ packages:
       send: 0.17.1
       ws: 8.18.3
     optionalDependencies:
-      '@utoo/pack-darwin-arm64': 0.0.1-alpha.48
-      '@utoo/pack-darwin-x64': 0.0.1-alpha.48
-      '@utoo/pack-linux-arm64-gnu': 0.0.1-alpha.48
-      '@utoo/pack-linux-arm64-musl': 0.0.1-alpha.48
-      '@utoo/pack-linux-x64-gnu': 0.0.1-alpha.48
-      '@utoo/pack-linux-x64-musl': 0.0.1-alpha.48
-      '@utoo/pack-win32-x64-msvc': 0.0.1-alpha.48
+      '@utoo/pack-darwin-arm64': 0.0.1-alpha.53
+      '@utoo/pack-darwin-x64': 0.0.1-alpha.53
+      '@utoo/pack-linux-arm64-gnu': 0.0.1-alpha.53
+      '@utoo/pack-linux-arm64-musl': 0.0.1-alpha.53
+      '@utoo/pack-linux-x64-gnu': 0.0.1-alpha.53
+      '@utoo/pack-linux-x64-musl': 0.0.1-alpha.53
+      '@utoo/pack-win32-x64-msvc': 0.0.1-alpha.53
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil


### PR DESCRIPTION
主要是支持通过用户传递的 `utoopack: {}` config 去自定义修改 utoopack 本身的 bundler 配置，例如通过如下配置关闭 `utoopack` 默认的 scopehoisting:

```ts
export default {
  routes: [{ path: '/', component: 'index' }],
  npmClient: 'pnpm',
  utoopack: {
     optimization: {
        concatenateModules: false,
     }
  }
};
```

升级了一下 `devDependencies` 里面的 `@utoo/pack` 版本，后续集成在框架里的 `@utoo/pack` 在 pnpm 包管理工具中使用就不用 hoist 配置了