### PR TITLE
fix(utoopack): devServer hostname compitable with ipv6

### DIFF
--- a/packages/bundler-utoopack/src/index.ts
+++ b/packages/bundler-utoopack/src/index.ts
@@ -205,6 +205,7 @@ export async function dev(opts: IDevOpts) {
   try {
     await utooPackServe(utooPackConfig, cwd, rootDir, {
       port: utooServePort,
+      hostname: '127.0.0.1',
     });
 
     const stats = createStatsObject();


### PR DESCRIPTION
PR: https://github.com/umijs/umi/pull/13198 处理的不严谨。

如果不给 utoopack serve 传 hostname, utoopack 默认的 serve hostname 是 `localhost`: https://github.com/utooland/utoo/blob/next/packages/pack/src/dev.ts#L61

实际上这里代理的 utoopack serve 固定 hostname 是 127.0.0.1(跟 mako 保持一致)，`localhost` 在 ipv6 的情况下会代理不到 `127.0.0.1` 这个地址。

所以这里直接把 hostname 固定掉，mako 的 devServer config host name 默认值是 127.0.0.1(https://github.com/umijs/mako/blob/master/crates/mako/src/dev.rs#L64)