### PR TITLE
refactor: simplify bundler-utoopack config assembly

### DIFF
--- a/packages/bundler-utoopack/src/config.ts
+++ b/packages/bundler-utoopack/src/config.ts
@@ -299,6 +299,119 @@ function getUserUtoopackConfig(utoopackConfig: Record<string, any> = {}) {
   return lodash.omit(utoopackConfig, ['root']);
 }
 
+function getBaseUtooPackConfig(webpackConfig: WebpackConfig): BundleOptions {
+  return compatOptionsFromWebpack({
+    ...lodash.omit(webpackConfig, ['target', 'module', 'externals']),
+    webpackMode: true,
+  } as WebpackConfig) as BundleOptions;
+}
+
+function getExtraBabelPluginFeatures(extraBabelPlugins: any[] = []) {
+  return {
+    modularizeImports: getModularizeImports(extraBabelPlugins),
+    emotion: extraBabelPlugins.some((plugin) => {
+      return plugin === '@emotion' || plugin === '@emotion/babel-plugin';
+    }),
+  };
+}
+
+function getDefineConfig(userDefine?: Record<string, any>) {
+  const define: Record<string, any> = {};
+
+  if (userDefine) {
+    for (const key of Object.keys(userDefine)) {
+      define[key] = normalizeDefineValue(userDefine[key]);
+    }
+  }
+
+  if (process.env.SOCKET_SERVER) {
+    define['process.env.SOCKET_SERVER'] = normalizeDefineValue(
+      process.env.SOCKET_SERVER,
+    );
+  }
+
+  return define;
+}
+
+function getMergedUtooPackConfig(opts: {
+  utooBundlerOpts: BundleOptions;
+  rootDir: string;
+  config: Record<string, any>;
+  disableCopy?: boolean;
+  clean?: boolean;
+  extraBabelPlugins?: any[];
+  extraConfig?: Record<string, any>;
+  optimization?: Record<string, any>;
+}) {
+  const {
+    utooBundlerOpts,
+    rootDir,
+    config,
+    disableCopy,
+    clean,
+    extraBabelPlugins = [],
+    extraConfig = {},
+    optimization = {},
+  } = opts;
+  const { modularizeImports, emotion } =
+    getExtraBabelPluginFeatures(extraBabelPlugins);
+  const define = getDefineConfig(config.define);
+  // const normalizedPostcssConfig = config.extraPostCSSPlugins?.length
+  //   ? mergeExtraPostcssPlugins(undefined, config.extraPostCSSPlugins)
+  //   : undefined;
+
+  const {
+    publicPath,
+    runtimePublicPath,
+    externals: userExternals,
+    copy = [],
+    svgr,
+    svgo = {},
+    inlineLimit,
+  } = config;
+  const userUtoopackConfig = getUserUtoopackConfig(config.utoopack);
+
+  return {
+    ...utooBundlerOpts,
+    config: lodash.merge(
+      lodash.omit(utooBundlerOpts.config, ['define']),
+      {
+        output: {
+          clean,
+          publicPath: runtimePublicPath ? 'runtime' : publicPath || '/',
+          ...(disableCopy ? { copy: [] } : { copy: ['public'].concat(copy) }),
+        },
+        optimization: {
+          modularizeImports,
+          ...optimization,
+        },
+        resolve: {
+          alias: getNormalizedAlias(
+            utooBundlerOpts.config.resolve?.alias as Record<string, string>,
+            rootDir,
+          ),
+        },
+        styles: {
+          less: {
+            modifyVars: config.theme,
+            javascriptEnabled: true,
+            ...config.lessLoader,
+          },
+          // postcss: normalizedPostcssConfig,
+          sass: config.sassLoader ?? undefined,
+          emotion,
+        },
+        define,
+        nodePolyfill: true,
+        externals: getNormalizedExternals(userExternals),
+        ...extraConfig,
+        ...getSvgModuleRules({ svgr, svgo, inlineLimit }),
+      },
+      userUtoopackConfig,
+    ),
+  } as BundleOptions;
+}
+
 export async function getProdUtooPackConfig(
   opts: IOpts,
 ): Promise<BundleOptions> {
@@ -325,89 +438,22 @@ export async function getProdUtooPackConfig(
     disableCopy: opts.disableCopy,
   });
 
