### PR TITLE
fix(plugins): guard model import for utoopack windows

### DIFF
--- a/packages/plugins/src/access.ts
+++ b/packages/plugins/src/access.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { join } from 'path';
 import { IApi } from 'umi';
-import { withTmpPath } from './utils/withTmpPath';
+import { getPluginModelImport, withTmpPath } from './utils/withTmpPath';
 
 export default (api: IApi) => {
   api.describe({
@@ -27,7 +27,10 @@ import React from 'react';${
         hasAccessFile
           ? `
 import accessFactory from '@/access';
-import { useModel } from '@@/plugin-model';
+import { useModel } from '${getPluginModelImport({
+              api,
+              from: 'runtime.tsx',
+            })}';
 `
           : ''
       }

--- a/packages/plugins/src/initial-state.ts
+++ b/packages/plugins/src/initial-state.ts
@@ -1,5 +1,5 @@
 import { IApi, RUNTIME_TYPE_FILE_NAME } from 'umi';
-import { withTmpPath } from './utils/withTmpPath';
+import { getPluginModelImport, withTmpPath } from './utils/withTmpPath';
 
 export default (api: IApi) => {
   api.describe({
@@ -38,7 +38,10 @@ export default (api: IApi) => {
       path: 'Provider.tsx',
       content: `
 import React from 'react';
-import { useModel } from '@@/plugin-model';
+import { useModel } from '${getPluginModelImport({
+        api,
+        from: 'Provider.tsx',
+      })}';
 ${
   loading
     ? `import Loading from '${loading}'`

--- a/packages/plugins/src/layout.ts
+++ b/packages/plugins/src/layout.ts
@@ -4,7 +4,7 @@ import { IApi, RUNTIME_TYPE_FILE_NAME } from 'umi';
 import { lodash, Mustache, semver, winPath } from 'umi/plugin-utils';
 import { isFlattedNodeModulesDir } from './utils/npmClient';
 import { resolveProjectDep } from './utils/resolveProjectDep';
-import { withTmpPath } from './utils/withTmpPath';
+import { getPluginModelImport, withTmpPath } from './utils/withTmpPath';
 
 // 获取所有 icons
 const antIconsPath = winPath(
@@ -155,7 +155,10 @@ import Exception from './Exception';
 import { getRightRenderContent } from './rightRender';
 ${
   hasInitialStatePlugin
-    ? `import { useModel } from '@@/plugin-model';`
+    ? `import { useModel } from '${getPluginModelImport({
+        api,
+        from: 'Layout.tsx',
+      })}';`
     : 'const useModel = null;'
 }
 ${

--- a/packages/plugins/src/qiankun/master.ts
+++ b/packages/plugins/src/qiankun/master.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { IApi, RUNTIME_TYPE_FILE_NAME } from 'umi';
 import { winPath } from 'umi/plugin-utils';
-import { withTmpPath } from '../utils/withTmpPath';
+import { getPluginModelImport, withTmpPath } from '../utils/withTmpPath';
 import {
   defaultHistoryType,
   defaultMasterRootId,
@@ -191,7 +191,10 @@ export const setMasterOptions = (newOpts) => options = ({ ...options, ...newOpts
             .replace(
               '__USE_MODEL__',
               api.isPluginEnable('model')
-                ? `import { useModel } from '@@/plugin-model'`
+                ? `import { useModel } from '${getPluginModelImport({
+                    api,
+                    from: 'masterRuntimePlugin.tsx',
+                  })}'`
                 : `console.warn(\`[plugins/qiankun]: Seems like you're not using @umijs/plugin-model, you need to install it or some features may not work!\`);\nconst useModel = null`,
             )
             .replace(

--- a/packages/plugins/src/qiankun/slave.ts
+++ b/packages/plugins/src/qiankun/slave.ts
@@ -15,7 +15,7 @@ import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { IApi, RUNTIME_TYPE_FILE_NAME } from 'umi';
 import { winPath } from 'umi/plugin-utils';
-import { withTmpPath } from '../utils/withTmpPath';
+import { getPluginModelImport, withTmpPath } from '../utils/withTmpPath';
 import { qiankunStateFromMasterModelNamespace } from './constants';
 
 type SlaveOptions = any;
@@ -290,7 +290,10 @@ if (!isServer && !window.__POWERED_BY_QIANKUN__) {
             .replace(
               '__USE_MODEL__',
               api.isPluginEnable('model')
-                ? `import { useModel } from '@@/plugin-model'`
+                ? `import { useModel } from '${getPluginModelImport({
+                    api,
+                    from: 'slaveRuntimePlugin.ts',
+                  })}'`
                 : `console.warn(\`[plugins/qiankun]: Seems like you're not using @umijs/plugin-model, you need to install it or some features may not work!\`);\nconst useModel = null`,
             )
             .replace(

--- a/packages/plugins/src/utils/withTmpPath.ts
+++ b/packages/plugins/src/utils/withTmpPath.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { dirname, join, relative } from 'path';
 import { IApi } from 'umi';
 import { winPath } from 'umi/plugin-utils';
 
@@ -16,4 +16,24 @@ export function withTmpPath(opts: {
       opts.path,
     ),
   );
+}
+
+function withTmpPluginPath(opts: { api: IApi; pluginKey: string }) {
+  return winPath(join(opts.api.paths.absTmpPath, `plugin-${opts.pluginKey}`));
+}
+
+export function isUtooWin(api: IApi) {
+  return process.platform === 'win32' && api.appData.bundler === 'utoopack';
+}
+
+export function getPluginModelImport(opts: { api: IApi; from: string }) {
+  if (!isUtooWin(opts.api)) {
+    return '@@/plugin-model';
+  }
+
+  const from = withTmpPath({ api: opts.api, path: opts.from });
+  const to = withTmpPluginPath({ api: opts.api, pluginKey: 'model' });
+  const relPath = winPath(relative(dirname(from), to));
+
+  return relPath.startsWith('.') ? relPath : `./${relPath}`;
 }


### PR DESCRIPTION
closes: https://github.com/umijs/umi/issues/13331

构造了一个 windows 的 ci 来 e2e 测试这个 case，e2e 测试正常通过了: 

https://github.com/umijs/umi/actions/runs/26812382235/job/79045436575

通过 playwright 在 windows ci 上验证 use-model examples 的页面能否正常渲染。