### PR TITLE
test: verify utoopack windows runtime without fallbacks

### DIFF
--- a/.github/workflows/e2e-utoopack-windows.yml
+++ b/.github/workflows/e2e-utoopack-windows.yml
@@ -1,0 +1,202 @@
+name: e2e-utoopack-windows
+
+env:
+  NODE_OPTIONS: --max-old-space-size=6144
+
+on:
+  pull_request:
+    types:
+      - 'opened'
+      - 'synchronize'
+  workflow_dispatch:
+    inputs:
+      utoo-pack-version:
+        description: '@utoo/pack version to verify, leave empty to use the pinned version'
+        required: false
+        default: ''
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-utoopack-windows:
+    timeout-minutes: 60
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Setup Global Cypress-cache-folder in Windows
+        run: echo "CYPRESS_CACHE_FOLDER=${HOME}\.cache\Cypress"  >> $env:GITHUB_ENV
+
+      - name: Install dependencies
+        run: pnpm i
+
+      - name: Override @utoo/pack
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.utoo-pack-version != '' }}
+        shell: bash
+        env:
+          UTOO_PACK_VERSION: ${{ inputs.utoo-pack-version }}
+        run: pnpm --filter @umijs/bundler-utoopack add "@utoo/pack@${UTOO_PACK_VERSION}"
+
+      - name: Print @utoo/pack version
+        shell: bash
+        run: pnpm --filter @umijs/bundler-utoopack exec node -p "require('@utoo/pack/package.json').version"
+
+      - name: Enable utoopack in with-use-model example
+        shell: bash
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const configPath = 'examples/with-use-model/.umirc.ts';
+          const config = fs.readFileSync(configPath, 'utf8');
+          if (!config.includes('utoopack')) {
+            fs.writeFileSync(configPath, config.replace(/\n};\s*$/, '\n  utoopack: {},\n};\n'));
+          }
+          NODE
+
+      - name: Build targets
+        run: pnpm umi-scripts turbo build
+          --filter ./packages/umi/...
+          --filter ./packages/plugins/...
+          --filter ./packages/bundler-utoopack/...
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install chromium
+
+      - name: e2e:example:with-use-model:dev:utoopack
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd examples/with-use-model
+          FORCE_UTOOPACK=1 PORT=9527 pnpm dev > ../../with-use-model.log 2>&1 &
+          server_pid=$!
+          trap 'kill "$server_pid" 2>/dev/null || true; cat ../../with-use-model.log' EXIT
+
+          node --input-type=module <<'NODE'
+          const url = 'http://127.0.0.1:9527/';
+          const started = Date.now();
+          const timeout = 120000;
+          const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+          while (Date.now() - started < timeout) {
+            try {
+              const res = await fetch(url);
+              if (res.ok) process.exit(0);
+            } catch {}
+            await sleep(1000);
+          }
+          throw new Error(`Timed out waiting for ${url}`);
+          NODE
+
+          for i in {1..120}; do
+            if grep -Eq "utoo pack v.* ready" ../../with-use-model.log; then
+              break
+            fi
+            if ! kill -0 "$server_pid" 2>/dev/null; then
+              cat ../../with-use-model.log
+              exit 1
+            fi
+            if [ "$i" -eq 120 ]; then
+              cat ../../with-use-model.log
+              echo "Timed out waiting for utoopack dev server ready log"
+              exit 1
+            fi
+            sleep 1
+          done
+
+          node --input-type=module <<'NODE'
+          import { chromium } from 'playwright-chromium';
+          async function dumpBundleDiagnostics(page, errors) {
+            const stack = errors.join('\n');
+            const locations = [
+              ...stack.matchAll(/(https?:\/\/[^\s)]+\.js):(\d+):(\d+)/g),
+            ].map((match) => ({ url: match[1], line: Number(match[2]) }));
+            const scripts = await page
+              .locator('script[src]')
+              .evaluateAll((nodes) => nodes.map((node) => node.src))
+              .catch(() => []);
+            const urls = [...new Set([...locations.map((loc) => loc.url), ...scripts])];
+
+            console.log('Loaded script urls:');
+            for (const url of urls) {
+              console.log(`- ${url}`);
+            }
+
+            for (const url of urls) {
+              let source = '';
+              try {
+                source = await fetch(url).then((res) => res.text());
+              } catch (e) {
+                console.log(`Failed to fetch ${url}: ${e.message}`);
+                continue;
+              }
+
+              const lines = source.split(/\r?\n/);
+              console.log(`\n--- Diagnostics for ${url} (${lines.length} lines) ---`);
+
+              for (const loc of locations.filter((loc) => loc.url === url).slice(0, 4)) {
+                const start = Math.max(1, loc.line - 8);
+                const end = Math.min(lines.length, loc.line + 8);
+                console.log(`Stack source around line ${loc.line}:`);
+                for (let i = start; i <= end; i += 1) {
+                  console.log(`${i}: ${lines[i - 1]}`);
+                }
+              }
+
+              let matches = 0;
+              const needles = ['plugin-model', 'useModel', 'InitialStateProvider', 'createContext'];
+              lines.forEach((line, index) => {
+                if (matches >= 80) return;
+                if (needles.some((needle) => line.includes(needle))) {
+                  console.log(`match ${index + 1}: ${line.slice(0, 500)}`);
+                  matches += 1;
+                }
+              });
+            }
+          }
+
+          const browser = await chromium.launch();
+          const page = await browser.newPage();
+          const errors = [];
+          page.on('pageerror', (error) => errors.push(error.stack || error.message));
+          page.on('console', (message) => {
+            if (message.type() === 'error') errors.push(message.text());
+          });
+          await page.goto('http://127.0.0.1:9527/', { waitUntil: 'domcontentloaded' });
+          const expectedTexts = ['todos', 'foo', 'bar', 'count', '123'];
+          const started = Date.now();
+          let text = '';
+          while (Date.now() - started < 60000) {
+            text = await page.locator('body').innerText().catch(() => '');
+            if (errors.length) {
+              await dumpBundleDiagnostics(page, errors);
+              await browser.close();
+              throw new Error(`Browser runtime errors:\n${errors.join('\n')}\n\nBody:\n${text}`);
+            }
+            if (expectedTexts.every((expected) => text.includes(expected))) {
+              await browser.close();
+              process.exit(0);
+            }
+            if (text.includes('Bundling...')) {
+              await page.reload({ waitUntil: 'domcontentloaded' }).catch(() => {});
+            }
+            await page.waitForTimeout(1000);
+          }
+          await browser.close();
+          throw new Error(
+            `Timed out waiting for page text.\nExpected: ${expectedTexts.join(', ')}\nLast body:\n${text}\nRuntime errors:\n${errors.join('\n') || '(none)'}`,
+          );
+          NODE
+        env:
+          FORCE_UTOOPACK: 1

