### PR TITLE
refactor(example): remove utoopack extractPostcssPlugin support

### DIFF
--- a/examples/with-tailwindcss-v4/.umirc.ts
+++ b/examples/with-tailwindcss-v4/.umirc.ts
@@ -1,4 +1,5 @@
 export default {
-  extraPostCSSPlugins: [['@tailwindcss/postcss', {}]],
+  plugins: [require.resolve('@umijs/plugins/dist/tailwindcss')],
+  tailwindcss: {},
   utoopack: {},
 };

--- a/examples/with-tailwindcss-v4/app.tsx
+++ b/examples/with-tailwindcss-v4/app.tsx
@@ -1,1 +1,0 @@
-import './tailwind.css';

--- a/examples/with-tailwindcss-v4/package.json
+++ b/examples/with-tailwindcss-v4/package.json
@@ -7,8 +7,11 @@
     "start": "npm run dev"
   },
   "dependencies": {
-    "@tailwindcss/postcss": "^4.2.2",
+    "@umijs/plugins": "workspace:*",
     "tailwindcss": "^4.2.2",
     "umi": "workspace:*"
+  },
+  "devDependencies": {
+    "@tailwindcss/cli": "^4.2.2"
   }
 }

--- a/examples/with-tailwindcss-v4/pages/index.tsx
+++ b/examples/with-tailwindcss-v4/pages/index.tsx
@@ -2,26 +2,26 @@ import React from 'react';
 
 const badges = [
   'Tailwind CSS v4',
-  '@tailwindcss/postcss',
-  'extraPostCSSPlugins',
-  'User-land setup',
+  '@umijs/plugins',
+  '@tailwindcss/cli',
+  'tailwindcss: {}',
 ];
 
 const cards = [
   {
-    title: 'CSS-first entry',
+    title: 'Official Umi plugin',
     description:
-      'The example imports tailwind.css directly and lets PostCSS expand the framework styles during bundling.',
+      'The example enables @umijs/plugins/dist/tailwindcss and keeps the setup aligned with the standard Umi Tailwind workflow.',
   },
   {
-    title: 'Works with Umi config',
+    title: 'Tailwind CSS v4 ready',
     description:
-      'This example passes @tailwindcss/postcss through extraPostCSSPlugins and lets bundler-utoopack bridge it into its PostCSS pipeline.',
+      'Tailwind CSS v4 runs through the plugin with @tailwindcss/cli, so the example no longer needs manual PostCSS wiring.',
   },
   {
-    title: 'No generated temp CSS',
+    title: 'CSS-first authoring',
     description:
-      'Tailwind v4 runs directly in the normal PostCSS pipeline, so there is no separate CLI process generating a temp stylesheet.',
+      'The stylesheet still uses Tailwind v4 syntax with @import "tailwindcss" and @source for template scanning.',
   },
 ];
 
