### PR TITLE
docs: 修复Umi Max文档中数据流部分userModel相关代码示例的导入缺失

### DIFF
--- a/docs/docs/docs/max/data-flow.en-US.md
+++ b/docs/docs/docs/max/data-flow.en-US.md
@@ -92,7 +92,7 @@ In real-world projects, we usually need to request backend interfaces to obtain 
 
 ```ts
 // src/models/userModel.ts
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { getUser } from '@/services/user';
 
 export default function Page() {

--- a/docs/docs/docs/max/data-flow.md
+++ b/docs/docs/docs/max/data-flow.md
@@ -91,7 +91,7 @@ export default function Page() {
 
 ```ts
 // src/models/userModel.ts
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { getUser } from '@/services/user';
 
 export default function Page() {


### PR DESCRIPTION
修复[数据流文档](https://umijs.org/docs/max/data-flow)中userModel代码示例缺少了useEffect的导入的问题

<img width="874" height="561" alt="image" src="https://github.com/user-attachments/assets/8d437580-368c-47a4-a38d-69aae6468b63" />

<img width="837" height="570" alt="image" src="https://github.com/user-attachments/assets/d6a2dd98-cc17-4185-a1de-571c7ea94d82" />
