### PR TITLE
perf(preset-umi): icon log optimize

### DIFF
--- a/packages/preset-umi/src/features/icons/icons.ts
+++ b/packages/preset-umi/src/features/icons/icons.ts
@@ -50,6 +50,7 @@ export default (api: IApi) => {
 
   const icons: Set<string> = new Set();
   let noIconsLogged = false;
+  let lastGenerateIconsLog: string | null = null;
   api.addPrepareBuildPlugins(() => {
     return [
       iconPlugin.esbuildIconPlugin({
@@ -71,7 +72,12 @@ export default (api: IApi) => {
       return;
     }
 
-    logger.info(`[icons] generate icons ${Array.from(icons).join(', ')}`);
+    const iconNames = Array.from(allIcons);
+    const generateIconsLog = iconNames.join(', ');
+    if (generateIconsLog !== lastGenerateIconsLog) {
+      logger.info(`[icons] generate icons ${generateIconsLog}`);
+      lastGenerateIconsLog = generateIconsLog;
+    }
     const code: string[] = [];
     const { generateIconName, generateSvgr } = svgr;
     for (const iconStr of allIcons) {

--- a/packages/preset-umi/src/features/icons/icons.ts
+++ b/packages/preset-umi/src/features/icons/icons.ts
@@ -49,6 +49,7 @@ export default (api: IApi) => {
   const EMPTY_ICONS_FILE = `export const __no_icons = true;`;
 
   const icons: Set<string> = new Set();
+  let noIconsLogged = false;
   api.addPrepareBuildPlugins(() => {
     return [
       iconPlugin.esbuildIconPlugin({
@@ -63,7 +64,10 @@ export default (api: IApi) => {
     const allIcons = new Set([...icons, ...extraIcons]);
 
     if (!allIcons.size) {
-      logger.info(`[icons] no icons was found`);
+      if (!noIconsLogged) {
+        logger.info(`[icons] no icons was found`);
+        noIconsLogged = true;
+      }
       return;
     }
 


### PR DESCRIPTION
log 会输出多次:

<img width="426" height="246" alt="image" src="https://github.com/user-attachments/assets/996d92b0-7c53-4cfb-94c3-a9cb4fd2a662" />

优化成输出过之后就不要再输出了:

<img width="1796" height="586" alt="image" src="https://github.com/user-attachments/assets/91bc2ff0-029b-4a1b-b7a3-5235467c7f5b" />
