### PR TITLE
fix: Slovenia  🇸🇮  flag in locale

### DIFF
--- a/packages/plugins/templates/locale/SelectLang.tpl
+++ b/packages/plugins/templates/locale/SelectLang.tpl
@@ -333,7 +333,7 @@ const defaultLangUConfigMap = {
   'sl-SI': {
     lang: 'sl-SI',
     label: 'Slovenščina',
-    icon: '🇸🇱',
+    icon: '🇸🇮',
     title: 'Jezik'
   },
   'sv-SE': {
@@ -460,7 +460,7 @@ export const SelectLang: React.FC<SelectLangProps> = (props) => {
   } else { // 需要 antd 4.20.0 以上版本
     dropdownProps = { overlay: <Menu {...langMenu} /> };
   }
-  
+
   const inlineStyle = {
     cursor: "pointer",
     padding: "12px",


### PR DESCRIPTION
Surprisingly, the flag set for `sl-SI` locale which is for Slovenia, was for Sierra Leone. So I just changed the flag emoji.