### PR TITLE
fix(plugins): resolve antd icons package metadata

### DIFF
--- a/packages/plugins/src/layout.ts
+++ b/packages/plugins/src/layout.ts
@@ -8,7 +8,7 @@ import { withTmpPath } from './utils/withTmpPath';
 
 // 获取所有 icons
 const antIconsPath = winPath(
-  dirname(require.resolve('@ant-design/icons/package')),
+  dirname(require.resolve('@ant-design/icons/package.json')),
 );
 
 const getAllIcons = () => {


### PR DESCRIPTION
## 背景

`@umijs/plugins` 的 layout 插件通过 `require.resolve('@ant-design/icons/package')` 定位 `@ant-design/icons` 包目录，再读取 `lib/icons/index.d.ts` 来获取图标列表。

在 `@ant-design/icons@6.2.2` 新增 `exports` 后，`@ant-design/icons/package` 会被 `./*` 通配规则解析到不存在的 `lib/icons/package.js`，导致 layout 插件初始化失败。

## 修改

将解析路径从：

`@ant-design/icons/package`

改为：

`@ant-design/icons/package.json`

外层仍然通过 `dirname(...)` 获取包根目录，保持原有逻辑不变，只是显式使用 package.json 作为稳定锚点。

## 验证

- 本地验证 `@ant-design/icons@6.2.2` 下：
  - `@ant-design/icons/package` 解析失败
  - `@ant-design/icons/package.json` 可正确解析到包根目录下的 package.json
- 在实际 Umi 使用项目中用同等 patch 验证 `max verify-commit` 可正常加载 layout 插件
- `git diff --check` 通过

> 新 clone 的 Umi 仓库未安装依赖，因此未跑完整 `pnpm test`。
