### PR TITLE
fix(utoopack): compitable with webpack alias

### DIFF
--- a/packages/bundler-utoopack/src/config.ts
+++ b/packages/bundler-utoopack/src/config.ts
@@ -106,6 +106,8 @@ function getNormalizedAlias(
   const newAlias = { ...alias };
 
   // Add wildcard aliases for all aliases that point to directories (not files)
+  // refer to: https://github.com/utooland/utoo/issues/2288
+  // webpack alias: https://webpack.js.org/configuration/resolve/#resolvealias
   for (const [key, value] of Object.entries(newAlias)) {
     // Skip if already has wildcard
     if (


### PR DESCRIPTION
utoopack 的 alias 完全匹配对应完全匹配，wildcard alias 对应文件匹配，参考 issue: https://github.com/utooland/utoo/issues/2288

这里在框架层适配一下 alias。