### PR TITLE
fix: avoid shell execution in git file helpers

### DIFF
--- a/packages/utils/src/getFileGitIno.test.ts
+++ b/packages/utils/src/getFileGitIno.test.ts
@@ -1,0 +1,74 @@
+import { execFileSync } from 'child_process';
+import { existsSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { getFileCreateInfo, getFileLastModifyInfo } from './getFileGitIno';
+
+const createGitRepo = () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'umijs-utils-git-'));
+
+  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+  writeFileSync(join(cwd, 'index.ts'), 'export default 1;\n');
+  execFileSync('git', ['add', 'index.ts'], { cwd, stdio: 'ignore' });
+  execFileSync(
+    'git',
+    [
+      '-c',
+      'user.name=Umi Test',
+      '-c',
+      'user.email=umi-test@example.com',
+      'commit',
+      '-m',
+      'init',
+    ],
+    { cwd, stdio: 'ignore' },
+  );
+
+  return cwd;
+};
+
+describe('getFileGitIno', () => {
+  let cwd: string;
+
+  afterEach(() => {
+    if (cwd) {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test('gets file create and last modify info', async () => {
+    cwd = createGitRepo();
+
+    await expect(getFileCreateInfo('index.ts', cwd)).resolves.toMatchObject({
+      creator: 'Umi Test',
+      creatorEmail: 'umi-test@example.com',
+    });
+    await expect(getFileLastModifyInfo('index.ts', cwd)).resolves.toMatchObject(
+      {
+        modifier: 'Umi Test',
+        modifierEmail: 'umi-test@example.com',
+      },
+    );
+  });
+
+  const testOrSkip = process.platform === 'win32' ? test.skip : test;
+
+  testOrSkip(
+    'does not execute shell metacharacters in file paths',
+    async () => {
+      cwd = mkdtempSync(join(tmpdir(), 'umijs-utils-git-'));
+      const marker = join(cwd, 'pwned');
+      const payload = `x;touch ${marker};#`;
+
+      await getFileCreateInfo(payload, cwd).catch(() => {});
+      expect(existsSync(marker)).toBe(false);
+
+      await getFileLastModifyInfo(payload, cwd).catch(() => {});
+      expect(existsSync(marker)).toBe(false);
+
+      if (existsSync(marker)) {
+        unlinkSync(marker);
+      }
+    },
+  );
+});

--- a/packages/utils/src/getFileGitIno.ts
+++ b/packages/utils/src/getFileGitIno.ts
@@ -63,11 +63,18 @@ export const getFileCreateInfo = async (
     const info = await promisifySpawn(
       'git',
       // time|name|email|since
-      ['log', '--reverse', '-1000000', "--pretty='%ad|%an|%ae|%ar'", filePath],
+      [
+        'log',
+        '--reverse',
+        '-1000000',
+        '--pretty=%ad|%an|%ae|%ar',
+        '--',
+        filePath,
+      ],
       {
         cwd: gitDirPath,
         onlyOnce: true,
-        shell: true,
+        shell: false,
       },
     );
     if (info.length && info[0]) {
@@ -99,11 +106,11 @@ export const getFileLastModifyInfo = async (
   try {
     const info = await promisifySpawn(
       'git',
-      ['log', '-1', "--pretty='%ad|%an|%ae|%ar'", filePath],
+      ['log', '-1', '--pretty=%ad|%an|%ae|%ar', '--', filePath],
       {
         cwd: gitDirPath,
         onlyOnce: true,
-        shell: true,
+        shell: false,
       },
     );
 


### PR DESCRIPTION
## Summary

Fixes #13345.

This removes shell execution from the `@umijs/utils` git file helpers so user-controlled file paths are passed to `git log` as path arguments instead of being interpreted by a shell.

## Changes

- Use `shell: false` for `getFileCreateInfo()` and `getFileLastModifyInfo()`.
- Pass `--` before `filePath` so paths beginning with `-` are not interpreted as git options.
- Remove shell-only quoting from the `--pretty` argument.
- Add regression coverage for normal git metadata lookup and shell metacharacter payloads.

## Test

```bash
pnpm jest packages/utils/src/getFileGitIno.test.ts --runInBand
```