### PR TITLE
fix: fallback to https.createServer on Node.js >= 24

### DIFF
--- a/packages/bundler-utils/src/https.ts
+++ b/packages/bundler-utils/src/https.ts
@@ -104,7 +104,8 @@ export async function createHttpsServer(
 
   // Create server
   let createServer: typeof CreateServer;
-  if (httpsConfig.http2 === false) {
+  const nodeMajor = parseInt(process.versions.node.split('.')[0], 10);
+  if (httpsConfig.http2 === false || nodeMajor >= 24) {
     createServer = https.createServer;
   } else {
     try {


### PR DESCRIPTION
## Summary

- On Node.js >= 24, skip importing `spdy` and use built-in `https.createServer` instead
- `spdy` depends on `http-deceiver` which calls `process.binding('http_parser')`, a private API removed in Node.js v24+, causing `No such module: http_parser` at runtime

Close https://github.com/ant-design/ant-design/issues/57090
Ref: https://github.com/spdy-http2/node-spdy/issues/397

## Test plan

- [ ] Run HTTPS dev server on Node.js >= 24, verify no `http_parser` error
- [ ] Run HTTPS dev server on Node.js < 24, verify spdy HTTP/2 still works
- [ ] Run with `https: { http2: false }` config, verify unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)