### PR TITLE
fix(utoopack): svgr should not work with inline asset

### DIFF
--- a/examples/with-svg/pages/bg.img.svg
+++ b/examples/with-svg/pages/bg.img.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1184px" height="120px" viewBox="0 0 1184 120" version="1.1" xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>banner</title>
+    <defs>
+        <linearGradient x1="0%" y1="49.4863952%" x2="64.328799%" y2="51.2511997%" id="linearGradient-1">
+            <stop stop-color="#4AB6FF" offset="0%"></stop>
+            <stop stop-color="#4692FF" offset="100%"></stop>
+        </linearGradient>
+        <path
+            d="M2,0 L1182,0 C1183.10457,-2.02906125e-16 1184,0.8954305 1184,2 L1184,120 L1184,120 L0,120 L0,2 C-1.3527075e-16,0.8954305 0.8954305,2.02906125e-16 2,0 Z"
+            id="path-2"></path>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="83.2669495%" id="linearGradient-4">
+            <stop stop-color="#FFFFFF" stop-opacity="0" offset="0%"></stop>
+            <stop stop-color="#68FFFF" stop-opacity="0.16" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="91.2632575%" id="linearGradient-5">
+            <stop stop-color="#FFFFFF" stop-opacity="0" offset="0%"></stop>
+            <stop stop-color="#68FFFF" stop-opacity="0.16" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="59.9205505%" y1="0%" x2="59.9205505%" y2="58.498623%" id="linearGradient-6">
+            <stop stop-color="#FFFFFF" stop-opacity="0" offset="0%"></stop>
+            <stop stop-color="#68FFFF" stop-opacity="0.16" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="83.2669495%" id="linearGradient-7">
+            <stop stop-color="#FFFFFF" stop-opacity="0" offset="0%"></stop>
+            <stop stop-color="#68FFFF" stop-opacity="0.16" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="50%" y1="57.8754399%" x2="69.987794%" y2="-30.4426258%" id="linearGradient-8">
+            <stop stop-color="#FFFFFF" stop-opacity="0" offset="0%"></stop>
+            <stop stop-color="#68FFFF" stop-opacity="0.16" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="50%" y1="57.8754399%" x2="54.2985513%" y2="-25.4561623%" id="linearGradient-9">
+            <stop stop-color="#FFFFFF" stop-opacity="0" offset="0%"></stop>
+            <stop stop-color="#68FFFF" stop-opacity="0.16" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="FIOS一期V0.1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="1.0-实验模版" transform="translate(-233.000000, -116.000000)">
+            <g id="背景" transform="translate(233.000000, 116.000000)">
+                <mask id="mask-3" fill="white">
+                    <use xlink:href="#path-2"></use>
+                </mask>
+                <use id="Mask" fill="url(#linearGradient-1)" xlink:href="#path-2"></use>
+                <path
+                    d="M993.5,-13 L1077,28.4198232 L996.837,68.338 L997,68.4198232 L913.5,110 L830,68.4198232 L910.319,28.578 L910,28.4198232 L993.5,-13 Z"
+                    id="Combined-Shape-Copy" fill="url(#linearGradient-4)" mask="url(#mask-3)"></path>
+                <polygon id="Combined-Shape-Copy" fill="url(#linearGradient-5)" mask="url(#mask-3)"
+                    points="913.489073 120.54881 913 68.4173797 830 81.0349513 830 162.13143"></polygon>
+                <polygon id="Combined-Shape-Copy" fill="url(#linearGradient-6)" mask="url(#mask-3)"
+                    points="913.474969 116.44593 913 28.4459304 1076.5 109.865754 1077 198"></polygon>
+                <path
+                    d="M498.5,-92 L582,-50.5801768 L501.837,-10.662 L502,-10.5801768 L418.5,31 L335,-10.5801768 L415.319,-50.422 L415,-50.5801768 L498.5,-92 Z"
+                    id="Combined-Shape-Copy-5" fill="url(#linearGradient-4)" mask="url(#mask-3)"></path>
+                <path
+                    d="M1262.5,7 L1346,48.4198232 L1265.837,88.338 L1266,88.4198232 L1182.5,130 L1099,88.4198232 L1179.319,48.578 L1179,48.4198232 L1262.5,7 Z"
+                    id="Combined-Shape-Copy-3" fill="url(#linearGradient-4)" opacity="0.400000006" mask="url(#mask-3)">
+                </path>
+                <path
+                    d="M78.5,7 L162,48.4198232 L81.837,88.338 L82,88.4198232 L-1.5,130 L-85,88.4198232 L-4.681,48.578 L-5,48.4198232 L78.5,7 Z"
+                    id="Combined-Shape-Copy-4" fill="url(#linearGradient-4)" mask="url(#mask-3)"></path>
+                <polygon id="Polygon" fill="url(#linearGradient-7)" opacity="0.699999988" mask="url(#mask-3)"
+                    points="763.5 45 810 68.5454013 763.5 92 717 68.5454013"></polygon>
+                <polygon id="Polygon" fill="url(#linearGradient-8)" opacity="0.699999988" mask="url(#mask-3)"
+                    points="717 119 763.5 142.545401 763.5 92.4545987 717 69"></polygon>
+                <polygon id="Polygon" fill="url(#linearGradient-9)" opacity="0.699999988" mask="url(#mask-3)"
+                    points="809.466539 119 763 142.526198 763 92.4353954 809.466539 69"></polygon>
+                <polygon id="Polygon-Copy-5" stroke="#60ACFF" opacity="0.400000006" mask="url(#mask-3)"
+                    transform="translate(763.500000, 54.500000) scale(1, -1) translate(-763.500000, -54.500000) "
+                    points="763.5 31 810 54.5454013 763.5 78 717 54.5454013"></polygon>
+                <path
+                    d="M993.5,-40 L1077,1.4198232 L996.837,41.338 L997,41.4198232 L913.5,83 L830,41.4198232 L910.319,1.578 L910,1.4198232 L993.5,-40 Z"
+                    id="Combined-Shape" stroke="#60ACFF" opacity="0.800000012" mask="url(#mask-3)"></path>
+                <path
+                    d="M609.5,58 L693,99.4198232 L612.837,139.338 L613,139.419823 L529.5,181 L446,139.419823 L526.319,99.578 L526,99.4198232 L609.5,58 Z"
+                    id="Combined-Shape-Copy-2" stroke="#60ACFF" mask="url(#mask-3)"></path>
+                <path
+                    d="M263.5,89 L347,130.419823 L266.837,170.338 L267,170.419823 L183.5,212 L100,170.419823 L180.319,130.578 L180,130.419823 L263.5,89 Z"
+                    id="Combined-Shape-Copy-6" stroke="#60ACFF" mask="url(#mask-3)"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/examples/with-svg/pages/index.less
+++ b/examples/with-svg/pages/index.less
@@ -1,0 +1,15 @@
+.backgroundImg {
+  background: url('./bg.img.svg');
+  background-repeat: no-repeat;
+  background-size: cover;
+  height: 120px;
+}
+
+@font-face {
+  font-family: 'UtooSvgFont';
+  src: url('./bg.img.svg') format('svg');
+}
+
+.icon {
+  font-family: 'UtooSvgFont';
+}

