### PR TITLE
fix: remove runtimePublicPath handling in getDevUtooPackConfig

### DIFF
--- a/packages/bundler-utoopack/src/config.ts
+++ b/packages/bundler-utoopack/src/config.ts
@@ -391,7 +391,6 @@ export async function getDevUtooPackConfig(
 
   const {
     publicPath,
-    runtimePublicPath,
     externals: userExternals,
     copy = [],
     svgr,
@@ -409,7 +408,12 @@ export async function getDevUtooPackConfig(
         output: {
           // utoopack 的 dev 需要默认清空产物目录
           clean: opts.clean === undefined ? true : opts.clean,
-          publicPath: runtimePublicPath ? 'runtime' : publicPath || '/',
+          // In dev mode, always use the actual publicPath so that the
+          // @utoo/pack dev server can correctly strip the prefix from
+          // incoming requests in order to locate files on disk.
+          // By the way, the runtimePublicPath is only relevant in build mode,
+          // So we do not need to deal with it here.
+          publicPath: publicPath || '/',
           ...(opts.disableCopy
             ? { copy: [] }
             : { copy: ['public'].concat(copy) }),


### PR DESCRIPTION
# Description of the Bug 
When `publicPath`, `utoopack`, and `qiankun` are used together, the development server renders a blank page because the content of the JavaScript and CSS files is mistakenly replaced by the entry HTML.  

Reproduction Repository: 
You can check the issue in this repo: https://github.com/xc1427/repro-utoo-qiankun-publicPath/tree/main  

Noteworthy Observation:  
This issue does not occur when only two of the three configurations are enabled.  

# Analysis of the Bug  
An LLM can provide valuable insights. Still I will attempt to explain the issue in a clear and concise manner.  

If we dive deep into the `qiankun` plugin, it sets runtimePublicPath and injects sth similar to `window.publicPath = ${config.publicPath}` in script tag, which makes the value "runtime" passed to startServer() function in `@utoo/pack`'s dev command. However, `@utoo/pack`'s dev server do not do any path prefix removal in "runtime" condition, so at last the actual JavaScript and CSS files are not found on disk then a fallback html content is responded instead.

# Why is the fix reasonable
"runtime publicPath" feature is actually relevant to build instead of dev server. The dev server should try it best to server the correct assets no matter runtimePublicPath is set or not. It is safe to completely remove the condition of the current config having "runtime publicPath". And this aligns with the classic webpack-dev-middleware's behaviour.