@@ -31,17 +31,17 @@ export default function HomePage() {
       <section className="mx-auto flex min-h-screen w-full max-w-6xl flex-col justify-center px-6 py-16">
         <div className="inline-flex w-fit items-center gap-2 rounded-full border border-cyan-400/30 bg-cyan-400/10 px-4 py-2 text-sm font-medium text-cyan-200">
           <span className="h-2 w-2 rounded-full bg-cyan-300" />
-          Tailwind CSS v4 via extraPostCSSPlugins
+          Tailwind CSS v4 via Umi plugin
         </div>
 
         <h1 className="mt-8 max-w-4xl text-5xl font-black tracking-tight text-white sm:text-6xl">
-          Umi + Tailwind CSS v4 without the extra CLI step.
+          Umi + Tailwind CSS v4 with the built-in Tailwind plugin.
         </h1>
 
         <p className="mt-6 max-w-2xl text-lg leading-8 text-slate-300">
-          This example shows a pure user-land Tailwind CSS v4 setup for Umi by
-          wiring @tailwindcss/postcss through extraPostCSSPlugins and importing
-          the stylesheet from app.tsx.
+          This example shows the recommended Umi setup for Tailwind CSS v4:
+          enable the Tailwind plugin in config, keep a small tailwind.css entry,
+          and let the plugin drive the v4 CLI integration for you.
         </p>
 
         <div className="mt-8 flex flex-wrap gap-3">
@@ -81,20 +81,30 @@ export default function HomePage() {
                 Current setup
               </p>
               <p className="mt-3 text-2xl font-semibold text-white">
-                extraPostCSSPlugins
+                tailwindcss plugin
               </p>
             </div>
 
             <div className="grid grid-cols-2 gap-4 text-sm text-slate-200">
               <div className="rounded-2xl bg-slate-900/60 px-4 py-3 ring-1 ring-white/10">
+                <p className="text-slate-400">Umi config</p>
+                <p className="mt-1 font-semibold text-white">
+                  {'tailwindcss: {}'}
+                </p>
+              </div>
+              <div className="rounded-2xl bg-slate-900/60 px-4 py-3 ring-1 ring-white/10">
+                <p className="text-slate-400">CLI package</p>
+                <p className="mt-1 font-semibold text-white">
+                  @tailwindcss/cli
+                </p>
+              </div>
+              <div className="rounded-2xl bg-slate-900/60 px-4 py-3 ring-1 ring-white/10">
                 <p className="text-slate-400">Tailwind package</p>
                 <p className="mt-1 font-semibold text-white">tailwindcss@4</p>
               </div>
               <div className="rounded-2xl bg-slate-900/60 px-4 py-3 ring-1 ring-white/10">
-                <p className="text-slate-400">PostCSS package</p>
-                <p className="mt-1 font-semibold text-white">
-                  @tailwindcss/postcss
-                </p>
+                <p className="text-slate-400">Plugin package</p>
+                <p className="mt-1 font-semibold text-white">@umijs/plugins</p>
               </div>
             </div>
           </div>

--- a/examples/with-tailwindcss-v4/readme.md
+++ b/examples/with-tailwindcss-v4/readme.md
@@ -1,3 +1,3 @@
 # with-tailwindcss-v4
 
-An example of using [UmiJS](https://umijs.org/zh-CN) with [Tailwind CSS v4](https://tailwindcss.com/).
+An example of using [UmiJS](https://umijs.org/zh-CN) with [Tailwind CSS v4](https://tailwindcss.com/) via the built-in Umi Tailwind plugin.

--- a/examples/with-tailwindcss-v4/tailwind.config.js
+++ b/examples/with-tailwindcss-v4/tailwind.config.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/examples/with-tailwindcss-v4/tailwind.css
+++ b/examples/with-tailwindcss-v4/tailwind.css
@@ -1,3 +1,3 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 @source "./pages/**/*.{js,jsx,ts,tsx}";

--- a/packages/bundler-utoopack/src/config.ts
+++ b/packages/bundler-utoopack/src/config.ts
@@ -281,7 +281,7 @@ function normalizeExtraPostcssPlugin(plugin: any): [string, any][] {
   );
 }
 
-function mergeExtraPostcssPlugins(
+export function mergeExtraPostcssPlugins(
   postcssConfig: any,
   extraPlugins: any[] = [],
 ) {
@@ -347,9 +347,9 @@ export async function getProdUtooPackConfig(
       process.env.SOCKET_SERVER,
     );
   }
-  const normalizedPostcssConfig = opts.config.extraPostCSSPlugins?.length
-    ? mergeExtraPostcssPlugins(undefined, opts.config.extraPostCSSPlugins)
-    : undefined;
+  // const normalizedPostcssConfig = opts.config.extraPostCSSPlugins?.length
+  //   ? mergeExtraPostcssPlugins(undefined, opts.config.extraPostCSSPlugins)
+  //   : undefined;
 
   const {
     publicPath,
@@ -389,7 +389,7 @@ export async function getProdUtooPackConfig(
             javascriptEnabled: true,
             ...opts.config.lessLoader,
           },
-          postcss: normalizedPostcssConfig,
+          // postcss: normalizedPostcssConfig,
           sass: opts.config.sassLoader ?? undefined,
           emotion: emotion || undefined,
         },
@@ -487,9 +487,9 @@ export async function getDevUtooPackConfig(
       process.env.SOCKET_SERVER,
     );
   }
-  const normalizedPostcssConfig = opts.config.extraPostCSSPlugins?.length
-    ? mergeExtraPostcssPlugins(undefined, opts.config.extraPostCSSPlugins)
-    : undefined;
+  // const normalizedPostcssConfig = opts.config.extraPostCSSPlugins?.length
+  //   ? mergeExtraPostcssPlugins(undefined, opts.config.extraPostCSSPlugins)
+  //   : undefined;
 
   const {
     publicPath,
@@ -528,7 +528,7 @@ export async function getDevUtooPackConfig(
             javascriptEnabled: true,
             ...opts.config.lessLoader,
           },
-          postcss: normalizedPostcssConfig,
+          // postcss: normalizedPostcssPlugin,
           sass: opts.config.sassLoader ?? undefined,
           emotion: emotion || undefined,
         },

--- a/packages/bundler-utoopack/src/index.ts
+++ b/packages/bundler-utoopack/src/index.ts
@@ -23,8 +23,6 @@ export async function build(opts: IOpts) {
     rootDir,
   });
 
-  // console.log('utooPackConfig: ', JSON.stringify(utooPackConfig, null, 2));
-
   try {
     await utooPackBuild(utooPackConfig, cwd, rootDir);
   } catch (e: any) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1635,15 +1635,19 @@ importers:
 
   examples/with-tailwindcss-v4:
     dependencies:
-      '@tailwindcss/postcss':
-        specifier: ^4.2.2
-        version: 4.2.2
+      '@umijs/plugins':
+        specifier: workspace:*
+        version: link:../../packages/plugins
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
       umi:
         specifier: workspace:*
         version: link:../../packages/umi
+    devDependencies:
+      '@tailwindcss/cli':
+        specifier: ^4.2.2
+        version: 4.2.2
 
   examples/with-unocss:
     dependencies:
@@ -3131,11 +3135,6 @@ packages:
     dependencies:
       postcss: 5.2.18
     dev: true
-
-  /@alloc/quick-lru@5.2.0:
-    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
-    engines: {node: '>=10'}
-    dev: false
 
   /@amap/amap-jsapi-loader@0.0.3:
     resolution: {integrity: sha512-3Tz50UdmRY2BiONK/mafEQzshYGUinK2hmDlKjYtoJHC/aVydiMOolHENWmP98F603RcrWTM7aLxOFMgesFfug==}
@@ -14747,7 +14746,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.25
 
   /@jridgewell/remapping@2.3.5:
@@ -14755,7 +14754,7 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
-    dev: false
+    dev: true
 
   /@jridgewell/resolve-uri@3.1.0:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
@@ -14807,7 +14806,6 @@ packages:
 
   /@jridgewell/sourcemap-codec@1.5.5:
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
-    dev: false
 
   /@jridgewell/trace-mapping@0.3.13:
     resolution: {integrity: sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==}
@@ -18364,6 +18362,19 @@ packages:
       defer-to-connect: 2.0.1
     dev: true
 
+  /@tailwindcss/cli@4.2.2:
+    resolution: {integrity: sha512-iJS+8kAFZ8HPqnh0O5DHCLjo4L6dD97DBQEkrhfSO4V96xeefUus2jqsBs1dUMt3OU9Ks4qIkiY0mpL5UW+4LQ==}
+    hasBin: true
+    dependencies:
+      '@parcel/watcher': 2.1.0
+      '@tailwindcss/node': 4.2.2
+      '@tailwindcss/oxide': 4.2.2
+      enhanced-resolve: 5.20.1
+      mri: 1.2.0
+      picocolors: 1.1.1
+      tailwindcss: 4.2.2
+    dev: true
+
   /@tailwindcss/node@4.2.2:
     resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
     dependencies:
@@ -18374,7 +18385,7 @@ packages:
       magic-string: 0.30.21
       source-map-js: 1.2.1
       tailwindcss: 4.2.2
-    dev: false
+    dev: true
 
   /@tailwindcss/oxide-android-arm64@4.2.2:
     resolution: {integrity: sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==}
@@ -18382,7 +18393,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /@tailwindcss/oxide-darwin-arm64@4.2.2:
@@ -18391,7 +18402,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /@tailwindcss/oxide-darwin-x64@4.2.2:
@@ -18400,7 +18411,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /@tailwindcss/oxide-freebsd-x64@4.2.2:
@@ -18409,7 +18420,7 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2:
@@ -18418,7 +18429,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /@tailwindcss/oxide-linux-arm64-gnu@4.2.2:
@@ -18427,7 +18438,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /@tailwindcss/oxide-linux-arm64-musl@4.2.2:
@@ -18436,7 +18447,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /@tailwindcss/oxide-linux-x64-gnu@4.2.2:
@@ -18445,7 +18456,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /@tailwindcss/oxide-linux-x64-musl@4.2.2:
@@ -18454,7 +18465,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /@tailwindcss/oxide-wasm32-wasi@4.2.2:
@@ -18462,7 +18473,7 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
     bundledDependencies:
       - '@napi-rs/wasm-runtime'
@@ -18478,7 +18489,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /@tailwindcss/oxide-win32-x64-msvc@4.2.2:
@@ -18487,7 +18498,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /@tailwindcss/oxide@4.2.2:
@@ -18506,17 +18517,7 @@ packages:
       '@tailwindcss/oxide-wasm32-wasi': 4.2.2
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
-    dev: false
-
-  /@tailwindcss/postcss@4.2.2:
-    resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      '@tailwindcss/node': 4.2.2
-      '@tailwindcss/oxide': 4.2.2
-      postcss: 8.5.9
-      tailwindcss: 4.2.2
-    dev: false
+    dev: true
 
   /@tanstack/match-sorter-utils@8.7.6:
     resolution: {integrity: sha512-2AMpRiA6QivHOUiBpQAVxjiHAA68Ei23ZUMNaRJrN6omWiSFLoYrxGcT6BXtuzp0Jw4h6HZCmGGIM/gbwebO2A==}
@@ -20404,7 +20405,7 @@ packages:
       '@swc/helpers': 0.5.1
       '@types/resolve': 1.20.6
       chalk: 4.1.2
-      enhanced-resolve: 5.18.3
+      enhanced-resolve: 5.20.1
       less: 4.4.1
       less-loader: 12.3.0(less@4.4.1)
       loader-runner: 4.3.0
@@ -27095,7 +27096,7 @@ packages:
   /detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
-    dev: false
+    dev: true
 
   /detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
@@ -27767,21 +27768,12 @@ packages:
       graceful-fs: 4.2.11
       tapable: 2.2.1
 
-  /enhanced-resolve@5.18.3:
-    resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
-    engines: {node: '>=10.13.0'}
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.2.1
-    dev: false
-
   /enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
-    dev: false
 
   /enhanced-resolve@5.9.3:
     resolution: {integrity: sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==}
@@ -33757,7 +33749,7 @@ packages:
   /jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
-    dev: false
+    dev: true
 
   /jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
@@ -34445,7 +34437,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /lightningcss-darwin-arm64@1.22.1:
@@ -34462,7 +34454,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /lightningcss-darwin-x64@1.22.1:
@@ -34479,7 +34471,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /lightningcss-freebsd-x64@1.22.1:
@@ -34496,7 +34488,7 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /lightningcss-linux-arm-gnueabihf@1.22.1:
@@ -34513,7 +34505,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /lightningcss-linux-arm64-gnu@1.22.1:
@@ -34530,7 +34522,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /lightningcss-linux-arm64-musl@1.22.1:
@@ -34547,7 +34539,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /lightningcss-linux-x64-gnu@1.22.1:
@@ -34564,7 +34556,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /lightningcss-linux-x64-musl@1.22.1:
@@ -34581,7 +34573,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /lightningcss-win32-arm64-msvc@1.32.0:
@@ -34590,7 +34582,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /lightningcss-win32-x64-msvc@1.22.1:
@@ -34607,7 +34599,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /lightningcss@1.22.1:
@@ -34643,7 +34635,7 @@ packages:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
-    dev: false
+    dev: true
 
   /lilconfig@2.0.6:
     resolution: {integrity: sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==}
@@ -35139,7 +35131,7 @@ packages:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-    dev: false
+    dev: true
 
   /magic-string@0.30.4:
     resolution: {integrity: sha512-Q/TKtsC5BPm0kGqgBIF9oXAs/xEf2vRKiIB4wCRQTJOQIByZ1d+NnUOotvJOvNpi5RNIgVOMC3pOuaP1ZTDlVg==}
@@ -40499,15 +40491,6 @@ packages:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.0.2
-
-  /postcss@8.5.9:
-    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
-    engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-    dev: false
 
   /potpack@1.0.2:
     resolution: {integrity: sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==}
@@ -49930,7 +49913,7 @@ packages:
   /source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
-    dev: false
+    dev: true
 
   /source-map-resolve@0.6.0:
     resolution: {integrity: sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==}
@@ -51201,7 +51184,6 @@ packages:
 
   /tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
-    dev: false
 
   /tapable@1.1.3:
     resolution: {integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==}
@@ -51215,7 +51197,6 @@ packages:
   /tapable@2.3.2:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
-    dev: false
 
   /tape@4.16.0:
     resolution: {integrity: sha512-mBlqYFr2mHysgCFXAuSarIQ+ffhielpb7a5/IbeOhMaLnQYhkJLUm6CwO1RszWeHRxnIpMessZ3xL2Cfo94BWw==}


### PR DESCRIPTION
- 移除 utoopack 的 extraPostcssPlugin 支持转换，目前只支持能序列化的 key-value 写法，容易对已有项目造成 breaking error
- tailwindcss-v4 example 使用 `@umijs/plugins/dist/tailwindcss`