-  let utooBundlerOpts = compatOptionsFromWebpack({
-    ...lodash.omit(webpackConfig, ['target', 'module', 'externals']),
-    webpackMode: true,
-  } as WebpackConfig);
-
   const extraBabelPlugins = [
     ...(opts.extraBabelPlugins || []),
     ...(opts.config.extraBabelPlugins || []),
   ];
 
-  const modularizeImports = getModularizeImports(extraBabelPlugins);
-  const emotion = extraBabelPlugins.some((p) => {
-    return p === '@emotion' || p === '@emotion/babel-plugin';
+  return getMergedUtooPackConfig({
+    utooBundlerOpts: getBaseUtooPackConfig(webpackConfig),
+    rootDir: opts.rootDir,
+    config: opts.config,
+    disableCopy: opts.disableCopy,
+    clean: opts.clean,
+    extraBabelPlugins,
+    optimization: {
+      concatenateModules: true,
+    },
   });
-  const define: Record<string, any> = {};
-  if (opts.config.define) {
-    for (const key of Object.keys(opts.config.define)) {
-      define[key] = normalizeDefineValue(opts.config.define[key]);
-    }
-  }
-
-  if (process.env.SOCKET_SERVER) {
-    define['process.env.SOCKET_SERVER'] = normalizeDefineValue(
-      process.env.SOCKET_SERVER,
-    );
-  }
-  // const normalizedPostcssConfig = opts.config.extraPostCSSPlugins?.length
-  //   ? mergeExtraPostcssPlugins(undefined, opts.config.extraPostCSSPlugins)
-  //   : undefined;
-
-  const {
-    publicPath,
-    runtimePublicPath,
-    externals: userExternals,
-    copy = [],
-    svgr,
-    svgo = {},
-    inlineLimit,
-  } = opts.config;
-  const userUtoopackConfig = getUserUtoopackConfig(opts.config.utoopack);
-
-  utooBundlerOpts = {
-    ...utooBundlerOpts,
-    config: lodash.merge(
-      lodash.omit(utooBundlerOpts.config, ['define']),
-      {
-        output: {
-          clean: opts.clean,
-          publicPath: runtimePublicPath ? 'runtime' : publicPath || '/',
-          ...(opts.disableCopy
-            ? { copy: [] }
-            : { copy: ['public'].concat(copy) }),
-        },
-        optimization: {
-          modularizeImports,
-          concatenateModules: true,
-        },
-        resolve: {
-          alias: getNormalizedAlias(
-            utooBundlerOpts.config.resolve?.alias as Record<string, string>,
-            opts.rootDir,
-          ),
-        },
-        styles: {
-          less: {
-            modifyVars: opts.config.theme,
-            javascriptEnabled: true,
-            ...opts.config.lessLoader,
-          },
-          // postcss: normalizedPostcssConfig,
-          sass: opts.config.sassLoader ?? undefined,
-          emotion,
-        },
-        define,
-        nodePolyfill: true,
-        externals: getNormalizedExternals(userExternals),
-        ...getSvgModuleRules({ svgr, svgo, inlineLimit }),
-      },
-      userUtoopackConfig,
-    ),
-  } as BundleOptions;
-
-  return utooBundlerOpts;
 }
 
 export type IDevOpts = {
@@ -442,7 +488,7 @@ export type IDevOpts = {
 export async function getDevUtooPackConfig(
   opts: IDevOpts,
 ): Promise<BundleOptions> {
-  let webpackConfig = await getConfig({
+  const webpackConfig = await getConfig({
     cwd: opts.cwd,
     rootDir: opts.rootDir,
     env: 'development' as any,
@@ -465,93 +511,27 @@ export async function getDevUtooPackConfig(
     analyze: process.env.ANALYZE,
   });
 
-  let utooBundlerOpts = compatOptionsFromWebpack({
-    ...lodash.omit(webpackConfig, ['target', 'module', 'externals']),
-    webpackMode: true,
-  } as WebpackConfig);
-
   const extraBabelPlugins = [
     ...(opts.extraBabelPlugins || []),
     ...(opts.config.extraBabelPlugins || []),
   ];
 
-  const modularizeImports = getModularizeImports(extraBabelPlugins);
-  const emotion = extraBabelPlugins.some((p) => {
-    return p === '@emotion' || p === '@emotion/babel-plugin';
-  });
-
-  const define: Record<string, any> = {};
-  if (opts.config.define) {
-    for (const key of Object.keys(opts.config.define)) {
-      define[key] = normalizeDefineValue(opts.config.define[key]);
-    }
-  }
-
-  if (process.env.SOCKET_SERVER) {
-    define['process.env.SOCKET_SERVER'] = normalizeDefineValue(
-      process.env.SOCKET_SERVER,
-    );
-  }
-  // const normalizedPostcssConfig = opts.config.extraPostCSSPlugins?.length
-  //   ? mergeExtraPostcssPlugins(undefined, opts.config.extraPostCSSPlugins)
-  //   : undefined;
-
-  const {
-    publicPath,
-    runtimePublicPath,
-    externals: userExternals,
-    copy = [],
-    svgr,
-    svgo = {},
-    inlineLimit,
-  } = opts.config;
-  const userUtoopackConfig = getUserUtoopackConfig(opts.config.utoopack);
-
-  utooBundlerOpts = {
-    ...utooBundlerOpts,
-    config: lodash.merge(
-      lodash.omit(utooBundlerOpts.config, ['define']),
-      {
-        output: {
-          clean: opts.clean === undefined ? true : opts.clean,
-          publicPath: runtimePublicPath ? 'runtime' : publicPath || '/',
-          ...(opts.disableCopy
-            ? { copy: [] }
-            : { copy: ['public'].concat(copy) }),
-        },
-        resolve: {
-          alias: getNormalizedAlias(
-            utooBundlerOpts.config.resolve?.alias as Record<string, string>,
-            opts.rootDir,
-          ),
-        },
-        optimization: {
-          modularizeImports,
-        },
-        styles: {
-          less: {
-            modifyVars: opts.config.theme,
-            javascriptEnabled: true,
-            ...opts.config.lessLoader,
-          },
-          // postcss: normalizedPostcssPlugin,
-          sass: opts.config.sassLoader ?? undefined,
-          emotion,
-        },
-        define,
+  return {
+    ...getMergedUtooPackConfig({
+      utooBundlerOpts: getBaseUtooPackConfig(webpackConfig),
+      rootDir: opts.rootDir,
+      config: opts.config,
+      disableCopy: opts.disableCopy,
+      clean: opts.clean === undefined ? true : opts.clean,
+      extraBabelPlugins,
+      extraConfig: {
         // dev enable persistent cache by default
         persistentCaching: true,
-        nodePolyfill: true,
-        externals: getNormalizedExternals(userExternals),
-        ...getSvgModuleRules({ svgr, svgo, inlineLimit }),
       },
-      userUtoopackConfig,
-    ),
+    }),
     watch: {
       enable: true,
     },
     dev: true,
   };
-
-  return utooBundlerOpts;
 }

--- a/packages/bundler-utoopack/src/config.ts
+++ b/packages/bundler-utoopack/src/config.ts
@@ -359,6 +359,15 @@ async function getWebpackConfigForUtooPack(
   });
 }
 
+type ICreateUtooPackConfigOpts = {
+  env: 'production' | 'development';
+  clean?: boolean;
+  webpackConfig?: Partial<Parameters<typeof getConfig>[0]>;
+  extraConfig?: Record<string, any>;
+  optimization?: Record<string, any>;
+  resultConfig?: Partial<BundleOptions>;
+};
+
 function getBaseUtooPackConfig(webpackConfig: WebpackConfig): BundleOptions {
   return compatOptionsFromWebpack({
     ...lodash.omit(webpackConfig, ['target', 'module', 'externals']),
@@ -472,23 +481,43 @@ function getMergedUtooPackConfig(opts: {
   } as BundleOptions;
 }
 
-export async function getProdUtooPackConfig(
-  opts: IOpts,
-): Promise<BundleOptions> {
-  const webpackConfig = await getWebpackConfigForUtooPack(opts, 'production', {
-    pkg: opts.pkg,
-    disableCopy: opts.disableCopy,
-  });
+async function createUtooPackConfig(
+  opts: ISharedUtooPackOpts,
+  buildOpts: ICreateUtooPackConfigOpts,
+) {
+  const webpackConfig = await getWebpackConfigForUtooPack(
+    opts,
+    buildOpts.env,
+    buildOpts.webpackConfig,
+  );
 
-  const extraBabelPlugins = getUtooExtraBabelPlugins(opts);
-
-  return getMergedUtooPackConfig({
+  const utooPackConfig = getMergedUtooPackConfig({
     utooBundlerOpts: getBaseUtooPackConfig(webpackConfig),
     rootDir: opts.rootDir,
     config: opts.config,
     disableCopy: opts.disableCopy,
+    clean: buildOpts.clean,
+    extraBabelPlugins: getUtooExtraBabelPlugins(opts),
+    extraConfig: buildOpts.extraConfig,
+    optimization: buildOpts.optimization,
+  });
+
+  return {
+    ...utooPackConfig,
+    ...buildOpts.resultConfig,
+  } as BundleOptions;
+}
+
+export async function getProdUtooPackConfig(
+  opts: IOpts,
+): Promise<BundleOptions> {
+  return createUtooPackConfig(opts, {
+    env: 'production',
     clean: opts.clean,
-    extraBabelPlugins,
+    webpackConfig: {
+      pkg: opts.pkg,
+      disableCopy: opts.disableCopy,
+    },
     optimization: {
       concatenateModules: true,
     },
@@ -527,29 +556,22 @@ export type IDevOpts = {
 export async function getDevUtooPackConfig(
   opts: IDevOpts,
 ): Promise<BundleOptions> {
-  const webpackConfig = await getWebpackConfigForUtooPack(opts, 'development', {
-    // TO avoild bundler webpack add extra entry.
-    hmr: false,
-  });
-
-  const extraBabelPlugins = getUtooExtraBabelPlugins(opts);
-
-  return {
-    ...getMergedUtooPackConfig({
-      utooBundlerOpts: getBaseUtooPackConfig(webpackConfig),
-      rootDir: opts.rootDir,
-      config: opts.config,
-      disableCopy: opts.disableCopy,
-      clean: opts.clean === undefined ? true : opts.clean,
-      extraBabelPlugins,
-      extraConfig: {
-        // dev enable persistent cache by default
-        persistentCaching: true,
-      },
-    }),
-    watch: {
-      enable: true,
+  return createUtooPackConfig(opts, {
+    env: 'development',
+    clean: opts.clean === undefined ? true : opts.clean,
+    webpackConfig: {
+      // TO avoild bundler webpack add extra entry.
+      hmr: false,
     },
-    dev: true,
-  };
+    extraConfig: {
+      // dev enable persistent cache by default
+      persistentCaching: true,
+    },
+    resultConfig: {
+      watch: {
+        enable: true,
+      },
+      dev: true,
+    },
+  });
 }

--- a/packages/bundler-utoopack/src/config.ts
+++ b/packages/bundler-utoopack/src/config.ts
@@ -299,6 +299,66 @@ function getUserUtoopackConfig(utoopackConfig: Record<string, any> = {}) {
   return lodash.omit(utoopackConfig, ['root']);
 }
 
+type ISharedUtooPackOpts = Pick<
+  IDevOpts,
+  | 'cwd'
+  | 'rootDir'
+  | 'entry'
+  | 'config'
+  | 'babelPreset'
+  | 'beforeBabelPlugins'
+  | 'extraBabelPlugins'
+  | 'beforeBabelPresets'
+  | 'extraBabelPresets'
+  | 'chainWebpack'
+  | 'modifyWebpackConfig'
+  | 'pkg'
+  | 'disableCopy'
+>;
+
+function getWebpackExtraBabelPlugins(opts: ISharedUtooPackOpts) {
+  return [
+    ...(opts.beforeBabelPlugins || []),
+    ...(opts.extraBabelPlugins || []),
+  ];
+}
+
+function getWebpackExtraBabelPresets(opts: ISharedUtooPackOpts) {
+  return [
+    ...(opts.beforeBabelPresets || []),
+    ...(opts.extraBabelPresets || []),
+  ];
+}
+
+function getUtooExtraBabelPlugins(opts: ISharedUtooPackOpts) {
+  return [
+    ...(opts.extraBabelPlugins || []),
+    ...(opts.config.extraBabelPlugins || []),
+  ];
+}
+
+async function getWebpackConfigForUtooPack(
+  opts: ISharedUtooPackOpts,
+  env: 'production' | 'development',
+  extraConfig: Partial<Parameters<typeof getConfig>[0]> = {},
+) {
+  return getConfig({
+    cwd: opts.cwd,
+    rootDir: opts.rootDir,
+    env: env as any,
+    entry: opts.entry,
+    userConfig: opts.config,
+    analyze: process.env.ANALYZE,
+    babelPreset: opts.babelPreset,
+    extraBabelPlugins: getWebpackExtraBabelPlugins(opts),
+    extraBabelPresets: getWebpackExtraBabelPresets(opts),
+    extraBabelIncludes: opts.config.extraBabelIncludes,
+    chainWebpack: opts.chainWebpack,
+    modifyWebpackConfig: opts.modifyWebpackConfig,
+    ...extraConfig,
+  });
+}
+
 function getBaseUtooPackConfig(webpackConfig: WebpackConfig): BundleOptions {
   return compatOptionsFromWebpack({
     ...lodash.omit(webpackConfig, ['target', 'module', 'externals']),
@@ -415,33 +475,12 @@ function getMergedUtooPackConfig(opts: {
 export async function getProdUtooPackConfig(
   opts: IOpts,
 ): Promise<BundleOptions> {
-  const webpackConfig = await getConfig({
-    cwd: opts.cwd,
-    rootDir: opts.rootDir,
-    env: 'production' as any,
-    entry: opts.entry,
-    userConfig: opts.config,
-    analyze: process.env.ANALYZE,
-    babelPreset: opts.babelPreset,
-    extraBabelPlugins: [
-      ...(opts.beforeBabelPlugins || []),
-      ...(opts.extraBabelPlugins || []),
-    ],
-    extraBabelPresets: [
-      ...(opts.beforeBabelPresets || []),
-      ...(opts.extraBabelPresets || []),
-    ],
-    extraBabelIncludes: opts.config.extraBabelIncludes,
-    chainWebpack: opts.chainWebpack,
-    modifyWebpackConfig: opts.modifyWebpackConfig,
+  const webpackConfig = await getWebpackConfigForUtooPack(opts, 'production', {
     pkg: opts.pkg,
     disableCopy: opts.disableCopy,
   });
 
-  const extraBabelPlugins = [
-    ...(opts.extraBabelPlugins || []),
-    ...(opts.config.extraBabelPlugins || []),
-  ];
+  const extraBabelPlugins = getUtooExtraBabelPlugins(opts);
 
   return getMergedUtooPackConfig({
     utooBundlerOpts: getBaseUtooPackConfig(webpackConfig),
@@ -488,33 +527,12 @@ export type IDevOpts = {
 export async function getDevUtooPackConfig(
   opts: IDevOpts,
 ): Promise<BundleOptions> {
-  const webpackConfig = await getConfig({
-    cwd: opts.cwd,
-    rootDir: opts.rootDir,
-    env: 'development' as any,
-    entry: opts.entry,
-    userConfig: opts.config,
-    babelPreset: opts.babelPreset,
-    extraBabelPlugins: [
-      ...(opts.beforeBabelPlugins || []),
-      ...(opts.extraBabelPlugins || []),
-    ],
-    extraBabelPresets: [
-      ...(opts.beforeBabelPresets || []),
-      ...(opts.extraBabelPresets || []),
-    ],
-    extraBabelIncludes: opts.config.extraBabelIncludes,
-    chainWebpack: opts.chainWebpack,
-    modifyWebpackConfig: opts.modifyWebpackConfig,
+  const webpackConfig = await getWebpackConfigForUtooPack(opts, 'development', {
     // TO avoild bundler webpack add extra entry.
     hmr: false,
-    analyze: process.env.ANALYZE,
   });
 
-  const extraBabelPlugins = [
-    ...(opts.extraBabelPlugins || []),
-    ...(opts.config.extraBabelPlugins || []),
-  ];
+  const extraBabelPlugins = getUtooExtraBabelPlugins(opts);
 
   return {
     ...getMergedUtooPackConfig({


### PR DESCRIPTION
## Summary

This refactors `packages/bundler-utoopack/src/config.ts` to reduce duplicated dev/prod config assembly logic.

## What Changed

- extracted a shared helper to convert webpack config output into the base utoopack config
- extracted shared helpers for deriving `define` values and extra Babel plugin features
- consolidated the common utoopack config merge path used by both `getProdUtooPackConfig` and `getDevUtooPackConfig`
- kept dev/prod-only behavior at the call sites, such as `concatenateModules`, `persistentCaching`, and dev watch flags

## Why

Both config builders were maintaining nearly identical logic for alias resolution, styles, externals, SVG handling, copy behavior, and define injection. Centralizing that flow makes the file easier to read and lowers the risk of the two paths drifting apart.

## Validation

- `pnpm prettier --check packages/bundler-utoopack/src/config.ts`
- `pnpm --filter @umijs/bundler-utoopack build`
