### PR TITLE
docs: fix Express.js 4.x API documentation link

### DIFF
--- a/docs/docs/docs/guides/mock.en-US.md
+++ b/docs/docs/docs/guides/mock.en-US.md
@@ -101,7 +101,7 @@ export default {
 }
 ```
 
-For the APIs of `req` and `res`, refer to the [Express@4 official documentation](https://expressjs.com/en/api.html) for further understanding.
+For the APIs of `req` and `res`, refer to the [Express@4 official documentation](https://expressjs.com/en/4x/api.html) for further understanding.
 
 ### defineMock
 

--- a/docs/docs/docs/guides/mock.md
+++ b/docs/docs/docs/guides/mock.md
@@ -100,7 +100,7 @@ export default {
 }
 ```
 
-关于 `req` 和 `res` 的 API 可参考 [Express@4 官方文档](https://expressjs.com/en/api.html) 来进一步了解。
+关于 `req` 和 `res` 的 API 可参考 [Express@4 官方文档](https://expressjs.com/en/4x/api.html) 来进一步了解。
 
 ### defineMock
 


### PR DESCRIPTION
## Summary
- Fix incorrect Express.js documentation link in mock guide
- The link `https://expressjs.com/en/api.html` now redirects to Express 5.x docs
- Updated to correct 4.x URL: `https://expressjs.com/en/4x/api.html`

## Changes
- `docs/docs/docs/guides/mock.md` - Chinese documentation
- `docs/docs/docs/guides/mock.en-US.md` - English documentation

## Test plan
- [x] Verified that `https://expressjs.com/en/api.html` shows Express 5.x API Reference
- [x] Verified that `https://expressjs.com/en/4x/api.html` shows Express 4.x API Reference
