### PR TITLE
fix(utoopack): avoid to collect all js assets under dev

### DIFF
--- a/packages/preset-umi/src/features/utoopack/utoopack.ts
+++ b/packages/preset-umi/src/features/utoopack/utoopack.ts
@@ -85,20 +85,6 @@ export default (api: IApi) => {
       }
       assets[ext].push(...files);
     });
-
-    // add globalThis.TURBOPACK_CHUNK_LISTS to enable hmr
-    const allAssets = (stats.assets || []).map((asset) => asset.name);
-    for (const asset of allAssets) {
-      if (
-        asset.endsWith('.js') &&
-        !assets.js.includes(asset) &&
-        !asset.includes('umi.js')
-      ) {
-        assets.js.push(asset);
-      } else if (asset.endsWith('.css') && !assets.css.includes(asset)) {
-        assets.css.push(asset);
-      }
-    }
   });
 
   api.onBuildComplete(({ stats }: { stats: webpack.StatsCompilation }) => {


### PR DESCRIPTION
utoopack 会在 stats.json 的 entry 中添加对应的 DevChunk，不需要手动添加了(会误添加一些额外的 js asset 导致 dev 运行时执行报错)

utoopack pr: https://github.com/utooland/utoo/pull/2422