### PR TITLE
fix(utoopack): devServer compitable with runtimePublicPath

### DIFF
--- a/examples/with-utoopack-qiankun-slave/.gitignore
+++ b/examples/with-utoopack-qiankun-slave/.gitignore
@@ -1,0 +1,7 @@
+/.env.local
+/.umirc.local.ts
+/.umirc.local.js
+/config/config.local.ts
+/config/config.local.js
+/src/.umi
+/.umi

--- a/examples/with-utoopack-qiankun-slave/.umirc.ts
+++ b/examples/with-utoopack-qiankun-slave/.umirc.ts
@@ -1,0 +1,9 @@
+export default {
+  routes: [{ path: '/', component: 'index' }],
+  npmClient: 'pnpm',
+  publicPath: '/_inf_static/bug/',
+  qiankun: {
+    slave: {},
+  },
+  utoopack: {},
+};

--- a/examples/with-utoopack-qiankun-slave/package.json
+++ b/examples/with-utoopack-qiankun-slave/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@example/with-utoopack-qiankun-slave",
+  "private": true,
+  "scripts": {
+    "build": "max build",
+    "dev": "max dev",
+    "preview": "umi preview",
+    "setup": "umi setup",
+    "start": "npm run dev"
+  },
+  "dependencies": {
+    "@umijs/max": "workspace:*",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  }
+}

--- a/examples/with-utoopack-qiankun-slave/pages/index.tsx
+++ b/examples/with-utoopack-qiankun-slave/pages/index.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function HomePage() {
+  return <div>Utoopack with Qiankun Slave</div>;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1666,6 +1666,18 @@ importers:
         specifier: workspace:*
         version: link:../../packages/umi
 
+  examples/with-utoopack-qiankun-slave:
+    dependencies:
+      '@umijs/max':
+        specifier: workspace:*
+        version: link:../../packages/max
+      react:
+        specifier: ^18.0.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.0.0
+        version: 18.3.1(react@18.3.1)
+
   examples/with-valtio:
     dependencies:
       '@umijs/plugins':


### PR DESCRIPTION
对 pr: https://github.com/umijs/umi/pull/13257 的一个增强修复

具体可以通过添加的 `examples/with-utoopack-qiankun-slave` 来运行 `pnpm run dev` 观察:

<img width="2952" height="824" alt="image" src="https://github.com/user-attachments/assets/e24467b3-ddc8-40f7-b3b7-5cf65f9e94b8" />