### PR TITLE
fix: escape question mark in file extension regex to prevent incorrect replacements

### DIFF
--- a/packages/preset-umi/src/libs/folderCache/LazySourceCodeCache.ts
+++ b/packages/preset-umi/src/libs/folderCache/LazySourceCodeCache.ts
@@ -188,7 +188,8 @@ export class LazySourceCodeCache {
     for (const f of files) {
       let newFile = join(this.cachePath, relative(this.srcPath, f));
 
-      newFile = newFile.replace(new RegExp(`${extname(newFile)}$`), '.js');
+      const extRegexStr = extname(newFile).replace(/[.?]/g, '\\$&');
+      newFile = newFile.replace(new RegExp(`${extRegexStr}$`), '.js');
 
       loaded[f] = readFileSync(newFile, 'utf-8');
     }


### PR DESCRIPTION
对于 vite bundler 构建时，会使用 `?url` 的方式导入文件 url，例如如下场景

```ts
import { createFromIconfontCN } from '@ant-design/icons';
import iconfontUrl from './font_5036736_flr7joicve?url';

export const Iconfont = createFromIconfontCN({
  scriptUrl: iconfontUrl,
});
```

https://github.com/umijs/umi/blob/5b6b16d36dd4e1e8a9654a958d17d05a1f29301b/packages/preset-umi/src/libs/folderCache/LazySourceCodeCache.ts#L188-L194

此时 189 行 `newFile` 的值会为 `path/to/font_5036736_flr7joicve?url`，由于 `?` 在正则表达式中存在特殊含义，191 行中通过 `extname` 方法返回值构建的正则表达式为 `/.js?url/` 并不能正确替换为 `.js`，正确的正则表达式应该为 `/\.js\?url/`