### PR TITLE
ci: update node test versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [20.x, 22.x, 24.x]
         os: [ubuntu-latest, windows-2022]
       fail-fast: false
     steps:
@@ -35,25 +35,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install pnpm
-        if: ${{ matrix.node-version != '14.x' }}
         uses: pnpm/action-setup@v4
-
-      - name: Get pnpm version (node 14)
-        if: ${{ matrix.node-version == '14.x' }}
-        uses: actions/github-script@v7
-        id: pnpm-version
-        with:
-          result-encoding: string
-          script: |
-            const packageJson = require('./package.json')
-            const pnpmVersion = packageJson.packageManager.split('@')[1]
-            console.log(`Use pnpm ${pnpmVersion}`)
-            return pnpmVersion
-
-      - name: Install pnpm (node 14)
-        if: ${{ matrix.node-version == '14.x' }}
-        run: |
-          npm install -g @pnpm/exe@${{ steps.pnpm-version.outputs.result }}
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 env:
   NODE_OPTIONS: --max-old-space-size=6144
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
 on:
   push:

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Use latest LTS Node.js
+      - name: Use Node.js 24
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 24.x
           registry-url: 'https://registry.npmjs.org/'
           cache: 'pnpm'
 

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -2,6 +2,7 @@ name: Compressed Size
 
 env:
   NODE_OPTIONS: --max-old-space-size=6144
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
 on:
   pull_request:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -40,10 +40,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Use Node.js
+      - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org/'
           cache: 'pnpm'
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,7 @@ name: Coverage
 
 env:
   NODE_OPTIONS: --max-old-space-size=6144
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
 on:
   push:
@@ -30,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [24.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x, 22.x, 24.x]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -35,10 +35,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Use Node.js
+      - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org/'
           cache: 'pnpm'
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -2,6 +2,7 @@ name: doc
 
 env:
   NODE_OPTIONS: --max-old-space-size=6144
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
 on:
   push:
@@ -26,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [24.x]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/e2e-basic.yml
+++ b/.github/workflows/e2e-basic.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [24.x]
+        node-version: [20.x]
         os: [ubuntu-latest, windows-2022]
       fail-fast: false
     steps:

--- a/.github/workflows/e2e-basic.yml
+++ b/.github/workflows/e2e-basic.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x, 22.x, 24.x]
         os: [ubuntu-latest, windows-2022]
       fail-fast: false
     steps:

--- a/.github/workflows/e2e-basic.yml
+++ b/.github/workflows/e2e-basic.yml
@@ -2,6 +2,7 @@ name: e2e-basic
 
 env:
   NODE_OPTIONS: --max-old-space-size=6144
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
 on:
   schedule:
@@ -28,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [24.x]
         os: [ubuntu-latest, windows-2022]
       fail-fast: false
     steps:

--- a/.github/workflows/e2e-boilerplate.yml
+++ b/.github/workflows/e2e-boilerplate.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x, 22.x, 24.x]
         os: [ubuntu-latest, windows-2022]
       fail-fast: false
     steps:

--- a/.github/workflows/e2e-boilerplate.yml
+++ b/.github/workflows/e2e-boilerplate.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [24.x]
+        node-version: [20.x]
         os: [ubuntu-latest, windows-2022]
       fail-fast: false
     steps:

--- a/.github/workflows/e2e-boilerplate.yml
+++ b/.github/workflows/e2e-boilerplate.yml
@@ -2,6 +2,7 @@ name: e2e-boilerplate
 
 env:
   NODE_OPTIONS: --max-old-space-size=6144
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
 on:
   schedule:
@@ -27,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [24.x]
         os: [ubuntu-latest, windows-2022]
       fail-fast: false
     steps:

--- a/.github/workflows/e2e-mfsu.yml
+++ b/.github/workflows/e2e-mfsu.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         mfsu-strategy: [normal, eager]
         os: [ubuntu-latest, windows-2022]
-        node-version: [24.x]
+        node-version: [20.x]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/e2e-mfsu.yml
+++ b/.github/workflows/e2e-mfsu.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         mfsu-strategy: [normal, eager]
         os: [ubuntu-latest, windows-2022]
-        node-version: [16.x]
+        node-version: [20.x, 22.x, 24.x]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/e2e-mfsu.yml
+++ b/.github/workflows/e2e-mfsu.yml
@@ -2,6 +2,7 @@ name: e2e-mfsu
 
 env:
   NODE_OPTIONS: --max-old-space-size=6144
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
 on:
   schedule:
@@ -29,7 +30,7 @@ jobs:
       matrix:
         mfsu-strategy: [normal, eager]
         os: [ubuntu-latest, windows-2022]
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [24.x]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/e2e-qiankun.yml
+++ b/.github/workflows/e2e-qiankun.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x, 22.x, 24.x]
         os: [ubuntu-latest, windows-2022]
       fail-fast: false
     steps:

--- a/.github/workflows/e2e-qiankun.yml
+++ b/.github/workflows/e2e-qiankun.yml
@@ -2,6 +2,7 @@ name: e2e-qiankun
 
 env:
   NODE_OPTIONS: --max-old-space-size=6144
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
 on:
   schedule:
@@ -27,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [24.x]
         os: [ubuntu-latest, windows-2022]
       fail-fast: false
     steps:

--- a/.github/workflows/e2e-qiankun.yml
+++ b/.github/workflows/e2e-qiankun.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [24.x]
+        node-version: [20.x]
         os: [ubuntu-latest, windows-2022]
       fail-fast: false
     steps:

--- a/.github/workflows/e2e-vite.yml
+++ b/.github/workflows/e2e-vite.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x, 22.x, 24.x]
         os: [ubuntu-latest, windows-2022]
       fail-fast: false
     steps:

--- a/.github/workflows/e2e-vite.yml
+++ b/.github/workflows/e2e-vite.yml
@@ -2,6 +2,7 @@ name: e2e-vite
 
 env:
   NODE_OPTIONS: --max-old-space-size=6144
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
 on:
   schedule:
@@ -27,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [24.x]
         os: [ubuntu-latest, windows-2022]
       fail-fast: false
     steps:

--- a/.github/workflows/e2e-vite.yml
+++ b/.github/workflows/e2e-vite.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [24.x]
+        node-version: [20.x]
         os: [ubuntu-latest, windows-2022]
       fail-fast: false
     steps:


### PR DESCRIPTION
## Summary

- Update the core CI Node.js matrix from `14.x, 16.x, 18.x` to `20.x, 22.x, 24.x`.
- Keep e2e workflows on a single `20.x` job per OS/strategy to avoid multiplying long-running e2e checks and to stay on the repo's current Volta baseline while Cypress 12.6 is unstable on Windows + Node 24.
- Run coverage and docs on `24.x`, and update compressed-size from the stale `16.x` latest-LTS setting to `24.x`.
- Remove the Node 14-specific pnpm installation path, since the matrix no longer runs Node 14.
- Skip Playwright browser downloads during workflow dependency installation to avoid Node 24 install hangs in workflows that do not run Playwright tests.

## Validation

- `git diff --check`
- `ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f) }' .github/workflows/*.yml`