### PR TITLE
test(utoopack): cover postcss runtime on windows

### DIFF
--- a/.github/workflows/e2e-utoopack-windows.yml
+++ b/.github/workflows/e2e-utoopack-windows.yml
@@ -174,7 +174,7 @@ jobs:
             if (message.type() === 'error') errors.push(message.text());
           });
           await page.goto('http://127.0.0.1:9527/', { waitUntil: 'domcontentloaded' });
-          const expectedTexts = ['todos', 'foo', 'bar', 'count', '123'];
+          const expectedTexts = ['todos', 'foo', 'bar', 'count', '123', 'postcss-runtime'];
           const started = Date.now();
           let text = '';
           while (Date.now() - started < 60000) {
@@ -185,6 +185,15 @@ jobs:
               throw new Error(`Browser runtime errors:\n${errors.join('\n')}\n\nBody:\n${text}`);
             }
             if (expectedTexts.every((expected) => text.includes(expected))) {
+              const postcssColor = await page
+                .locator('.utoopack-postcss-runtime')
+                .evaluate((node) => getComputedStyle(node).color)
+                .catch(() => '');
+              if (postcssColor !== 'rgb(1, 2, 3)') {
+                throw new Error(
+                  `Expected utoopack PostCSS runtime marker color rgb(1, 2, 3), got ${postcssColor || '(empty)'}`,
+                );
+              }
               await browser.close();
               process.exit(0);
             }

--- a/examples/with-use-model/pages/index.tsx
+++ b/examples/with-use-model/pages/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 // @ts-ignore
 import { useModel } from 'umi';
+import './postcss-runtime.css';
 
 export default function HomePage() {
   const { todos } = useModel('todo');
@@ -15,6 +16,7 @@ export default function HomePage() {
       </ul>
       <h2>count</h2>
       <div>{total}</div>
+      <div className="utoopack-postcss-runtime">postcss-runtime</div>
     </div>
   );
 }

--- a/examples/with-use-model/pages/postcss-runtime.css
+++ b/examples/with-use-model/pages/postcss-runtime.css
@@ -1,0 +1,3 @@
+.utoopack-postcss-runtime {
+  color: rgb(255, 0, 0);
+}

--- a/examples/with-use-model/postcss.config.js
+++ b/examples/with-use-model/postcss.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  plugins: [
+    {
+      postcssPlugin: 'utoopack-postcss-runtime-marker',
+      Declaration(decl) {
+        if (
+          decl.prop === 'color' &&
+          decl.value.replace(/\s+/g, ' ') === 'rgb(255, 0, 0)'
+        ) {
+          decl.value = 'rgb(1, 2, 3)';
+        }
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

- add a PostCSS config to the `with-use-model` example used by `e2e-utoopack-windows`
- import a CSS marker file so utoopack must run the PostCSS runtime during dev
- assert the PostCSS plugin output through Playwright computed style

## Notes

This is intended to catch regressions where the generated utoopack PostCSS runtime tries to load the internal `@vercel/turbopack/postcss` specifier instead of resolving the real `postcss` package.

## Testing

- Not run locally: this checkout does not currently have `postcss` installed at the repo root; the target validation is the Windows GitHub Actions workflow after `pnpm i`.