### PR TITLE
feat(utoopack): babelPluginImport support camel2DashComponentName options

### DIFF
--- a/packages/bundler-utoopack/src/config.ts
+++ b/packages/bundler-utoopack/src/config.ts
@@ -44,7 +44,13 @@ function getModularizeImports(extraBabelPlugins: any[]) {
     .filter((p) => /^import$|babel-plugin-import/.test(p[0]))
     .reduce(
       (acc, [_, v]) => {
-        const { libraryName, libraryDirectory, style, ...rest } = v;
+        const {
+          libraryName,
+          libraryDirectory,
+          style,
+          camel2DashComponentName,
+          ...rest
+        } = v;
 
         if (Object.keys(rest).length > 0) {
           throw new Error(
@@ -60,8 +66,13 @@ function getModularizeImports(extraBabelPlugins: any[]) {
           );
         }
 
+        let transformRule = '{{ kebabCase member }}';
+        if (camel2DashComponentName === false) {
+          transformRule = '{{ member }}';
+        }
+
         acc[libraryName as string] = {
-          transform: `${libraryName}/${libraryDirectory}/{{ kebabCase member }}`,
+          transform: `${libraryName}/${libraryDirectory}/${transformRule}`,
           preventFullImport: false,
           skipDefaultConversion: false,
           style: typeof style === 'boolean' ? 'style' : style,


### PR DESCRIPTION
utoopack 修复如下 case:

<img width="3082" height="1448" alt="image" src="https://github.com/user-attachments/assets/fe88ad69-7b8c-44d3-8fdb-7a49bcd69762" />

测试 case 参考: https://github.com/utooland/utoo/pull/2306