### PR TITLE
fix(utoopack): remove utoopack's define json stringify

### DIFF
--- a/packages/bundler-utoopack/src/config.test.ts
+++ b/packages/bundler-utoopack/src/config.test.ts
@@ -58,6 +58,59 @@ describe('utoopack mdx config', () => {
   });
 });
 
+describe('utoopack define config', () => {
+  test('passes user define values to production utoopack config without stringifying leaves', async () => {
+    const routePathEnum = {
+      INDEX: '/',
+      DETAIL: '/detail',
+    };
+
+    const config = await getProdUtooPackConfig({
+      ...baseOpts,
+      config: {
+        define: {
+          RoutePathEnum: routePathEnum,
+          FEATURE_FLAG: true,
+          COUNT: 1,
+        },
+      },
+    } as any);
+
+    expect(config.config.define).toMatchObject({
+      RoutePathEnum: routePathEnum,
+      FEATURE_FLAG: true,
+      COUNT: 1,
+    });
+    expect(config.config.define?.RoutePathEnum.INDEX).toBe('/');
+    expect(config.config.define?.RoutePathEnum.DETAIL).toBe('/detail');
+  });
+
+  test('passes SOCKET_SERVER as a raw string value', async () => {
+    const prevSocketServer = process.env.SOCKET_SERVER;
+    process.env.SOCKET_SERVER = 'http://127.0.0.1:8001';
+
+    try {
+      const config = await getDevUtooPackConfig({
+        ...baseOpts,
+        config: {},
+      } as any);
+
+      expect(config.config.define?.['process.env.SOCKET_SERVER']).toBe(
+        'http://127.0.0.1:8001',
+      );
+      expect(config.processEnv?.['process.env.SOCKET_SERVER']).toBe(
+        'http://127.0.0.1:8001',
+      );
+    } finally {
+      if (prevSocketServer === undefined) {
+        delete process.env.SOCKET_SERVER;
+      } else {
+        process.env.SOCKET_SERVER = prevSocketServer;
+      }
+    }
+  });
+});
+
 describe('utoopack externals config', () => {
   test('keeps script-prefixed CDN externals as script externals', async () => {
     const config = await getProdUtooPackConfig({

--- a/packages/bundler-utoopack/src/config.ts
+++ b/packages/bundler-utoopack/src/config.ts
@@ -7,15 +7,19 @@ import fs from 'fs';
 import { extname, resolve as pathResolve } from 'path';
 import type { IOpts } from './types';
 
-function normalizeDefineValue(val: any) {
-  if (!lodash.isPlainObject(val)) {
-    return JSON.stringify(val);
-  } else {
-    return Object.keys(val).reduce((obj: Record<string, any>, key: string) => {
-      obj[key] = normalizeDefineValue(val[key]);
-      return obj;
-    }, {});
+function getUtoopackDefine(opts: { config: Record<string, any> }) {
+  const define: Record<string, any> = {
+    ...(opts.config.define || {}),
+  };
+
+  // Utoopack consumes define entries as concrete JSON values. Unlike Mako,
+  // string values are not parsed again as JavaScript expressions, so
+  // pre-stringifying leaves would turn "/foo" into the runtime value "\"/foo\"".
+  if (process.env.SOCKET_SERVER) {
+    define['process.env.SOCKET_SERVER'] = process.env.SOCKET_SERVER;
   }
+
+  return define;
 }
 
 function getModularizeImports(extraBabelPlugins: any[]) {
@@ -340,18 +344,7 @@ export async function getProdUtooPackConfig(
   const emotion = extraBabelPlugins.some((p) => {
     return p === '@emotion' || p === '@emotion/babel-plugin';
   });
-  const define: Record<string, any> = {};
-  if (opts.config.define) {
-    for (const key of Object.keys(opts.config.define)) {
-      define[key] = normalizeDefineValue(opts.config.define[key]);
-    }
-  }
-
-  if (process.env.SOCKET_SERVER) {
-    define['process.env.SOCKET_SERVER'] = normalizeDefineValue(
-      process.env.SOCKET_SERVER,
-    );
-  }
+  const define = getUtoopackDefine(opts);
   // const normalizedPostcssConfig = opts.config.extraPostCSSPlugins?.length
   //   ? mergeExtraPostcssPlugins(undefined, opts.config.extraPostCSSPlugins)
   //   : undefined;
@@ -484,18 +477,7 @@ export async function getDevUtooPackConfig(
     return p === '@emotion' || p === '@emotion/babel-plugin';
   });
 
-  const define: Record<string, any> = {};
-  if (opts.config.define) {
-    for (const key of Object.keys(opts.config.define)) {
-      define[key] = normalizeDefineValue(opts.config.define[key]);
-    }
-  }
-
-  if (process.env.SOCKET_SERVER) {
-    define['process.env.SOCKET_SERVER'] = normalizeDefineValue(
-      process.env.SOCKET_SERVER,
-    );
-  }
+  const define = getUtoopackDefine(opts);
   // const normalizedPostcssConfig = opts.config.extraPostCSSPlugins?.length
   //   ? mergeExtraPostcssPlugins(undefined, opts.config.extraPostCSSPlugins)
   //   : undefined;


### PR DESCRIPTION
Unlike mako, if under utoopack pass a define like:

```ts
export enum RoutePathEnum {
  INDEX = '/',
  DETAIL = '/detail'
}

export default {
  define: {
     RoutePathEnum: RoutePathEnum,
  }
}
```

the config define will pass as:

```ts
RoutePathEnum {
  INDEX = '"/"',
  DETAIL = '"/detail"'
}
```

mako can strip it because parse as JS Expression, but utoopack will just replace it directly.