### PR TITLE
fix(utoopack): devServer connect error

### DIFF
--- a/packages/bundler-utoopack/src/index.ts
+++ b/packages/bundler-utoopack/src/index.ts
@@ -185,7 +185,7 @@ export async function dev(opts: IDevOpts) {
       );
       stats = JSON.parse(fs.readFileSync(statsPath, 'utf-8'));
     } catch (e) {
-      throw new Error('Stats.json not found by utoopack dev');
+      throw new Error('File stats.json not found by utoopack dev');
     }
 
     stats.hasErrors = () => false;
@@ -205,7 +205,6 @@ export async function dev(opts: IDevOpts) {
   try {
     await utooPackServe(utooPackConfig, cwd, rootDir, {
       port: utooServePort,
-      hostname: opts.host,
     });
 
     const stats = createStatsObject();


### PR DESCRIPTION
utoopack server 的 hostname 在 umi 框架下不用调整，因为代理的 hostname 永远都是 localhost: https://github.com/umijs/umi/blob/master/packages/bundler-utoopack/src/index.ts#L104

这里的逻辑和 mako 之前的保持一致，先不做调整了: https://github.com/utooland/utoo/blob/master/packages/bundler-mako/index.js#L109