### PR TITLE
feat(utoopack): support svgr-loader to deal react svg component

### DIFF
--- a/packages/bundler-utoopack/src/config.ts
+++ b/packages/bundler-utoopack/src/config.ts
@@ -199,6 +199,13 @@ function getSvgModuleRules(opts: {
                 ...svgr,
                 svgo: !!svgo,
               },
+              condition: {
+                all: [
+                  // Exclude node_modules (similar to excluding non-source files)
+                  { not: 'foreign' },
+                  { path: /\.[jt]sx?$/ },
+                ],
+              },
             },
             {
               loader: require.resolve(


### PR DESCRIPTION
utoopack 支持处理 svg react component，例如以下的 case:

```ts
import { ReactComponent as Help } from '../assets/help.svg';

export default function HomePage() {
  return (
     <>
        <Help key="InfoCircleFilled" />
     </>
  )
}
```

代码逻辑对齐 bundler-webpack: https://github.com/umijs/umi/blob/master/packages/bundler-webpack/src/config/svgRules.ts#L16-L52

Before:

svg 不能正常渲染，运行时抛错。

<img width="3010" height="1680" alt="image" src="https://github.com/user-attachments/assets/dc7d134d-a2d4-4e1d-ab3c-668e0a2ca63c" />


After:

svg 正常渲染。

<img width="3024" height="1288" alt="image" src="https://github.com/user-attachments/assets/6aa9afea-454e-4a58-ad5d-313b60c416be" />


