### PR TITLE
fix(utoopack): version upgrade & bug fix

### DIFF
--- a/packages/bundler-utoopack/package.json
+++ b/packages/bundler-utoopack/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@umijs/bundler-utils": "workspace:*",
     "@umijs/bundler-webpack": "workspace:*",
-    "@utoo/pack": "1.0.4",
+    "@utoo/pack": "1.0.5",
     "compression": "^1.7.4",
     "connect-history-api-fallback": "^2.0.0",
     "cors": "^2.8.5",

--- a/packages/bundler-utoopack/src/config.ts
+++ b/packages/bundler-utoopack/src/config.ts
@@ -6,40 +6,6 @@ import { compatOptionsFromWebpack } from '@utoo/pack';
 import { extname } from 'path';
 import type { IOpts } from './types';
 
-/**
- * Convert webpack DefinePlugin's process.env format to utoopack format
- * Webpack format: { 'process.env': { NODE_ENV: '"development"', API_URL: '"https://api.example.com"' } }
- * Utoopack format: { 'process.env': '{"NODE_ENV":"development","API_URL":"https://api.example.com"}' }
- */
-function convertProcessEnvForUtoopack(webpackConfig: any): Record<string, any> {
-  let processEnvForUtoopack: Record<string, any> = {};
-
-  if (webpackConfig.plugins) {
-    const definePlugin = webpackConfig.plugins.find(
-      (plugin: any) => plugin.constructor.name === 'DefinePlugin',
-    ) as any;
-
-    if (definePlugin?.definitions?.['process.env']) {
-      // Convert webpack's individual stringified env values back to objects
-      for (const [key, value] of Object.entries(
-        definePlugin.definitions['process.env'],
-      )) {
-        if (
-          typeof value === 'string' &&
-          value.startsWith('"') &&
-          value.endsWith('"')
-        ) {
-          processEnvForUtoopack[key] = JSON.parse(value);
-        } else {
-          processEnvForUtoopack[key] = value;
-        }
-      }
-    }
-  }
-
-  return processEnvForUtoopack;
-}
-
 function getModularizeImports(extraBabelPlugins: any[]) {
   return extraBabelPlugins
     .filter((p) => /^import$|babel-plugin-import/.test(p[0]))
@@ -194,8 +160,6 @@ export async function getProdUtooPackConfig(
 
   const modularizeImports = getModularizeImports(extraBabelPlugins);
 
-  // Convert webpack's process.env format to utoopack format
-  const processEnvForUtoopack = convertProcessEnvForUtoopack(webpackConfig);
   const {
     publicPath,
     runtimePublicPath,
@@ -232,10 +196,6 @@ export async function getProdUtooPackConfig(
             ...opts.config.lessLoader,
           },
           sass: opts.config.sassLoader ?? undefined,
-        },
-        // Override process.env for utoopack format
-        define: {
-          'process.env': JSON.stringify(processEnvForUtoopack),
         },
         nodePolyfill: true,
         externals: getNormalizedExternals(userExternals),
@@ -314,8 +274,6 @@ export async function getDevUtooPackConfig(
 
   const modularizeImports = getModularizeImports(extraBabelPlugins);
 
-  // Convert webpack's process.env format to utoopack format
-  const processEnvForUtoopack = convertProcessEnvForUtoopack(webpackConfig);
   const {
     publicPath,
     runtimePublicPath,
@@ -352,10 +310,6 @@ export async function getDevUtooPackConfig(
             ...opts.config.lessLoader,
           },
           sass: opts.config.sassLoader ?? undefined,
-        },
-        // Override process.env for utoopack format
-        define: {
-          'process.env': JSON.stringify(processEnvForUtoopack),
         },
         nodePolyfill: true,
         externals: getNormalizedExternals(userExternals),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1945,8 +1945,8 @@ importers:
         specifier: workspace:*
         version: link:../bundler-webpack
       '@utoo/pack':
-        specifier: 1.0.4
-        version: 1.0.4
+        specifier: 1.0.5
+        version: 1.0.5
       compression:
         specifier: ^1.7.4
         version: 1.7.4
@@ -20646,8 +20646,8 @@ packages:
       react: 18.3.1
     dev: false
 
-  /@utoo/pack-darwin-arm64@1.0.4:
-    resolution: {integrity: sha512-/KTqYXaHvz5QfGpzhWXh/NjXTzyHs0SuiYDXfnXTAxNNhB6ZTuKGcWfLlG6YL81ZAmQWBB9WF5FhRqa3RFHgWg==}
+  /@utoo/pack-darwin-arm64@1.0.5:
+    resolution: {integrity: sha512-aH9pREVvBYUc9uZl3lxkxWm6SKNSMCcO44N6H4JAfjzlMritmc3w8gUpNuSW+RpLUr0RrYAYOzD4lvpVkQAbRA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
@@ -20655,8 +20655,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-darwin-x64@1.0.4:
-    resolution: {integrity: sha512-WlWo8nG62AiiwSwSaHMqWCLl7zl6XnqE0pXxDkpLl4wwHptHCqLWJCw4dhQCFHQkoFqXzp1PdTaUL4/7/hv/Vw==}
+  /@utoo/pack-darwin-x64@1.0.5:
+    resolution: {integrity: sha512-/Q7Hiv6r6NTdBiUbQByItc9I/wxXeYtTHMY6zJqXF9+MPZ6AmZP+a45LiLdUJOiiMKz4YORyAif4UouvSvDENQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
@@ -20664,8 +20664,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-linux-arm64-gnu@1.0.4:
-    resolution: {integrity: sha512-8dvb0yyLOpfafu6ONm3cA6IrhJJx1RNLVSNBgVbZaIKPoo4cqiDxGu2CTUJ4GJz1ceZ2BwJrDA7o9tlD58LhOw==}
+  /@utoo/pack-linux-arm64-gnu@1.0.5:
+    resolution: {integrity: sha512-IgoQAt9zAHW2rath6dWQHrL9z2Ni86cmc631Qk6JAUjHyJwW9LM3wHJ2UTPWhtRm1NitAWtJQSEx/uVEdIdvoA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -20673,8 +20673,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-linux-arm64-musl@1.0.4:
-    resolution: {integrity: sha512-uh2Egzyzb+K3BujxcmoQHxD8R0IUsAnNqDZORu5BYEMNVrAxg7vtmdnftS/uFeEGP96pDfLHB2XrZ9UXzxovgg==}
+  /@utoo/pack-linux-arm64-musl@1.0.5:
+    resolution: {integrity: sha512-TL/jp0IOa+X9Lo2fn+T2BcBX87HliRiNS3lzsuE5E0+wTvUUV3epv1zx2KD2N/O9VwrF1Itk4Mrq1bCKH3I9AQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -20682,8 +20682,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-linux-x64-gnu@1.0.4:
-    resolution: {integrity: sha512-7DS6UTysGpB5q7sLhT5Nmpqo/foP2VFt6Pn/5AoKUg7HFUppC3nl9iui3rjbhpcBIxfp5a1KbhcblUlsMN/bLg==}
+  /@utoo/pack-linux-x64-gnu@1.0.5:
+    resolution: {integrity: sha512-1mZwkftoRblW64F6wB2LHavTsiUmZojBCoFaaq6ZtWUyMq00h1PMcJsDwVkR0tcg00RiNz0HbHymNu0JsAc7zA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -20691,8 +20691,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-linux-x64-musl@1.0.4:
-    resolution: {integrity: sha512-GbdTMgmk1RnFW2dyQPfmna0Szg6Jbe++KIBY3mFPfp0u+RX24fyelgiEb9f/xj54M6kupHetHpcZeUUXkPAp0A==}
+  /@utoo/pack-linux-x64-musl@1.0.5:
+    resolution: {integrity: sha512-bnEykxUOUvvqvynjKv5tRpzI9aNQXPe13bvpEb7yh/YaN9xBYhbaNlvk3830xQy3ok5B456L3PVMCN5r+v958w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -20708,8 +20708,8 @@ packages:
       picocolors: 1.1.1
     dev: false
 
-  /@utoo/pack-win32-x64-msvc@1.0.4:
-    resolution: {integrity: sha512-ImhYZZuphS9aY6EyfTvSAIDmmveoEmwlI03czTEP8G8pfT+/ryuMNCB49PgpPU9nBqHxc6DDqjLRudUCxM7B/w==}
+  /@utoo/pack-win32-x64-msvc@1.0.5:
+    resolution: {integrity: sha512-pZxMA+B9oEsBpcAAL7oQVTE5sb2Iq8/hHltxAwSrw+Dw0O+uzlp0QjWZK9O96a0GWXBaCKxH0RnLxpYKwCPstA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
@@ -20717,8 +20717,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack@1.0.4:
-    resolution: {integrity: sha512-c/nvAHe4K8cHt6JezVpv1zV+HTXhNdFqWM9lDt7R+aXX/5gjptvyKqzVjXxdJINxpFM9mWG8NMEh1hVZkQNloA==}
+  /@utoo/pack@1.0.5:
+    resolution: {integrity: sha512-kducOvMF2ievnPjaAFgvdt6/6N1HetQXjkXx1N4/QZh8Nk2W9tWZD/av1J8uNACpbmiLWoCRaIffMEnAnbh8sg==}
     engines: {node: '>= 20'}
     peerDependencies:
       '@types/webpack': ^5.28.5
@@ -20740,13 +20740,13 @@ packages:
       send: 0.17.1
       ws: 8.18.3
     optionalDependencies:
-      '@utoo/pack-darwin-arm64': 1.0.4
-      '@utoo/pack-darwin-x64': 1.0.4
-      '@utoo/pack-linux-arm64-gnu': 1.0.4
-      '@utoo/pack-linux-arm64-musl': 1.0.4
-      '@utoo/pack-linux-x64-gnu': 1.0.4
-      '@utoo/pack-linux-x64-musl': 1.0.4
-      '@utoo/pack-win32-x64-msvc': 1.0.4
+      '@utoo/pack-darwin-arm64': 1.0.5
+      '@utoo/pack-darwin-x64': 1.0.5
+      '@utoo/pack-linux-arm64-gnu': 1.0.5
+      '@utoo/pack-linux-arm64-musl': 1.0.5
+      '@utoo/pack-linux-x64-gnu': 1.0.5
+      '@utoo/pack-linux-x64-musl': 1.0.5
+      '@utoo/pack-win32-x64-msvc': 1.0.5
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil


### PR DESCRIPTION
- 升级 `@utoo/pack` 到 v1.0.5: https://github.com/utooland/utoo/releases/tag/utoopack-v1.0.5
- 适配传入的 define 配置
- 修复 copy 目录不存在构建直接 panic 的问题
- 修复 `require('*.css')` 导入 css 模块时运行时找不到 module 的问题