### PR TITLE
chore: bump @utoo/pack to v1.1.14

### DIFF
--- a/examples/with-antd-5/.umirc.ts
+++ b/examples/with-antd-5/.umirc.ts
@@ -4,7 +4,6 @@ export default {
     title: true,
     default: 'zh-CN',
   },
-  publicPath: '{{__RENDER_STATIC_URL_PREFIX__}}/',
   utoopack: {},
   antd: {
     // valid for antd5.0 only

--- a/packages/bundler-utoopack/package.json
+++ b/packages/bundler-utoopack/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@umijs/bundler-utils": "workspace:*",
     "@umijs/bundler-webpack": "workspace:*",
-    "@utoo/pack": "1.1.13",
+    "@utoo/pack": "1.1.14",
     "compression": "^1.7.4",
     "connect-history-api-fallback": "^2.0.0",
     "cors": "^2.8.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1945,8 +1945,8 @@ importers:
         specifier: workspace:*
         version: link:../bundler-webpack
       '@utoo/pack':
-        specifier: 1.1.13
-        version: 1.1.13
+        specifier: 1.1.14
+        version: 1.1.14
       compression:
         specifier: ^1.7.4
         version: 1.7.4
@@ -20646,8 +20646,8 @@ packages:
       react: 18.3.1
     dev: false
 
-  /@utoo/pack-darwin-arm64@1.1.13:
-    resolution: {integrity: sha512-zKF2XCYN5yJHeaFSU+CLrPCK7PJfqy6SBcIb+/1bGILKtZTLpBV/Lellp8Ce4nUgy40cKnBfzqBQX3UFbDDGwg==}
+  /@utoo/pack-darwin-arm64@1.1.14:
+    resolution: {integrity: sha512-sL5OeskD3AAC8xNsn2aMq2oX03iPh6fv12Z9lt24wZk60jAVV79UH7gmOvZP0eY9xcvU4kE0DIu0K7nHZr/sqg==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
@@ -20655,8 +20655,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-darwin-x64@1.1.13:
-    resolution: {integrity: sha512-/xY2njQiFdAD8b9GrPSVSD5xWUPnnHCYb18WUcrZE7QjAl/Ef1A/wOhqrF8UmPVFAbdaqVJUMoZpyIJ0L3l9Jg==}
+  /@utoo/pack-darwin-x64@1.1.14:
+    resolution: {integrity: sha512-Wgw9k5fBPTDfQ2MVs33FXcrfHVLucBU36YUqXzXcYyvJlKFNUuznQMDaRymsf9hDtLqxCv0TatKHPWYc1HgaEw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
@@ -20664,8 +20664,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-linux-arm64-gnu@1.1.13:
-    resolution: {integrity: sha512-VRVOE+G3SOMAfJsccP8rrD2NtolISAhhzkzE6zn7uDxxq5tQGFLOxijWpUCVHSQHQrJ6DqFCvu1dpcPNFOb8mw==}
+  /@utoo/pack-linux-arm64-gnu@1.1.14:
+    resolution: {integrity: sha512-/jS5IFAye0o4dyE9Q61CEruytQJ7OJU9AHNeW173M2veA1I6a6o4P21wYSSlgY/PvUDyrhU+/d5faZLhzC7tyQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -20673,8 +20673,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-linux-arm64-musl@1.1.13:
-    resolution: {integrity: sha512-fAMZKwZfpR+v+dQiElM2sMvmYf5rP7cFFzA6P/GU7dalXYBAZgOV50Jbk9sT/rRRZA697BqZAH13ACzPOaKx2w==}
+  /@utoo/pack-linux-arm64-musl@1.1.14:
+    resolution: {integrity: sha512-bYjvNcNlZV30+L2jjoM2NKDxGh7xa4fkrkdQbNen45TcYkjl5LeN+sRmAndT/sCEwY0jwgNV3G8Bli5lca+J+w==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -20682,8 +20682,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-linux-x64-gnu@1.1.13:
-    resolution: {integrity: sha512-aik3arsEh/ixaRshbLTv92Nozti0QZU+Ks2DWhlZ5vmX/KRVrV5EjEvKAvHsE7I+WEO6fntKN4QZtDuhCwpZFg==}
+  /@utoo/pack-linux-x64-gnu@1.1.14:
+    resolution: {integrity: sha512-7KonjM7I0wDNSl9gQQJkm4HUZqKve9IR8dgCWVE32rXN7PWUfZUPUOijWf9aPuqEkxstXZ6l1q/gZl+uHHrtxA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -20691,8 +20691,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-linux-x64-musl@1.1.13:
-    resolution: {integrity: sha512-mKMt6nAhvCW1m4lQfj22aGmaFfFnr3bUM9GqPcw9X7pqbjMaHY8fVvl9y6T2UgJcNYqGFG6alZ8ejRKNiR/+ig==}
+  /@utoo/pack-linux-x64-musl@1.1.14:
+    resolution: {integrity: sha512-5kiyYkh1jRdxbib03wbJZjLhsyOew7gVbCmlFYoJM1Kgm83pGqUbqXL+OgPnF2UX+CAiDScb5Gl//o38ubiMgA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -20700,16 +20700,16 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-shared@1.1.13:
-    resolution: {integrity: sha512-HEsJXmWRj7SxHAlC/I3L53a/UWXSDo5/sfryO0dbptjAELQT6zhFhmo0WlfP2IbOEwyAPzPKDUsAmGGHyAl52g==}
+  /@utoo/pack-shared@1.1.14:
+    resolution: {integrity: sha512-8mdnNn4WpQWNtPoexukR+sp1rBPYRfB7Un+Tz66U3nDQY3N0sUemHy6BePDrapVdFVNop+nrw09glpMcpQH/hA==}
     engines: {node: '>= 20'}
     dependencies:
       '@babel/code-frame': 7.22.5
       picocolors: 1.1.1
     dev: false
 
-  /@utoo/pack-win32-x64-msvc@1.1.13:
-    resolution: {integrity: sha512-r5/UZRFFqlUenXjfrScZ+KYlwPUh2zwcz7x6J+umpEXMUNZVLlr1kSPzVtIi024pFKemNTYnzJhSmmxM1ZJ6zw==}
+  /@utoo/pack-win32-x64-msvc@1.1.14:
+    resolution: {integrity: sha512-17S5D2clg8k1N4vKOu3ihaXG0GRWUOggeWqeWc1DtxMdozHgRHLDEZCIFUf+G+/HPc0aaJ/HzUVtITZlBShTyg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
@@ -20717,8 +20717,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack@1.1.13:
-    resolution: {integrity: sha512-FrSeY+YdyFCkqaV6QyURYo/NmdZwkSx4csGQY6y4tq6hOrTdQgG/fv5RxG3QjT3I7t7XTDP4DcN5Y3UY7VzzUQ==}
+  /@utoo/pack@1.1.14:
+    resolution: {integrity: sha512-ASCdK8fcvjzjsPC5czjn/oaz8Wi3D5e+JF3QuRE6jNXIliJZzNJpeekpFYrByMWI7HeZY2mVbZ717V9Y5kvKeQ==}
     engines: {node: '>= 20'}
     peerDependencies:
       less: ^4.0.0
@@ -20733,7 +20733,7 @@ packages:
     dependencies:
       '@babel/code-frame': 7.22.5
       '@swc/helpers': 0.5.15
-      '@utoo/pack-shared': 1.1.13
+      '@utoo/pack-shared': 1.1.14
       '@utoo/style-loader': 1.0.1
       domparser-rs: 0.0.5
       find-up: 4.1.0
@@ -20742,13 +20742,13 @@ packages:
       send: 0.17.1
       ws: 8.18.3
     optionalDependencies:
-      '@utoo/pack-darwin-arm64': 1.1.13
-      '@utoo/pack-darwin-x64': 1.1.13
-      '@utoo/pack-linux-arm64-gnu': 1.1.13
-      '@utoo/pack-linux-arm64-musl': 1.1.13
-      '@utoo/pack-linux-x64-gnu': 1.1.13
-      '@utoo/pack-linux-x64-musl': 1.1.13
-      '@utoo/pack-win32-x64-msvc': 1.1.13
+      '@utoo/pack-darwin-arm64': 1.1.14
+      '@utoo/pack-darwin-x64': 1.1.14
+      '@utoo/pack-linux-arm64-gnu': 1.1.14
+      '@utoo/pack-linux-arm64-musl': 1.1.14
+      '@utoo/pack-linux-x64-gnu': 1.1.14
+      '@utoo/pack-linux-x64-musl': 1.1.14
+      '@utoo/pack-win32-x64-msvc': 1.1.14
     transitivePeerDependencies:
       - bufferutil
       - supports-color


### PR DESCRIPTION
升级 `@utoo/pack` 到 v1.1.14

带来 utoopack dev 和 build 上的性能提升以及一些 bug 修复，参考:

- https://github.com/utooland/utoo/releases/tag/utoopack-v1.1.14