### PR TITLE
refactor(preset-umi): remove @umijs/es-module-parser from prepare

### DIFF
--- a/packages/core/src/service/service.ts
+++ b/packages/core/src/service/service.ts
@@ -53,7 +53,6 @@ export class Service {
     framework?: IFrameworkType;
     prepare?: {
       buildResult: Omit<BuildResult, 'outputFiles'>;
-      fileImports?: Record<string, Declaration[]>;
     };
     mpa?: {
       entry?: { [key: string]: string }[];
@@ -715,63 +714,3 @@ export interface IServicePluginAPI {
   registerPresets: (presets: any[]) => void;
   registerPlugins: (plugins: (Plugin | {})[]) => void;
 }
-
-// this is manually copied from @umijs/es-module-parser
-type DeclareKind = 'value' | 'type';
-type Declaration =
-  | {
-      type: 'ImportDeclaration';
-      source: string;
-      specifiers: Array<SimpleImportSpecifier>;
-      importKind: DeclareKind;
-      start: number;
-      end: number;
-    }
-  | {
-      type: 'DynamicImport';
-      source: string;
-      start: number;
-      end: number;
-    }
-  | {
-      type: 'ExportNamedDeclaration';
-      source: string;
-      specifiers: Array<SimpleExportSpecifier>;
-      exportKind: DeclareKind;
-      start: number;
-      end: number;
-    }
-  | {
-      type: 'ExportAllDeclaration';
-      source: string;
-      start: number;
-      end: number;
-    };
-type SimpleImportSpecifier =
-  | {
-      type: 'ImportDefaultSpecifier';
-      local: string;
-    }
-  | {
-      type: 'ImportNamespaceSpecifier';
-      local: string;
-      imported: string;
-    }
-  | {
-      type: 'ImportNamespaceSpecifier';
-      local?: string;
-    };
-type SimpleExportSpecifier =
-  | {
-      type: 'ExportDefaultSpecifier';
-      exported: string;
-    }
-  | {
-      type: 'ExportNamespaceSpecifier';
-      exported?: string;
-    }
-  | {
-      type: 'ExportSpecifier';
-      exported: string;
-      local: string;
-    };

--- a/packages/preset-umi/package.json
+++ b/packages/preset-umi/package.json
@@ -38,7 +38,6 @@
     "@umijs/bundler-webpack": "workspace:*",
     "@umijs/core": "workspace:*",
     "@umijs/did-you-know": "^1.0.4",
-    "@umijs/es-module-parser": "0.0.7",
     "@umijs/history": "5.3.1",
     "@umijs/mfsu": "workspace:*",
     "@umijs/plugin-run": "workspace:*",

--- a/packages/preset-umi/src/features/prepare/prepare.ts
+++ b/packages/preset-umi/src/features/prepare/prepare.ts
@@ -1,58 +1,20 @@
 import type { BuildResult } from '@umijs/bundler-utils/compiled/esbuild';
-import type { Declaration } from '@umijs/es-module-parser';
-import { aliasUtils, importLazy, isJavaScriptFile, logger } from '@umijs/utils';
+import { aliasUtils, logger } from '@umijs/utils';
 import path from 'path';
 import { addUnWatch } from '../../commands/dev/watch';
 import { IApi, IOnGenerateFiles } from '../../types';
 
-const parser: typeof import('@umijs/es-module-parser') = importLazy(
-  require.resolve('@umijs/es-module-parser'),
-);
-
 export default (api: IApi) => {
-  function updateAppdata(prepareData: {
-    buildResult: BuildResult;
-    fileImports?: Record<string, Declaration[]>;
-  }) {
+  function updateAppdata(prepareData: { buildResult: BuildResult }) {
     const buildResult: BuildResult = {
       ...prepareData.buildResult,
       // we don't need output file in prepare stage
       outputFiles: undefined,
     };
 
-    const nextFileImports =
-      prepareData.fileImports ?? api.appData.prepare?.fileImports;
     api.appData.prepare = {
       buildResult,
-      fileImports: nextFileImports,
     };
-  }
-
-  async function parseProjectImportSpecifiers(br: BuildResult) {
-    const files = (Object.keys(br.metafile!.inputs) || []).filter(
-      isJavaScriptFile,
-    );
-    if (files.length === 0) {
-      return {};
-    }
-    try {
-      const start = Date.now();
-      const fileImports = await parser.parseFiles(
-        files.map((f) => path.join(api.paths.cwd, f)),
-      );
-
-      api.telemetry.record({
-        name: 'parse',
-        payload: { duration: Date.now() - start },
-      });
-      return fileImports;
-    } catch (e) {
-      api.telemetry.record({
-        name: 'parse:error',
-        payload: {},
-      });
-      return undefined;
-    }
   }
 
   api.register({
@@ -88,15 +50,13 @@ export default (api: IApi) => {
         entryPoints,
         watch: watch && {
           async onRebuildSuccess({ result }) {
-            const fileImports = await parseProjectImportSpecifiers(result);
-            updateAppdata({ buildResult: result, fileImports });
+            updateAppdata({ buildResult: result });
 
             await api.applyPlugins({
               key: 'onPrepareBuildSuccess',
               args: {
                 isWatch: true,
                 result,
-                fileImports,
               },
             });
           },
@@ -114,13 +74,11 @@ export default (api: IApi) => {
         });
       }
 
-      const fileImports = await parseProjectImportSpecifiers(buildResult);
-      updateAppdata({ buildResult, fileImports });
+      updateAppdata({ buildResult });
       await api.applyPlugins({
         key: 'onPrepareBuildSuccess',
         args: {
           result: buildResult,
-          fileImports,
         },
       });
     },

--- a/packages/preset-umi/src/types.ts
+++ b/packages/preset-umi/src/types.ts
@@ -17,7 +17,6 @@ import type {
   PluginAPI,
 } from '@umijs/core';
 import { Env } from '@umijs/core';
-import type { Declaration } from '@umijs/es-module-parser';
 import type { getMarkup } from '@umijs/server';
 import type { CheerioAPI } from '@umijs/utils/compiled/cheerio';
 import type { InlineConfig as ViteInlineConfig } from 'vite';
@@ -249,7 +248,6 @@ export type IApi = PluginAPI &
       origin: Record<string, any>;
     }>;
     onPrepareBuildSuccess: IEvent<{
-      fileImports?: Record<string, Declaration[]>;
       isWatch: boolean;
       result: ESBuildBuildResult;
     }>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2617,9 +2617,6 @@ importers:
       '@umijs/did-you-know':
         specifier: ^1.0.4
         version: link:../../did-you-know
-      '@umijs/es-module-parser':
-        specifier: 0.0.7
-        version: 0.0.7
       '@umijs/history':
         specifier: 5.3.1
         version: 5.3.1
@@ -20239,6 +20236,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@umijs/es-module-parser-darwin-x64@0.0.7:
@@ -20247,6 +20245,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@umijs/es-module-parser-linux-arm-gnueabihf@0.0.7:
@@ -20255,6 +20254,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@umijs/es-module-parser-linux-arm64-gnu@0.0.7:
@@ -20263,6 +20263,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@umijs/es-module-parser-linux-arm64-musl@0.0.7:
@@ -20271,6 +20272,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@umijs/es-module-parser-linux-x64-gnu@0.0.7:
@@ -20279,6 +20281,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@umijs/es-module-parser-linux-x64-musl@0.0.7:
@@ -20287,6 +20290,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@umijs/es-module-parser-win32-arm64-msvc@0.0.7:
@@ -20295,6 +20299,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@umijs/es-module-parser-win32-x64-msvc@0.0.7:
@@ -20303,6 +20308,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@umijs/es-module-parser@0.0.7:
@@ -20318,6 +20324,7 @@ packages:
       '@umijs/es-module-parser-linux-x64-musl': 0.0.7
       '@umijs/es-module-parser-win32-arm64-msvc': 0.0.7
       '@umijs/es-module-parser-win32-x64-msvc': 0.0.7
+    dev: true
 
   /@umijs/fabric@2.14.0:
     resolution: {integrity: sha512-tiqKWYFwK9dgrdC8U1IjdIqeIv6W3NhROJHb07u1D72KWpGoN2U7/gVRtyMq7psBSK4EwHyXL6sFtIGUibs2ng==}


### PR DESCRIPTION
## 背景

`packages/preset-umi/src/features/prepare/prepare.ts` 中通过 `@umijs/es-module-parser` 的 native `parseFiles` 解析项目 import，在 flow 环境中可能导致进程异常中断。

## 评估结论

该 parser 的产出 `fileImports` 是**死数据**——计算了但全代码库无任何消费方：

- 三个 `onPrepareBuildSuccess` 订阅者（`icons` / `phantomDependency` / `check`）只用 `result`，从不读 `fileImports`
- `projectFileList.ts` 只读 `appData.prepare.buildResult`
- `Declaration` 类型在 `core/service.ts` 已有一份独立的手动副本，删除包不影响

因此可安全移除。

## 改动

- **prepare.ts** — 删除 parser 的 `importLazy`、`parseProjectImportSpecifiers` 函数（含触发 flow 异常的 native 调用及 `parse`/`parse:error` 埋点）、两处 `fileImports` 传递
- **types.ts** — 移除 `Declaration` import 及 `onPrepareBuildSuccess` 的 `fileImports?` 字段
- **core/service.ts** — 移除 `appData.prepare.fileImports` 字段及配套的死类型定义
- **package.json** — 移除 `@umijs/es-module-parser` 依赖

## 验证

- `core` 包 `tsc --noEmit` 通过
- 无 `Declaration` / `fileImports` 相关类型错误
- 全局已无 `es-module-parser` 源码引用

唯一行为变化：不再加载/调用会在 flow 环境崩溃的 native parser。

🤖 Generated with [Claude Code](https://claude.com/claude-code)