--- a/examples/with-svg/pages/index.tsx
+++ b/examples/with-svg/pages/index.tsx
@@ -1,10 +1,11 @@
 import Deploy from '../images/deploy.svg';
 import { ReactComponent as EmptyState } from '../images/emptyState.svg';
+import styles from './index.less';
 
 console.log('Deploy', Deploy);
 export default function Page() {
   return (
-    <div>
+    <div className={styles.backgroundImg}>
       <EmptyState />
     </div>
   );

--- a/packages/bundler-utoopack/package.json
+++ b/packages/bundler-utoopack/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@umijs/bundler-utils": "workspace:*",
     "@umijs/bundler-webpack": "workspace:*",
-    "@utoo/pack": "1.4.11",
+    "@utoo/pack": "1.4.12-alpha.10",
     "compression": "^1.7.4",
     "connect-history-api-fallback": "^2.0.0",
     "cors": "^2.8.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2019,8 +2019,8 @@ importers:
         specifier: workspace:*
         version: link:../bundler-webpack
       '@utoo/pack':
-        specifier: 1.4.11
-        version: 1.4.11(less-loader@11.1.0)(less@4.1.3)(postcss@8.4.35)(resolve-url-loader@5.0.0)(sass-loader@13.2.0)(sass@1.54.0)
+        specifier: 1.4.12-alpha.10
+        version: 1.4.12-alpha.10(less-loader@11.1.0)(less@4.1.3)(postcss@8.4.35)(resolve-url-loader@5.0.0)(sass-loader@13.2.0)(sass@1.54.0)
       compression:
         specifier: ^1.7.4
         version: 1.7.4
@@ -21156,8 +21156,8 @@ packages:
       react: 18.3.1
     dev: false
 
-  /@utoo/pack-darwin-arm64@1.4.11:
-    resolution: {integrity: sha512-xBEL22D+PbyxtiyLWisHkt3mv+nD+vSkNXR9l2ZbtE8jIPYSd8oXYjr9JYUhL7WkvT7cHZ+r60u+Y5HEqx0l2g==}
+  /@utoo/pack-darwin-arm64@1.4.12-alpha.10:
+    resolution: {integrity: sha512-90xx7H6NZEFLsC6HiHr+VU+o6ALGhOXIomf3HWTuODm4Po43rjJc4s+HDXYM6RXdd66kMGOU24EQ2qUlgoYF1A==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
@@ -21174,8 +21174,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-darwin-x64@1.4.11:
-    resolution: {integrity: sha512-1cfoXE+GvVym9AOexD41NCX6V4ugCvAwVb5ENTWZqY+MCDCJgzdCjFRfLtfti7vpyRczbuX5FphfoDhZg3hadg==}
+  /@utoo/pack-darwin-x64@1.4.12-alpha.10:
+    resolution: {integrity: sha512-JjO4WIRYC3Dl7nJrkuqM3VE/ssYq5VbAYhGllPDJFPhT36qh+4mq0zpMWBAa3NLFAJvfCWBuk2DbmzqWDzMjLw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
@@ -21192,8 +21192,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-linux-arm64-gnu@1.4.11:
-    resolution: {integrity: sha512-Er/uu9UJOPKfrGtFZwa1SQsa+o+GIkD9lytwySIrcoxBm1gtlTveDSyj7D4Dg/cY3nVmMGoQhhluN+iPW71qMw==}
+  /@utoo/pack-linux-arm64-gnu@1.4.12-alpha.10:
+    resolution: {integrity: sha512-5EpPk/p/t27PK+nGYIS7rUFzw7qi7yzgY/XSNClxxVHdboZ2tFJ5HekmTpXG/Gsf1WJ5l2DCeLX6597D1Sy3sA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -21210,8 +21210,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-linux-arm64-musl@1.4.11:
-    resolution: {integrity: sha512-L1FBkudER1XMiYIbFXt+icNTQnERsLQx2fliPeu0NbwQ6KT0CwzAPjFjp8prWpxXmK5Z0jV3tQX+11bedRJOIA==}
+  /@utoo/pack-linux-arm64-musl@1.4.12-alpha.10:
+    resolution: {integrity: sha512-ni8jSmLfV/9iBIW1EzX/O2GOg1pKd2ZDhFfkIbHi7BaxbbHaUdcxaNgAufjUW9AvxXoGC4pja79hptVrtEQEjQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -21228,8 +21228,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-linux-x64-gnu@1.4.11:
-    resolution: {integrity: sha512-foUYC6qmYeRZQOLw/nWlC6R9IkNvQ2tIVbKzD8stxl817JJUpS6KtFggEanUEPzYuQRuMDu96wQF5DWlCfrfLA==}
+  /@utoo/pack-linux-x64-gnu@1.4.12-alpha.10:
+    resolution: {integrity: sha512-4krY3k530mKMmk0kkmBrZpc6QSzR5IKzLCQAIa2M4DP+3v9T7tJCYoyO/ODWs/bMcClzxoOlC/HuIapLAmYMuA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -21246,8 +21246,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-linux-x64-musl@1.4.11:
-    resolution: {integrity: sha512-XN2Ml+oPpd8uOqmXs+N8hQAS+0MHY8WEm6cWjbhmyDSKE+TEgNwz7kHSs6HjeS1I8bzwLLxFz0x1oW0qkbPF4w==}
+  /@utoo/pack-linux-x64-musl@1.4.12-alpha.10:
+    resolution: {integrity: sha512-M2gIuXbabU4YxkPWfYdlhPpaIiCaWKudLaW85SUrg2T0gjB5VMGXM6iTqfg0GDJpW2Bq6J+DTI+M+yf6V5oDzA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -21264,8 +21264,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-shared@1.4.11:
-    resolution: {integrity: sha512-9e7qMoNGDiVbPxq4Mf3KAZvQbA5H0s0Tme7bMUBDm+ynAdfZMKfzGg4FEIZNHzF81LWJXxHNgUVnWxBNjnN2cg==}
+  /@utoo/pack-shared@1.4.12-alpha.10:
+    resolution: {integrity: sha512-qlGOO+Lk9TRiIDwU84L3yi9dnDBZD7I8DYaXQ0aQhZau9hrRe/nls9wI2dmUXHuTpwVgmt5LQkUMQmwOulyYtw==}
     engines: {node: '>= 20'}
     dependencies:
       '@babel/code-frame': 7.22.5
@@ -21280,8 +21280,8 @@ packages:
       picocolors: 1.1.1
     dev: true
 
-  /@utoo/pack-win32-x64-msvc@1.4.11:
-    resolution: {integrity: sha512-37evJkMY+NmRdu5Uw/cXfreUQar2mJMYdj/n10+vojecqZB4eoeZyHKFbOXi6hypJgztDc0cv2NWAwAyVin53A==}
+  /@utoo/pack-win32-x64-msvc@1.4.12-alpha.10:
+    resolution: {integrity: sha512-69knUy8i3yRrURyvKNxnrGdY/iGZGnInnqXKWP6LRwFfewhLtyKwuWIqeQ7AHJlMyv1iA3loWtMLnjjp4ZC2VA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
@@ -21298,8 +21298,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack@1.4.11(less-loader@11.1.0)(less@4.1.3)(postcss@8.4.35)(resolve-url-loader@5.0.0)(sass-loader@13.2.0)(sass@1.54.0):
-    resolution: {integrity: sha512-mGon1CR6yem/aV0mjmW7/h+o9JaU3QIq86kMwH5txLex+SJ/8FdtzXLkRX8dpAteLMox0U3RVDHOkMR5J6s8Hg==}
+  /@utoo/pack@1.4.12-alpha.10(less-loader@11.1.0)(less@4.1.3)(postcss@8.4.35)(resolve-url-loader@5.0.0)(sass-loader@13.2.0)(sass@1.54.0):
+    resolution: {integrity: sha512-+Dxx/G4KqsWM+ibKlP7vtniUxodPTe0qBjd8AYpY6PS6Mp/jzJ1kwe4XK7vKfCDeY8pZOpzxG8x1AZ72Kjh8SQ==}
     engines: {node: '>= 20'}
     peerDependencies:
       less: ^4.0.0
@@ -21317,7 +21317,7 @@ packages:
       '@hono/node-server': 1.19.11(hono@4.12.7)
       '@hono/node-ws': 1.3.0(@hono/node-server@1.19.11)(hono@4.12.7)
       '@swc/helpers': 0.5.15
-      '@utoo/pack-shared': 1.4.11
+      '@utoo/pack-shared': 1.4.12-alpha.10
       domparser-rs: 0.0.7
       find-up: 4.1.0
       get-port: 5.1.1
@@ -21334,13 +21334,13 @@ packages:
       send: 0.17.1
       ws: 8.18.3
     optionalDependencies:
-      '@utoo/pack-darwin-arm64': 1.4.11
-      '@utoo/pack-darwin-x64': 1.4.11
-      '@utoo/pack-linux-arm64-gnu': 1.4.11
-      '@utoo/pack-linux-arm64-musl': 1.4.11
-      '@utoo/pack-linux-x64-gnu': 1.4.11
-      '@utoo/pack-linux-x64-musl': 1.4.11
-      '@utoo/pack-win32-x64-msvc': 1.4.11
+      '@utoo/pack-darwin-arm64': 1.4.12-alpha.10
+      '@utoo/pack-darwin-x64': 1.4.12-alpha.10
+      '@utoo/pack-linux-arm64-gnu': 1.4.12-alpha.10
+      '@utoo/pack-linux-arm64-musl': 1.4.12-alpha.10
+      '@utoo/pack-linux-x64-gnu': 1.4.12-alpha.10
+      '@utoo/pack-linux-x64-musl': 1.4.12-alpha.10
+      '@utoo/pack-win32-x64-msvc': 1.4.12-alpha.10
     transitivePeerDependencies:
       - bufferutil
       - supports-color


### PR DESCRIPTION
## Summary

- extend `examples/with-svg` to cover SVG usage from both JS/SVGR imports and CSS URLs
- add a CSS background SVG case: `background: url('./bg.img.svg')`
- keep the existing `ReactComponent` SVG usage to verify normal SVGR imports remain supported

## Dependency

This example currently depends on the Utoo/Turbopack fix tracked in:

- https://github.com/utooland/utoo/pull/3115
- https://github.com/utooland/next.js/pull/156

I will update this PR after the Utoo PR is completed and the Umi dependency can be moved to a version containing the fix.

## Tests

- `pnpm --filter @example/with-svg build`

Current result before updating Utoo dependency: fails with the expected old-pack error:

```text
./examples/with-svg/pages/bg.img.svg.js
Invalid module type
The module type must be Ecmascript or Typescript to add Ecmascript transforms (got StaticUrlCss)
```
