### PR TITLE
fix: unexpected server create error when enable https.http2

### DIFF
--- a/packages/bundler-utils/src/https.ts
+++ b/packages/bundler-utils/src/https.ts
@@ -108,7 +108,7 @@ export async function createHttpsServer(
     createServer = https.createServer;
   } else {
     try {
-      createServer = (await import('spdy')).createServer;
+      createServer = (await import('spdy')).default.createServer;
     } catch (e) {
       logger.error(
         '[HTTPS] Error accrued when loading module spdy, maybe you should check your Node.js version, it requires Node.js < v24. See: https://github.com/spdy-http2/node-spdy/issues/397',


### PR DESCRIPTION
spdy 的实际导出与 TypeScript 类型定义不符，必须从 `default` 引入否则会获取到 `undefined` 导致报错，进行修复

ref: #13041