--- a/packages/bundler-utoopack/package.json
+++ b/packages/bundler-utoopack/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@umijs/bundler-utils": "workspace:*",
     "@umijs/bundler-webpack": "workspace:*",
-    "@utoo/pack": "1.4.12-alpha.10",
+    "@utoo/pack": "1.4.12",
     "compression": "^1.7.4",
     "connect-history-api-fallback": "^2.0.0",
     "cors": "^2.8.5",

--- a/packages/plugins/src/access.ts
+++ b/packages/plugins/src/access.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { join } from 'path';
 import { IApi } from 'umi';
-import { getPluginModelImport, withTmpPath } from './utils/withTmpPath';
+import { withTmpPath } from './utils/withTmpPath';
 
 export default (api: IApi) => {
   api.describe({
@@ -27,10 +27,7 @@ import React from 'react';${
         hasAccessFile
           ? `
 import accessFactory from '@/access';
-import { useModel } from '${getPluginModelImport({
-              api,
-              from: 'runtime.tsx',
-            })}';
+import { useModel } from '@@/plugin-model';
 `
           : ''
       }

--- a/packages/plugins/src/antd.ts
+++ b/packages/plugins/src/antd.ts
@@ -6,7 +6,7 @@ import { IApi, RUNTIME_TYPE_FILE_NAME } from 'umi';
 import { deepmerge, semver, winPath } from 'umi/plugin-utils';
 import { TEMPLATES_DIR } from './constants';
 import { resolveProjectDep } from './utils/resolveProjectDep';
-import { isUtooWin, withTmpPath } from './utils/withTmpPath';
+import { withTmpPath } from './utils/withTmpPath';
 
 const ANTD_TEMPLATES_DIR = join(TEMPLATES_DIR, 'antd');
 
@@ -370,7 +370,6 @@ export default (api: IApi) => {
         // 是否启用了 theme algorithm
         enableModernThemeAlgorithm,
         antdConfigSetter,
-        isUtooWin: isUtooWin(api),
         modelPluginCompat,
         lodashPath,
         /**

--- a/packages/plugins/src/initial-state.ts
+++ b/packages/plugins/src/initial-state.ts
@@ -1,5 +1,5 @@
 import { IApi, RUNTIME_TYPE_FILE_NAME } from 'umi';
-import { getPluginModelImport, withTmpPath } from './utils/withTmpPath';
+import { withTmpPath } from './utils/withTmpPath';
 
 export default (api: IApi) => {
   api.describe({
@@ -38,10 +38,7 @@ export default (api: IApi) => {
       path: 'Provider.tsx',
       content: `
 import React from 'react';
-import { useModel } from '${getPluginModelImport({
-        api,
-        from: 'Provider.tsx',
-      })}';
+import { useModel } from '@@/plugin-model';
 ${
   loading
     ? `import Loading from '${loading}'`

--- a/packages/plugins/src/layout.ts
+++ b/packages/plugins/src/layout.ts
@@ -4,7 +4,7 @@ import { IApi, RUNTIME_TYPE_FILE_NAME } from 'umi';
 import { lodash, Mustache, semver, winPath } from 'umi/plugin-utils';
 import { isFlattedNodeModulesDir } from './utils/npmClient';
 import { resolveProjectDep } from './utils/resolveProjectDep';
-import { getPluginModelImport, withTmpPath } from './utils/withTmpPath';
+import { withTmpPath } from './utils/withTmpPath';
 
 // 获取所有 icons
 const antIconsPath = winPath(
@@ -155,10 +155,7 @@ import Exception from './Exception';
 import { getRightRenderContent } from './rightRender';
 ${
   hasInitialStatePlugin
-    ? `import { useModel } from '${getPluginModelImport({
-        api,
-        from: 'Layout.tsx',
-      })}';`
+    ? `import { useModel } from '@@/plugin-model';`
     : 'const useModel = null;'
 }
 ${

--- a/packages/plugins/src/qiankun/master.ts
+++ b/packages/plugins/src/qiankun/master.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { IApi, RUNTIME_TYPE_FILE_NAME } from 'umi';
 import { winPath } from 'umi/plugin-utils';
-import { getPluginModelImport, withTmpPath } from '../utils/withTmpPath';
+import { withTmpPath } from '../utils/withTmpPath';
 import {
   defaultHistoryType,
   defaultMasterRootId,
@@ -191,10 +191,7 @@ export const setMasterOptions = (newOpts) => options = ({ ...options, ...newOpts
             .replace(
               '__USE_MODEL__',
               api.isPluginEnable('model')
-                ? `import { useModel } from '${getPluginModelImport({
-                    api,
-                    from: 'masterRuntimePlugin.tsx',
-                  })}'`
+                ? `import { useModel } from '@@/plugin-model'`
                 : `console.warn(\`[plugins/qiankun]: Seems like you're not using @umijs/plugin-model, you need to install it or some features may not work!\`);\nconst useModel = null`,
             )
             .replace(

--- a/packages/plugins/src/qiankun/slave.ts
+++ b/packages/plugins/src/qiankun/slave.ts
@@ -15,7 +15,7 @@ import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { IApi, RUNTIME_TYPE_FILE_NAME } from 'umi';
 import { winPath } from 'umi/plugin-utils';
-import { getPluginModelImport, withTmpPath } from '../utils/withTmpPath';
+import { withTmpPath } from '../utils/withTmpPath';
 import { qiankunStateFromMasterModelNamespace } from './constants';
 
 type SlaveOptions = any;
@@ -290,10 +290,7 @@ if (!isServer && !window.__POWERED_BY_QIANKUN__) {
             .replace(
               '__USE_MODEL__',
               api.isPluginEnable('model')
-                ? `import { useModel } from '${getPluginModelImport({
-                    api,
-                    from: 'slaveRuntimePlugin.ts',
-                  })}'`
+                ? `import { useModel } from '@@/plugin-model'`
                 : `console.warn(\`[plugins/qiankun]: Seems like you're not using @umijs/plugin-model, you need to install it or some features may not work!\`);\nconst useModel = null`,
             )
             .replace(

--- a/packages/plugins/src/utils/withTmpPath.ts
+++ b/packages/plugins/src/utils/withTmpPath.ts
@@ -1,4 +1,4 @@
-import { dirname, join, relative } from 'path';
+import { join } from 'path';
 import { IApi } from 'umi';
 import { winPath } from 'umi/plugin-utils';
 
@@ -16,24 +16,4 @@ export function withTmpPath(opts: {
       opts.path,
     ),
   );
-}
-
-function withTmpPluginPath(opts: { api: IApi; pluginKey: string }) {
-  return winPath(join(opts.api.paths.absTmpPath, `plugin-${opts.pluginKey}`));
-}
-
-export function isUtooWin(api: IApi) {
-  return process.platform === 'win32' && api.appData.bundler === 'utoopack';
-}
-
-export function getPluginModelImport(opts: { api: IApi; from: string }) {
-  if (!isUtooWin(opts.api)) {
-    return '@@/plugin-model';
-  }
-
-  const from = withTmpPath({ api: opts.api, path: opts.from });
-  const to = withTmpPluginPath({ api: opts.api, pluginKey: 'model' });
-  const relPath = winPath(relative(dirname(from), to));
-
-  return relPath.startsWith('.') ? relPath : `./${relPath}`;
 }

--- a/packages/plugins/templates/antd/runtime.ts.tpl
+++ b/packages/plugins/templates/antd/runtime.ts.tpl
@@ -30,9 +30,9 @@ import merge from '{{{lodashPath.merge}}}'
 
 let cacheAntdConfig = null;
 
-const getAntdConfig = ({{#isUtooWin}}runtimePluginManager?: any{{/isUtooWin}}) => {
+const getAntdConfig = () => {
   if(!cacheAntdConfig){
-    cacheAntdConfig = {{#isUtooWin}}(runtimePluginManager || getPluginManager()){{/isUtooWin}}{{^isUtooWin}}getPluginManager(){{/isUtooWin}}.applyPlugins({
+    cacheAntdConfig = getPluginManager().applyPlugins({
       key: 'antd',
       type: ApplyPluginsType.modify,
       initialValue: {
@@ -53,14 +53,14 @@ const getAntdConfig = ({{#isUtooWin}}runtimePluginManager?: any{{/isUtooWin}}) =
   return cacheAntdConfig;
 }
 
-function AntdProvider({ children{{#isUtooWin}}, pluginManager{{/isUtooWin}} }) {
+function AntdProvider({ children }) {
   let container = children;
 
   const [antdConfig, _setAntdConfig] = React.useState(() => {
     const {
       appConfig: _,
       ...finalConfigProvider
-    } = getAntdConfig({{#isUtooWin}}pluginManager{{/isUtooWin}});
+    } = getAntdConfig();
     {{#enableModernThemeAlgorithm}}
       finalConfigProvider.theme ??= {};
       finalConfigProvider.theme.algorithm ??= [];
@@ -155,9 +155,9 @@ function AntdProvider({ children{{#isUtooWin}}, pluginManager{{/isUtooWin}} }) {
   return container;
 }
 
-export function rootContainer(children{{#isUtooWin}}, opts{{/isUtooWin}}) {
+export function rootContainer(children) {
   return (
-    <AntdProvider{{#isUtooWin}} pluginManager={opts?.plugin}{{/isUtooWin}}>
+    <AntdProvider>
       {children}
     </AntdProvider>
   );
@@ -166,10 +166,10 @@ export function rootContainer(children{{#isUtooWin}}, opts{{/isUtooWin}}) {
 {{#appConfig}}
 // The App component should be under ConfigProvider
 // plugin-locale has other ConfigProvider
-export function innerProvider(container: any{{#isUtooWin}}, opts: any{{/isUtooWin}}) {
+export function innerProvider(container: any) {
   const {
     appConfig: finalAppConfig = {},
-  } = getAntdConfig({{#isUtooWin}}opts?.plugin{{/isUtooWin}});
+  } = getAntdConfig();
   return <App {...finalAppConfig}>{container}</App>;
 }
 {{/appConfig}}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2019,8 +2019,8 @@ importers:
         specifier: workspace:*
         version: link:../bundler-webpack
       '@utoo/pack':
-        specifier: 1.4.12-alpha.10
-        version: 1.4.12-alpha.10(less-loader@11.1.0)(less@4.1.3)(postcss@8.4.35)(resolve-url-loader@5.0.0)(sass-loader@13.2.0)(sass@1.54.0)
+        specifier: 1.4.12
+        version: 1.4.12(less-loader@11.1.0)(less@4.1.3)(postcss@8.4.35)(resolve-url-loader@5.0.0)(sass-loader@13.2.0)(sass@1.54.0)
       compression:
         specifier: ^1.7.4
         version: 1.7.4
@@ -21156,8 +21156,8 @@ packages:
       react: 18.3.1
     dev: false
 
-  /@utoo/pack-darwin-arm64@1.4.12-alpha.10:
-    resolution: {integrity: sha512-90xx7H6NZEFLsC6HiHr+VU+o6ALGhOXIomf3HWTuODm4Po43rjJc4s+HDXYM6RXdd66kMGOU24EQ2qUlgoYF1A==}
+  /@utoo/pack-darwin-arm64@1.4.12:
+    resolution: {integrity: sha512-02tZBShCSyPjnnmh4a2b7CS3YlrJZhGLSfEiFsUg3StZGSJXCgUHlpgcg+1105cNc77OrPFbwMdi+qhJTtwjJQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
@@ -21174,8 +21174,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-darwin-x64@1.4.12-alpha.10:
-    resolution: {integrity: sha512-JjO4WIRYC3Dl7nJrkuqM3VE/ssYq5VbAYhGllPDJFPhT36qh+4mq0zpMWBAa3NLFAJvfCWBuk2DbmzqWDzMjLw==}
+  /@utoo/pack-darwin-x64@1.4.12:
+    resolution: {integrity: sha512-On0zerp4EBpiu5tvHvzm+oKhYIIKOZPbD1GKyCgOrdcHY82mDw58LaGflBAVerkiFfxmR8sxUc2b8B4BFRhC1Q==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
@@ -21192,8 +21192,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-linux-arm64-gnu@1.4.12-alpha.10:
-    resolution: {integrity: sha512-5EpPk/p/t27PK+nGYIS7rUFzw7qi7yzgY/XSNClxxVHdboZ2tFJ5HekmTpXG/Gsf1WJ5l2DCeLX6597D1Sy3sA==}
+  /@utoo/pack-linux-arm64-gnu@1.4.12:
+    resolution: {integrity: sha512-xDf9IsgHJHuGA17x1To4WrjkpwbYzlnAWj1OusmtZ/1e6ekM8FUN1kEkORGWth8hGmNaA3vaSqYs7pUgQEMcaw==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -21210,8 +21210,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-linux-arm64-musl@1.4.12-alpha.10:
-    resolution: {integrity: sha512-ni8jSmLfV/9iBIW1EzX/O2GOg1pKd2ZDhFfkIbHi7BaxbbHaUdcxaNgAufjUW9AvxXoGC4pja79hptVrtEQEjQ==}
+  /@utoo/pack-linux-arm64-musl@1.4.12:
+    resolution: {integrity: sha512-gRk9WJ2bb407FsNz06aPaafv91aJRRfSQ9PsAbHViRF2P0Bs9T9ZpmHVH3SBsebVeT1NdY+j1jUE7vJYw0PFhw==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -21228,8 +21228,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-linux-x64-gnu@1.4.12-alpha.10:
-    resolution: {integrity: sha512-4krY3k530mKMmk0kkmBrZpc6QSzR5IKzLCQAIa2M4DP+3v9T7tJCYoyO/ODWs/bMcClzxoOlC/HuIapLAmYMuA==}
+  /@utoo/pack-linux-x64-gnu@1.4.12:
+    resolution: {integrity: sha512-G85pEaWhooK0jvjPI0jysJ9n9DwEEQ7x9vgeHqDUF0oTbOtDw0xNIb1YvbLl6zVI7gJObV9kghFdmEgvTuVL9A==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -21246,8 +21246,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-linux-x64-musl@1.4.12-alpha.10:
-    resolution: {integrity: sha512-M2gIuXbabU4YxkPWfYdlhPpaIiCaWKudLaW85SUrg2T0gjB5VMGXM6iTqfg0GDJpW2Bq6J+DTI+M+yf6V5oDzA==}
+  /@utoo/pack-linux-x64-musl@1.4.12:
+    resolution: {integrity: sha512-XFeqWXN6aPH5LP2Nbmtyu+lZ3KZHJ2qzt3ykTGfMf+NEkGxqzeTaTgz/v0K5ZyXXB1ueDTkLElKlvVqD7tQQsQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -21264,8 +21264,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-shared@1.4.12-alpha.10:
-    resolution: {integrity: sha512-qlGOO+Lk9TRiIDwU84L3yi9dnDBZD7I8DYaXQ0aQhZau9hrRe/nls9wI2dmUXHuTpwVgmt5LQkUMQmwOulyYtw==}
+  /@utoo/pack-shared@1.4.12:
+    resolution: {integrity: sha512-9wFLkCjBg4mPF7pr/S7voSy7bPX1L0Fkav8vqTjwp7CBPHElLkVJk81Sc7LU6i8+N3KnoI8esNsxnIWgLBQ9Ug==}
     engines: {node: '>= 20'}
     dependencies:
       '@babel/code-frame': 7.22.5
@@ -21280,8 +21280,8 @@ packages:
       picocolors: 1.1.1
     dev: true
 
-  /@utoo/pack-win32-x64-msvc@1.4.12-alpha.10:
-    resolution: {integrity: sha512-69knUy8i3yRrURyvKNxnrGdY/iGZGnInnqXKWP6LRwFfewhLtyKwuWIqeQ7AHJlMyv1iA3loWtMLnjjp4ZC2VA==}
+  /@utoo/pack-win32-x64-msvc@1.4.12:
+    resolution: {integrity: sha512-Fy/EHb5qlIKZCFLPCJ8LbEEU+TNm6Wvl5lTzsTvvFtFH5QHC/sr3IOwKVAnki3AaqlpCaMYWOoyXb3T4jdFfmQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
@@ -21298,8 +21298,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack@1.4.12-alpha.10(less-loader@11.1.0)(less@4.1.3)(postcss@8.4.35)(resolve-url-loader@5.0.0)(sass-loader@13.2.0)(sass@1.54.0):
-    resolution: {integrity: sha512-+Dxx/G4KqsWM+ibKlP7vtniUxodPTe0qBjd8AYpY6PS6Mp/jzJ1kwe4XK7vKfCDeY8pZOpzxG8x1AZ72Kjh8SQ==}
+  /@utoo/pack@1.4.12(less-loader@11.1.0)(less@4.1.3)(postcss@8.4.35)(resolve-url-loader@5.0.0)(sass-loader@13.2.0)(sass@1.54.0):
+    resolution: {integrity: sha512-dN0Sq7+Tp7ct9D5r+ULBp9IYdwj67yNsMW725mW4fURCf0QkPK6G15QEF/UKf1fsx37FehEjs+0mznznFUtTUw==}
     engines: {node: '>= 20'}
     peerDependencies:
       less: ^4.0.0
@@ -21317,7 +21317,7 @@ packages:
       '@hono/node-server': 1.19.11(hono@4.12.7)
       '@hono/node-ws': 1.3.0(@hono/node-server@1.19.11)(hono@4.12.7)
       '@swc/helpers': 0.5.15
-      '@utoo/pack-shared': 1.4.12-alpha.10
+      '@utoo/pack-shared': 1.4.12
       domparser-rs: 0.0.7
       find-up: 4.1.0
       get-port: 5.1.1
@@ -21334,13 +21334,13 @@ packages:
       send: 0.17.1
       ws: 8.18.3
     optionalDependencies:
-      '@utoo/pack-darwin-arm64': 1.4.12-alpha.10
-      '@utoo/pack-darwin-x64': 1.4.12-alpha.10
-      '@utoo/pack-linux-arm64-gnu': 1.4.12-alpha.10
-      '@utoo/pack-linux-arm64-musl': 1.4.12-alpha.10
-      '@utoo/pack-linux-x64-gnu': 1.4.12-alpha.10
-      '@utoo/pack-linux-x64-musl': 1.4.12-alpha.10
-      '@utoo/pack-win32-x64-msvc': 1.4.12-alpha.10
+      '@utoo/pack-darwin-arm64': 1.4.12
+      '@utoo/pack-darwin-x64': 1.4.12
+      '@utoo/pack-linux-arm64-gnu': 1.4.12
+      '@utoo/pack-linux-arm64-musl': 1.4.12
+      '@utoo/pack-linux-x64-gnu': 1.4.12
+      '@utoo/pack-linux-x64-musl': 1.4.12
+      '@utoo/pack-win32-x64-msvc': 1.4.12
     transitivePeerDependencies:
       - bufferutil
       - supports-color


### PR DESCRIPTION
### What changed

- Add a dedicated Windows GitHub Actions workflow for utoopack runtime verification.
- Use `examples/with-use-model` as a minimal model + initialState case.
- Enable utoopack in the example during CI without changing the example source.
- Bump `@umijs/bundler-utoopack` to `@utoo/pack@1.4.12` for verification.
- Trigger the workflow from PR updates (`opened` / `synchronize`) and manual `workflow_dispatch`.
- Revert the Umi-side Windows utoopack fallbacks from #13334 and #13335:
  - model import relative-path fallback for Windows + utoopack
  - antd runtime `opts.plugin` fallback for Windows + utoopack

### Why

This verifies whether `@utoo/pack@1.4.12` fixes the Windows utoopack runtime failure class at the bundler layer, without keeping Umi-side Windows-specific workarounds.

The failure class is plugin-generated modules splitting React context/module records and causing `useModel` / `initialState` runtime errors such as:

```text
TypeError: Cannot destructure property 'dispatcher' of 'useContext(...)' as it is null
    at useModel
    at InitialStateProvider
```

### Validation

- Windows e2e passed on `@utoo/pack@1.4.12`: https://github.com/umijs/umi/actions/runs/27009941723
- Job log confirmed `utoo pack v1.4.12 ready` and `e2e:example:with-use-model:dev:utoopack` completed successfully.