### PR TITLE
fix(utoopack): filter packageImports for legacy antd

### DIFF
--- a/packages/bundler-utoopack/src/config.test.ts
+++ b/packages/bundler-utoopack/src/config.test.ts
@@ -448,6 +448,65 @@ describe('utoopack extra babel config', () => {
     });
     expect(config.config.styles?.emotion).toBe(true);
   });
+
+  test('removes antd packageImports for legacy antd with modularized imports', async () => {
+    const config = await getProdUtooPackConfig({
+      ...baseOpts,
+      config: {
+        antd: {
+          import: true,
+        },
+        extraBabelPlugins: [
+          [
+            'babel-plugin-import',
+            {
+              libraryName: 'antd',
+              libraryDirectory: 'es',
+              style: true,
+            },
+          ],
+        ],
+        utoopack: {
+          optimization: {
+            packageImports: ['antd', 'lodash'],
+          },
+        },
+      },
+    } as any);
+
+    expect(config.config.optimization?.packageImports).toEqual(['lodash']);
+  });
+
+  test('keeps antd packageImports for modern antd', async () => {
+    const config = await getProdUtooPackConfig({
+      ...baseOpts,
+      config: {
+        antd: {
+          import: false,
+        },
+        extraBabelPlugins: [
+          [
+            'babel-plugin-import',
+            {
+              libraryName: 'antd',
+              libraryDirectory: 'es',
+              style: true,
+            },
+          ],
+        ],
+        utoopack: {
+          optimization: {
+            packageImports: ['antd', 'lodash'],
+          },
+        },
+      },
+    } as any);
+
+    expect(config.config.optimization?.packageImports).toEqual([
+      'antd',
+      'lodash',
+    ]);
+  });
 });
 
 describe('utoopack externals config', () => {

--- a/packages/bundler-utoopack/src/config.ts
+++ b/packages/bundler-utoopack/src/config.ts
@@ -596,8 +596,35 @@ export function mergeExtraPostcssPlugins(
   }, postcssConfig);
 }
 
-function getUserUtoopackConfig(utoopackConfig: Record<string, any> = {}) {
-  return lodash.omit(utoopackConfig, ['babelLoader', 'root']);
+function getUserUtoopackConfig(
+  utoopackConfig: Record<string, any> = {},
+  opts: {
+    config: Record<string, any>;
+    modularizeImports: Record<string, any>;
+  },
+) {
+  const userUtoopackConfig = lodash.omit(utoopackConfig, [
+    'babelLoader',
+    'root',
+  ]);
+  const packageImports = userUtoopackConfig.optimization?.packageImports || [];
+
+  if (
+    opts.config.antd?.import &&
+    opts.modularizeImports.antd &&
+    Array.isArray(packageImports) &&
+    packageImports.includes('antd')
+  ) {
+    return {
+      ...userUtoopackConfig,
+      optimization: {
+        ...userUtoopackConfig.optimization,
+        packageImports: packageImports.filter((pkg) => pkg !== 'antd'),
+      },
+    };
+  }
+
+  return userUtoopackConfig;
 }
 
 function getDefaultPersistentCaching() {
@@ -662,7 +689,10 @@ export async function getProdUtooPackConfig(
     inlineLimit,
     mdx,
   } = opts.config;
-  const userUtoopackConfig = getUserUtoopackConfig(opts.config.utoopack);
+  const userUtoopackConfig = getUserUtoopackConfig(opts.config.utoopack, {
+    config: opts.config,
+    modularizeImports,
+  });
 
   utooBundlerOpts = {
     ...utooBundlerOpts,
@@ -852,7 +882,10 @@ export async function getDevUtooPackConfig(
     inlineLimit,
     mdx,
   } = opts.config;
-  const userUtoopackConfig = getUserUtoopackConfig(opts.config.utoopack);
+  const userUtoopackConfig = getUserUtoopackConfig(opts.config.utoopack, {
+    config: opts.config,
+    modularizeImports,
+  });
 
   utooBundlerOpts = {
     ...utooBundlerOpts,


### PR DESCRIPTION
## Summary

- reuse Umi's existing `antd.import` signal for legacy antd import-style handling
- remove `antd` from user-provided `utoopack.optimization.packageImports` when antd is also handled by modularized imports
- keep `antd` packageImports untouched when the antd import pipeline is disabled

This avoids combining `packageImports: ['antd']` with the antd v4 `babel-plugin-import`/`modularizeImports` style pipeline, which can drop antd v4 style side-effect chunks under utoopack.

Note: @utoo/pack also has an internal default packageImports list. This Umi-side guard protects explicit/upstream Umi config; removing `antd` from the internal Utoo default list is tracked separately in https://github.com/utooland/utoo/pull/3117.

## Test

- `pnpm jest packages/bundler-utoopack/src/config.test.ts --runInBand`