### PR TITLE
feat(serverLoader): add modifyServerLoaderRequest runtime plugin hook

### DIFF
--- a/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
+++ b/packages/preset-umi/src/features/tmpFiles/tmpFiles.ts
@@ -485,6 +485,7 @@ if (process.env.NODE_ENV === 'development') {
         'outerProvider',
         'render',
         'onRouteChange',
+        'modifyServerLoaderRequest',
       ],
     });
 

--- a/packages/preset-umi/templates/defineApp.tpl
+++ b/packages/preset-umi/templates/defineApp.tpl
@@ -5,6 +5,7 @@ interface IDefaultRuntimeConfig {
   patchClientRoutes?: (props: { routes: any }) => void;
   render?: (oldRender: () => void) => void;
   rootContainer?: (lastRootContainer: JSX.Element, args?: any) => void;
+  modifyServerLoaderRequest?: (memo: { url: string, options: RequestInit }, args: { id: string, basename?: string }) => { url: string, options: RequestInit };
   [key: string]: any;
 }
 {{{ runtimeConfigType }}}

--- a/packages/renderer-react/src/appContext.ts
+++ b/packages/renderer-react/src/appContext.ts
@@ -52,7 +52,7 @@ type ServerLoaderFunc = (...args: any[]) => Promise<any> | any;
 // @deprecated  Please use `useLoaderData` instead.
 export function useServerLoaderData<T extends ServerLoaderFunc = any>() {
   const routes = useSelectedRoutes();
-  const { serverLoaderData, basename } = useAppData();
+  const { serverLoaderData, basename, pluginManager } = useAppData();
   const [data, setData] = React.useState(() => {
     const ret = {} as Awaited<ReturnType<T>>;
     let has = false;
@@ -78,6 +78,7 @@ export function useServerLoaderData<T extends ServerLoaderFunc = any>() {
                 fetchServerLoader({
                   id: route.route.id,
                   basename,
+                  pluginManager,
                   cb: resolve,
                 });
               }),

--- a/packages/renderer-react/src/browser.tsx
+++ b/packages/renderer-react/src/browser.tsx
@@ -274,6 +274,7 @@ const getBrowser = (
             fetchServerLoader({
               id,
               basename,
+              pluginManager: opts.pluginManager,
               cb: (data) => {
                 // setServerLoaderData when startTransition because if ssr is enabled,
                 // the component may being hydrated and setLoaderData will break the hydration
@@ -306,6 +307,7 @@ const getBrowser = (
                 fetchServerLoader({
                   id,
                   basename,
+                  pluginManager: opts.pluginManager,
                   cb: (data) => {
                     // setServerLoaderData when startTransition because if ssr is enabled,
                     // the component may being hydrated and setLoaderData will break the hydration

--- a/packages/renderer-react/src/dataFetcher.ts
+++ b/packages/renderer-react/src/dataFetcher.ts
@@ -1,11 +1,20 @@
+export interface IServerLoaderRequest {
+  url: string;
+  options: RequestInit;
+}
+
 export function fetchServerLoader({
   id,
   basename,
   cb,
+  pluginManager,
 }: {
   id: string;
   basename?: string;
   cb: (data: any) => void;
+  // Runtime plugin manager for the modifyServerLoaderRequest hook.
+  // Optional: falls back to the default request when absent.
+  pluginManager?: any;
 }) {
   const query = new URLSearchParams({
     route: id,
@@ -13,12 +22,27 @@ export function fetchServerLoader({
   }).toString();
   // 在有basename的情况下__serverLoader的请求路径需要加上basename
   // FIXME: 先临时解自定义 serverLoader 请求路径的问题，后续改造 serverLoader 时再提取成类似 runtimeServerLoader 的配置项
-  const url = `${withEndSlash(
+  const defaultUrl = `${withEndSlash(
     (window as any).umiServerLoaderPath || basename,
   )}__serverLoader?${query}`;
-  fetch(url, {
-    credentials: 'include',
-  })
+
+  // Runtime hook to let consumers rewrite the direct serverLoader request
+  // (e.g. add gateway headers/query when calling WebGW FaaS directly).
+  // The framework stays agnostic of any gateway protocol.
+  let req: IServerLoaderRequest = {
+    url: defaultUrl,
+    options: { credentials: 'include' },
+  };
+  if (pluginManager?.applyPlugins) {
+    req = pluginManager.applyPlugins({
+      key: 'modifyServerLoaderRequest',
+      type: 'modify',
+      initialValue: req,
+      args: { id, basename },
+    });
+  }
+
+  fetch(req.url, req.options)
     .then((d) => d.json())
     .then(cb)
     .catch(console.error);


### PR DESCRIPTION
## What

Client-side `serverLoader` requests can bypass ER and hit WebGW FaaS directly. Such direct requests need extra gateway-required headers/query that ER otherwise attaches on the server side — otherwise the gateway rejects them or routes to the wrong function revision.

Instead of hard-coding any gateway protocol (e.g. reading `window.__TERN__`) into the framework, this PR adds a generic **runtime plugin hook** so consumers inject whatever they need. The framework stays agnostic of any gateway protocol.

## How

Add a `modify`-type runtime plugin hook `modifyServerLoaderRequest` that lets consumers rewrite the direct request's `url` and fetch `options` (headers / credentials / query).

```ts
// app.ts
export function modifyServerLoaderRequest(memo, args) {
  return {
    ...memo,
    options: {
      ...memo.options,
      headers: { ...memo.options.headers, ...readGatewayHeaders() },
    },
  };
}
```

- `dataFetcher.fetchServerLoader`: optional `pluginManager` param, runs the hook over `{ url, options }`; falls back to the default request when absent (backward compatible)
- `browser.tsx` / `appContext.ts`: pass `pluginManager` at the three call sites
- `tmpFiles.ts`: register `modifyServerLoaderRequest` in `validKeys`
- `defineApp.tpl`: add the type declaration

## Test

- `pnpm build` (father) passes for `renderer-react`
- `jest packages/renderer-react` 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)