### PR TITLE
chore: bump click-to-react-component to 1.1.3

### DIFF
--- a/docs/docs/docs/api/config.en-US.md
+++ b/docs/docs/docs/api/config.en-US.md
@@ -178,7 +178,7 @@ export default {
 
 When this feature is enabled, you can jump to the source code location in the editor by `Option+Click/Alt+Click` on the component. `Option+Right-click/Alt+Right-click` opens the context to view the parent component.
 
-About parameters. The `editor` parameter defaults to 'vscode', supporting `vscode` & `vscode-insiders`.
+About parameters. The `editor` parameter defaults to 'vscode', supporting `vscode`, `vscode-insiders` and `cursor`.
 
 Configure the behavior of clickToComponent, for more details see [click-to-component](https://github.com/ericclemmons/click-to-component).
 

--- a/docs/docs/docs/api/config.md
+++ b/docs/docs/docs/api/config.md
@@ -176,7 +176,7 @@ export default {
 
 开启后，可通过 `Option+Click/Alt+Click` 点击组件跳转至编辑器源码位置，`Option+Right-click/Alt+Right-click` 可以打开上下文，查看父组件。
 
-关于参数。`editor` 为编辑器名称，默认为 'vscode'，支持 `vscode` & `vscode-insiders`。
+关于参数。`editor` 为编辑器名称，默认为 'vscode'，支持 `vscode`, `vscode-insiders` 和 `cursor`。
 
 配置 clickToComponent 的行为，详见 [click-to-component](https://github.com/ericclemmons/click-to-component)。
 

--- a/packages/preset-umi/package.json
+++ b/packages/preset-umi/package.json
@@ -49,7 +49,7 @@
     "@umijs/zod2ts": "workspace:*",
     "babel-plugin-dynamic-import-node": "2.3.3",
     "babel-plugin-react-compiler": "0.0.0-experimental-c23de8d-20240515",
-    "click-to-react-component": "1.1.0",
+    "click-to-react-component": "1.1.3",
     "core-js": "3.34.0",
     "current-script-polyfill": "1.0.0",
     "enhanced-resolve": "5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2623,8 +2623,8 @@ importers:
         specifier: 0.0.0-experimental-c23de8d-20240515
         version: 0.0.0-experimental-c23de8d-20240515
       click-to-react-component:
-        specifier: 1.1.0
-        version: 1.1.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+        specifier: 1.1.3
+        version: 1.1.3(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       core-js:
         specifier: 3.34.0
         version: 3.34.0
@@ -20612,7 +20612,7 @@ packages:
       '@umijs/utils': 4.1.2
       '@umijs/zod2ts': 4.1.2
       babel-plugin-dynamic-import-node: 2.3.3
-      click-to-react-component: 1.1.0(@types/react@18.3.3)(react-dom@18.1.0)(react@18.1.0)
+      click-to-react-component: 1.1.3(@types/react@18.3.3)(react-dom@18.1.0)(react@18.1.0)
       core-js: 3.34.0
       current-script-polyfill: 1.0.0
       enhanced-resolve: 5.9.3
@@ -25071,8 +25071,8 @@ packages:
     engines: {node: '>= 10'}
     dev: true
 
-  /click-to-react-component@1.1.0(@types/react@18.3.3)(react-dom@18.1.0)(react@18.1.0):
-    resolution: {integrity: sha512-/DjZemufS1BkxyRgZL3r7HXVVOFRWVQi5Xd4EBnjxZMwrHEh0OlUVA2N9CjXkZ0x8zMf8dL1cKnnx+xUWUg4VA==}
+  /click-to-react-component@1.1.3(@types/react@18.3.3)(react-dom@18.1.0)(react@18.1.0):
+    resolution: {integrity: sha512-tHXsXuvHBKCjjrevtGUzanngE+8HtZLt57precpAO677vjCO9Vxr3Lc3VqgNGGd2JpVybL0QHhnsrijZ2T5cng==}
     peerDependencies:
       react: '>=16.8.0'
     peerDependenciesMeta:
@@ -25088,8 +25088,8 @@ packages:
       - react-dom
     dev: true
 
-  /click-to-react-component@1.1.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-/DjZemufS1BkxyRgZL3r7HXVVOFRWVQi5Xd4EBnjxZMwrHEh0OlUVA2N9CjXkZ0x8zMf8dL1cKnnx+xUWUg4VA==}
+  /click-to-react-component@1.1.3(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-tHXsXuvHBKCjjrevtGUzanngE+8HtZLt57precpAO677vjCO9Vxr3Lc3VqgNGGd2JpVybL0QHhnsrijZ2T5cng==}
     peerDependencies:
       react: '>=16.8.0'
     peerDependenciesMeta:


### PR DESCRIPTION
bump `click-to-react-component` to v1.1.3,  now `cursor` also can work 