### PR TITLE
Fix #12689: [Bug] umi4.0 从第三方包引入了一个不存在的方法，仍然可以编译成功，只在运行时报错

### DIFF
--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -170,6 +170,13 @@ export async function getConfig(opts: IOpts): Promise<Configuration> {
     outputModule: !!userConfig.esm,
   });
 
+  // exportsPresence
+  if (userConfig.exportsPresence) {
+    config.module.parser.set('javascript', {
+      exportsPresence: userConfig.exportsPresence,
+    });
+  }
+
   // node polyfill
   await addNodePolyfill(applyOpts);
 

--- a/packages/bundler-webpack/src/schema.ts
+++ b/packages/bundler-webpack/src/schema.ts
@@ -81,6 +81,8 @@ export function getSchemas(): Record<string, (arg: { zod: typeof z }) => any> {
       ]),
     devtool: ({ zod }) => zod.union([zod.enum(devTool as any), zod.boolean()]),
     esm: ({ zod }) => zod.object({}),
+    exportsPresence: ({ zod }) =>
+      zod.enum(['error', 'warn', 'auto']).optional(),
     externals: ({ zod }) =>
       zod.union([
         zod.record(zod.string(), zod.any()),

--- a/packages/bundler-webpack/src/types.ts
+++ b/packages/bundler-webpack/src/types.ts
@@ -78,6 +78,7 @@ export interface IConfig {
   https?: HttpsServerOptions;
   externals?: WebpackConfig['externals'];
   esm?: { [key: string]: any };
+  exportsPresence?: 'error' | 'warn' | 'auto';
   extraBabelPlugins?: IBabelPlugin[];
   extraBabelPresets?: IBabelPlugin[];
   extraBabelIncludes?: Array<string | RegExp>;


### PR DESCRIPTION
Fixes #12689

## Summary
This PR addresses: [Bug] umi4.0 从第三方包引入了一个不存在的方法，仍然可以编译成功，只在运行时报错

## Changes
```
packages/bundler-webpack/src/config/config.ts | 7 +++++++
 packages/bundler-webpack/src/schema.ts        | 2 ++
 packages/bundler-webpack/src/types.ts         | 1 +
 3 files changed, 10 insertions(+)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: high. Happy to make any adjustments!*