### PR TITLE
feat(utoopack): cssFilename compitable with miniCssExtraPlugin

### DIFF
--- a/examples/max/.umirc.ts
+++ b/examples/max/.umirc.ts
@@ -108,5 +108,4 @@ export default defineConfig({
     autoInstall: {},
     include: ['local:rice', 'local:logo/umi', 'ant-design:fire-twotone'],
   },
-  utoopack: {},
 });

--- a/examples/max/.umirc.ts
+++ b/examples/max/.umirc.ts
@@ -108,4 +108,5 @@ export default defineConfig({
     autoInstall: {},
     include: ['local:rice', 'local:logo/umi', 'ant-design:fire-twotone'],
   },
+  utoopack: {},
 });

--- a/packages/bundler-utoopack/src/config.test.ts
+++ b/packages/bundler-utoopack/src/config.test.ts
@@ -18,11 +18,37 @@ jest.mock('@utoo/pack', () => ({
   })),
 }));
 
+import { getConfig } from '@umijs/bundler-webpack';
 import {
   getDevUtooPackConfig,
   getProdUtooPackConfig,
   getSSRUtooPackConfig,
 } from './config';
+
+class MiniCssExtractPlugin {
+  options: { filename?: string; chunkFilename?: string };
+
+  constructor(options: { filename?: string; chunkFilename?: string }) {
+    this.options = options;
+  }
+}
+
+const mockedGetConfig = getConfig as jest.Mock;
+
+function createWebpackConfig(miniCssExtractOptions?: {
+  filename?: string;
+  chunkFilename?: string;
+}) {
+  return {
+    output: {},
+    resolve: {
+      alias: {},
+    },
+    plugins: miniCssExtractOptions
+      ? [new MiniCssExtractPlugin(miniCssExtractOptions)]
+      : [],
+  };
+}
 
 const baseOpts = {
   cwd: process.cwd(),
@@ -32,8 +58,13 @@ const baseOpts = {
   },
 };
 
