### PR TITLE
Allow viewport scaling by default

### DIFF
--- a/examples/boilerplate/.umirc.ts
+++ b/examples/boilerplate/.umirc.ts
@@ -90,7 +90,7 @@ export default defineConfig({
   metas: [
     {
       name: 'viewport',
-      content: `width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no`,
+      content: `width=device-width,initial-scale=1,minimum-scale=1`,
     },
     {
       'http-equiv': 'X-UA-Compatible',

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -107,7 +107,7 @@ export async function getMarkup(
       !hasAttr('name', 'viewport') && {
         name: 'viewport',
         content:
-          'width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0',
+          'width=device-width, initial-scale=1.0, minimum-scale=1.0',
       },
       !hasAttr('http-equiv', 'X-UA-Compatible') && {
         'http-equiv': 'X-UA-Compatible',


### PR DESCRIPTION
Restricting viewport scalability is inaccessible and does not meet the [Web Content Accessibility  Guidelines (WCAG) guidelines](https://www.w3.org/TR/WCAG21/).

An example of where this affects users is when users are looking at a site on their phone. If the site has large, complex graphics, these cannot be read without zooming in. An example of this is the [nocobase docs](https://docs.nocobase.com/handbook/theme-editor)

This PR removes the [`user-scaleable`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name/viewport#user-scalable) and [`maximum-scale`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name/viewport#maximum-scale) keywords to allow users to zoom in without changing the initial rendering of the site.

See:
- https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/meta/name/viewport#user-scalable
- https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-scale.html