### PR TITLE
fix: ssg 模式下，meta 无法设置 property 属性

### DIFF
--- a/examples/ssg-basename/.umirc.ts
+++ b/examples/ssg-basename/.umirc.ts
@@ -3,4 +3,10 @@ export default {
   ssr: {},
   base: '/base/',
   publicPath: '/base/', // 布署时需要布署在 base 文件夹下.
+  metas: [
+    {
+      property: 'og:image',
+      content: 'https://example.com/example.png',
+    },
+  ],
 };

--- a/packages/renderer-react/src/html.tsx
+++ b/packages/renderer-react/src/html.tsx
@@ -78,7 +78,12 @@ const HydrateMetadata = (
         <meta name="keywords" content={htmlPageOpts.keywords.join(',')} />
       )}
       {htmlPageOpts?.metas?.map((em: any) => (
-        <meta key={em.name} name={em.name} content={em.content} />
+        <meta
+          key={em.name}
+          name={em.name}
+          property={em.property}
+          content={em.content}
+        />
       ))}
 
       {htmlPageOpts?.links?.map((link: Record<string, string>, key: number) => {


### PR DESCRIPTION
ssg 模式下，meta 的 property 属性会丢失。

```js
{
  exportStatic: {},
  metas: [
    {
      property: 'og:image',
      content: 'https://umijs.org/og.png',
    }
  ],
}
```

结果将会是 `<meta content="https://umijs.org/og.png" />`

property 属性主要是一些 `og:*` 在用。

这个 pr 修复了这个问题。