+beforeEach(() => {
+  mockedGetConfig.mockClear();
+  mockedGetConfig.mockResolvedValue(createWebpackConfig());
+});
+
 describe('utoopack mdx config', () => {
-  test('uses entry name as default css output filename', async () => {
+  test('uses name placeholder as default css output filename', async () => {
     const prodConfig = await getProdUtooPackConfig({
       ...baseOpts,
       config: {},
@@ -43,8 +74,89 @@ describe('utoopack mdx config', () => {
       config: {},
     } as any);
 
-    expect(prodConfig.config.output?.cssFilename).toBe('index.css');
-    expect(devConfig.config.output?.cssFilename).toBe('index.css');
+    expect(prodConfig.config.output?.cssFilename).toBe('[name].css');
+    expect(prodConfig.config.output?.cssChunkFilename).toBe('[name].chunk.css');
+    expect(devConfig.config.output?.cssFilename).toBe('[name].css');
+    expect(devConfig.config.output?.cssChunkFilename).toBe('[name].chunk.css');
+  });
+
+  test('uses entry name as ssr css output filename', async () => {
+    const config = await getProdUtooPackConfig({
+      ...baseOpts,
+      config: {
+        ssr: {},
+      },
+    } as any);
+
+    expect(config.config.output?.cssFilename).toBe('index.css');
+    expect(config.config.output?.cssChunkFilename).toBe('umi.css');
+    expect(config.config.optimization?.splitChunks?.css).toEqual({
+      minChunkSize: 100_000_000,
+      maxChunkCountPerGroup: 1,
+      maxMergeChunkSize: 100_000_000,
+    });
+  });
+
+  test('allows user ssr css splitChunks override', async () => {
+    const config = await getProdUtooPackConfig({
+      ...baseOpts,
+      config: {
+        ssr: {},
+        utoopack: {
+          optimization: {
+            splitChunks: {
+              css: {
+                maxChunkCountPerGroup: 2,
+                maxMergeChunkSize: 200_000_000,
+              },
+            },
+          },
+        },
+      },
+    } as any);
+
+    expect(config.config.optimization?.splitChunks?.css).toEqual({
+      minChunkSize: 100_000_000,
+      maxChunkCountPerGroup: 2,
+      maxMergeChunkSize: 200_000_000,
+    });
+  });
+
+  test('uses hashed css output filenames in production', async () => {
+    const config = await getProdUtooPackConfig({
+      ...baseOpts,
+      config: {
+        hash: true,
+      },
+    } as any);
+
+    expect(config.config.output?.cssFilename).toBe(
+      '[name].[contenthash:8].css',
+    );
+    expect(config.config.output?.cssChunkFilename).toBe(
+      '[name].[contenthash:8].chunk.css',
+    );
+  });
+
+  test('uses mini-css-extract css output templates from webpack config', async () => {
+    mockedGetConfig.mockResolvedValueOnce(
+      createWebpackConfig({
+        filename: 'css/[name].[hash:8].css',
+        chunkFilename: 'css/[name].[chunkhash:8].async.css',
+      }),
+    );
+
+    const config = await getProdUtooPackConfig({
+      ...baseOpts,
+      config: {},
+    } as any);
+
+    expect(config.config.output?.cssFilename).toBe(
+      'css/[name].[contenthash:8].css',
+    );
+    expect(config.config.output?.cssChunkFilename).toBe(
+      'css/[name].[contenthash:8].async.css',
+    );
   });
 
   test('does not use name placeholder for multi-entry css output filename', async () => {
@@ -57,7 +169,8 @@ describe('utoopack mdx config', () => {
       config: {},
     } as any);
 
-    expect(config.config.output?.cssFilename).toBeUndefined();
+    expect(config.config.output?.cssFilename).toBe('[name].css');
+    expect(config.config.output?.cssChunkFilename).toBe('[name].chunk.css');
   });
 
   test('allows user css output filename override', async () => {
@@ -67,6 +180,7 @@ describe('utoopack mdx config', () => {
         utoopack: {
           output: {
             cssFilename: 'custom.css',
+            cssChunkFilename: 'custom.chunk.css',
           },
         },
       },
@@ -77,13 +191,16 @@ describe('utoopack mdx config', () => {
         utoopack: {
           output: {
             cssFilename: 'custom.css',
+            cssChunkFilename: 'custom.chunk.css',
           },
         },
       },
     } as any);
 
     expect(prodConfig.config.output?.cssFilename).toBe('custom.css');
+    expect(prodConfig.config.output?.cssChunkFilename).toBe('custom.chunk.css');
     expect(devConfig.config.output?.cssFilename).toBe('custom.css');
+    expect(devConfig.config.output?.cssChunkFilename).toBe('custom.chunk.css');
   });
 
   test('passes mdx flag to production utoopack config', async () => {

--- a/packages/bundler-utoopack/src/config.ts
+++ b/packages/bundler-utoopack/src/config.ts
@@ -6,6 +6,7 @@ import { compatOptionsFromWebpack } from '@utoo/pack';
 import fs from 'fs';
 import { basename, dirname, extname, resolve as pathResolve } from 'path';
 import type { IOpts } from './types';
+import { getCssOutputFilenames, getSSRCssSplitChunks } from './util';
 
 function getUtoopackDefine(opts: { config: Record<string, any> }) {
   const define = Object.fromEntries(
@@ -450,12 +451,6 @@ function getUserUtoopackConfig(utoopackConfig: Record<string, any> = {}) {
   return lodash.omit(utoopackConfig, ['babelLoader', 'root']);
 }
 
-function getEntryCssFilename(entry: Record<string, string>) {
-  const entryNames = Object.keys(entry || {});
-
-  return entryNames.length === 1 ? `${entryNames[0]}.css` : undefined;
-}
-
 function getDefaultPersistentCaching() {
   return process.platform !== 'win32';
 }
@@ -516,7 +511,12 @@ export async function getProdUtooPackConfig(
     mdx,
   } = opts.config;
   const userUtoopackConfig = getUserUtoopackConfig(opts.config.utoopack);
-  const entryCssFilename = getEntryCssFilename(opts.entry);
+  const cssOutputFilenames = getCssOutputFilenames({
+    entry: opts.entry,
+    config: opts.config,
+    webpackConfig: webpackConfig as WebpackConfig,
+    useHash: !!opts.config.hash,
+  });
 
   utooBundlerOpts = {
     ...utooBundlerOpts,
@@ -526,7 +526,7 @@ export async function getProdUtooPackConfig(
       {
         output: {
           clean: opts.clean,
-          ...(entryCssFilename ? { cssFilename: entryCssFilename } : {}),
+          ...cssOutputFilenames,
           publicPath: runtimePublicPath ? 'runtime' : publicPath || '/',
           ...(opts.disableCopy
             ? { copy: [] }
@@ -535,6 +535,7 @@ export async function getProdUtooPackConfig(
         optimization: {
           modularizeImports,
           concatenateModules: true,
+          ...getSSRCssSplitChunks(opts.config),
         },
         resolve: {
           alias: getNormalizedAlias(
@@ -707,7 +708,12 @@ export async function getDevUtooPackConfig(
     mdx,
   } = opts.config;
   const userUtoopackConfig = getUserUtoopackConfig(opts.config.utoopack);
-  const entryCssFilename = getEntryCssFilename(opts.entry);
+  const cssOutputFilenames = getCssOutputFilenames({
+    entry: opts.entry,
+    config: opts.config,
+    webpackConfig: webpackConfig as WebpackConfig,
+    useHash: false,
+  });
 
   utooBundlerOpts = {
     ...utooBundlerOpts,
@@ -724,7 +730,7 @@ export async function getDevUtooPackConfig(
       {
         output: {
           clean: opts.clean === undefined ? true : opts.clean,
-          ...(entryCssFilename ? { cssFilename: entryCssFilename } : {}),
+          ...cssOutputFilenames,
           publicPath: runtimePublicPath ? 'runtime' : publicPath || '/',
           ...(opts.disableCopy
             ? { copy: [] }

--- a/packages/bundler-utoopack/src/util.test.ts
+++ b/packages/bundler-utoopack/src/util.test.ts
@@ -1,5 +1,18 @@
 import { stripAnsi } from '@umijs/utils';
-import { getBuildBanner, getDevBanner } from './util';
+import {
+  getBuildBanner,
+  getCssOutputFilenames,
+  getDevBanner,
+  getSSRCssSplitChunks,
+} from './util';
+
+class MiniCssExtractPlugin {
+  options: { filename?: string; chunkFilename?: string };
+
+  constructor(options: { filename?: string; chunkFilename?: string }) {
+    this.options = options;
+  }
+}
 
 describe('getDevBanner', () => {
   const originalVersion = process.env.UTOOPACK_VERSION;
@@ -42,5 +55,107 @@ describe('getDevBanner', () => {
     expect(banner).toContain('utoo pack v1.3.11 built in 2345ms');
     expect(banner).toContain('➜  Output:  dist');
     expect(banner).toContain('➜  Assets:  6 files');
+  });
+});
+
+describe('getCssOutputFilenames', () => {
+  test('returns default css output filename placeholders', () => {
+    expect(
+      getCssOutputFilenames({
+        entry: {
+          index: './src/index.tsx',
+        },
+        config: {},
+        webpackConfig: {
+          webpackMode: true,
+        },
+        useHash: false,
+      }),
+    ).toEqual({
+      cssFilename: '[name].css',
+      cssChunkFilename: '[name].chunk.css',
+    });
+  });
+
+  test('returns hashed default css output filenames', () => {
+    expect(
+      getCssOutputFilenames({
+        entry: {
+          index: './src/index.tsx',
+        },
+        config: {
+          hash: true,
+        },
+        webpackConfig: {
+          webpackMode: true,
+        },
+        useHash: true,
+      }),
+    ).toEqual({
+      cssFilename: '[name].[contenthash:8].css',
+      cssChunkFilename: '[name].[contenthash:8].chunk.css',
+    });
+  });
+
+  test('returns ssr css output filenames', () => {
+    expect(
+      getCssOutputFilenames({
+        entry: {
+          index: './src/index.tsx',
+        },
+        config: {
+          ssr: {},
+        },
+        webpackConfig: {
+          webpackMode: true,
+        },
+        useHash: false,
+      }),
+    ).toEqual({
+      cssFilename: 'index.css',
+      cssChunkFilename: 'umi.css',
+    });
+  });
+
+  test('uses mini-css-extract templates from webpack config', () => {
+    expect(
+      getCssOutputFilenames({
+        entry: {
+          index: './src/index.tsx',
+        },
+        config: {},
+        webpackConfig: {
+          webpackMode: true,
+          plugins: [
+            new MiniCssExtractPlugin({
+              filename: 'css/[name].[hash:8].css',
+              chunkFilename: 'css/[name].[chunkhash:8].async.css',
+            }),
+          ],
+        },
+        useHash: false,
+      }),
+    ).toEqual({
+      cssFilename: 'css/[name].[contenthash:8].css',
+      cssChunkFilename: 'css/[name].[contenthash:8].async.css',
+    });
+  });
+});
+
+describe('getSSRCssSplitChunks', () => {
+  test('returns empty config for non-ssr builds', () => {
+    expect(getSSRCssSplitChunks({})).toEqual({});
+  });
+
+  test('returns css split chunk config for ssr builds', () => {
+    expect(getSSRCssSplitChunks({ ssr: {} })).toEqual({
+      splitChunks: {
+        css: {
+          minChunkSize: 100_000_000,
+          maxChunkCountPerGroup: 1,
+          maxMergeChunkSize: 100_000_000,
+        },
+      },
+    });
   });
 });

--- a/packages/bundler-utoopack/src/util.ts
+++ b/packages/bundler-utoopack/src/util.ts
@@ -1,4 +1,5 @@
 import { chalk } from '@umijs/utils';
+import type { WebpackConfig } from '@utoo/pack';
 
 type IDevBannerOpts = {
   duration?: number;
@@ -49,6 +50,103 @@ function formatDuration(duration?: number) {
   }
 
   return `${Math.max(0, Math.round(duration))}ms`;
+}
+
+function normalizeUtoopackFilenameTemplate(filename: string) {
+  return filename.replace(
+    /\[(?:hash|chunkhash)(?::(\d+))?\]/g,
+    (_, length) => `[contenthash${length ? `:${length}` : ''}]`,
+  );
+}
+
+function getMiniCssExtractPluginOptions(
+  webpackConfig: WebpackConfig,
+): { filename?: string; chunkFilename?: string } | undefined {
+  const plugin = webpackConfig.plugins?.find((p: any) => {
+    return (
+      p &&
+      typeof p === 'object' &&
+      p.constructor?.name === 'MiniCssExtractPlugin'
+    );
+  });
+
+  return (plugin as any)?.options;
+}
+
+function getEntryCssFilename(
+  entry: Record<string, string>,
+  filenameTemplate: string,
+  replaceName: boolean,
+) {
+  const normalizedFilenameTemplate =
+    normalizeUtoopackFilenameTemplate(filenameTemplate);
+
+  if (!replaceName) {
+    return normalizedFilenameTemplate;
+  }
+
+  const entryNames = Object.keys(entry || {});
+
+  if (entryNames.length !== 1) {
+    return undefined;
+  }
+
+  return normalizedFilenameTemplate.replace(/\[name\]/g, entryNames[0]);
+}
+
+export function getCssOutputFilenames(opts: {
+  entry: Record<string, string>;
+  config: Record<string, any>;
+  webpackConfig: WebpackConfig;
+  useHash: boolean;
+}) {
+  const miniCssExtractOptions = getMiniCssExtractPluginOptions(
+    opts.webpackConfig,
+  );
+  const hash = opts.useHash ? '.[contenthash:8]' : '';
+  const cssFilenameTemplate =
+    typeof miniCssExtractOptions?.filename === 'string'
+      ? miniCssExtractOptions.filename
+      : `[name]${hash}.css`;
+  let cssChunkFilenameTemplate =
+    typeof miniCssExtractOptions?.chunkFilename === 'string'
+      ? miniCssExtractOptions.chunkFilename
+      : undefined;
+
+  if (!cssChunkFilenameTemplate) {
+    cssChunkFilenameTemplate = opts.config.ssr
+      ? `umi${hash}.css`
+      : `[name]${hash}.chunk.css`;
+  }
+
+  const cssFilename = getEntryCssFilename(
+    opts.entry,
+    cssFilenameTemplate,
+    !!opts.config.ssr,
+  );
+
+  return {
+    ...(cssFilename ? { cssFilename } : {}),
+    cssChunkFilename: normalizeUtoopackFilenameTemplate(
+      cssChunkFilenameTemplate,
+    ),
+  };
+}
+
+export function getSSRCssSplitChunks(config: Record<string, any>) {
+  if (!config.ssr) {
+    return {};
+  }
+
+  return {
+    splitChunks: {
+      css: {
+        minChunkSize: 100_000_000,
+        maxChunkCountPerGroup: 1,
+        maxMergeChunkSize: 100_000_000,
+      },
+    },
+  };
 }
 
 export function getDevBanner({

--- a/packages/preset-umi/src/commands/dev/createRouteMiddleware.ts
+++ b/packages/preset-umi/src/commands/dev/createRouteMiddleware.ts
@@ -16,8 +16,12 @@ function createRouteMiddleware(opts: { api: IApi }) {
 
     async function getStats(api: IApi) {
       if (!compiler && (api.config.mako || api.config.utoopack)) {
+        const assets: Record<string, string> = { 'umi.js': 'umi.js' };
+        if (api.config.mako) {
+          assets['umi.css'] = 'umi.css';
+        }
         return {
-          compilation: { assets: { 'umi.js': 'umi.js', 'umi.css': 'umi.css' } },
+          compilation: { assets },
           hasErrors: () => false,
         };
       }


### PR DESCRIPTION
cssFilename 支持从 `mini-css-extra-plugin` 里面转换配置:

- cssFilename
- cssChunkFilename

如果没有配置 `mini-css-extra-plugin`，走之前默认的转换逻辑，适配 Bigfish 场景的 css chunk hash filename。