### PR TITLE
fix(utoopack): script externals config convert

### DIFF
--- a/examples/legacy/package.json
+++ b/examples/legacy/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@example/legacy",
   "private": true,
+  "repository": "git@github.com:umijs/umi.git",
   "scripts": {
     "build": "umi build",
     "dev": "umi dev",


### PR DESCRIPTION
```ts
export default {
  externals: {
    lodash: [
      'script https://gw.alipayobjects.com/os/lib/lodash/4.17.21/lodash.min.js',
      '_',
    ],
  },
  utoopack: {}
};
```

配置转换的时候忽略了 `type: script`，需要补上一下，否则 utoopack 的 script externals 不会生效。