### PR TITLE
feat: inject utoopack ssr css assets

### DIFF
--- a/packages/preset-umi/src/commands/build.ts
+++ b/packages/preset-umi/src/commands/build.ts
@@ -3,6 +3,7 @@ import { getMarkup } from '@umijs/server';
 import { chalk, fsExtra, logger, rimraf, semver } from '@umijs/utils';
 import { writeFileSync } from 'fs';
 import { dirname, join, resolve } from 'path';
+import { generateBuildManifestFromStats } from '../features/ssr/utils';
 import type { IApi, IOnGenerateFiles } from '../types';
 import {
   measureFileSizesBeforeBuild,
@@ -155,6 +156,10 @@ umi build --clean
       });
 
       const stats = await bundler.build(opts);
+
+      if (api.config.ssr && isUtoopack) {
+        generateBuildManifestFromStats(api, stats);
+      }
 
       if (!api.config.vite && !api.config.mako) {
         // Measure files sizes before build

--- a/packages/preset-umi/src/features/ssr/utils.test.ts
+++ b/packages/preset-umi/src/features/ssr/utils.test.ts
@@ -41,7 +41,7 @@ test('generateBuildManifestFromStats adds umi.css alias for utoopack css assets'
       readFileSync(join(absOutputPath, 'build-manifest.json'), 'utf-8'),
     );
 
-    expect(manifest.assets['umi.css']).toEqual('/src_pages_c700bf89.css');
+    expect(manifest.assets['umi.css']).toEqual(['/src_pages_c700bf89.css']);
   } finally {
     rmSync(cwd, { recursive: true, force: true });
   }
@@ -67,7 +67,10 @@ test('generateBuildManifestFromStats prefers umi css assets', () => {
       readFileSync(join(absOutputPath, 'build-manifest.json'), 'utf-8'),
     );
 
-    expect(manifest.assets['umi.css']).toEqual('/umi.abc123ef.css');
+    expect(manifest.assets['umi.css']).toEqual([
+      '/umi.abc123ef.css',
+      '/fallback.css',
+    ]);
   } finally {
     rmSync(cwd, { recursive: true, force: true });
   }

--- a/packages/preset-umi/src/features/ssr/utils.ts
+++ b/packages/preset-umi/src/features/ssr/utils.ts
@@ -126,14 +126,15 @@ function isUtoopackSingleCss(file: string) {
   return /\.single\.css(?:[?#].*)?$/.test(file);
 }
 
-function findClientCssFile(files: string[]) {
+function findClientCssFiles(files: string[]) {
   const cssFiles = files.filter(isCssFile);
 
-  return (
-    cssFiles.find(isUmiCssFile) ||
-    cssFiles.find((file) => !isUtoopackSingleCss(file)) ||
-    cssFiles[0]
-  );
+  return Array.from(
+    new Set([
+      ...cssFiles.filter(isUmiCssFile),
+      ...cssFiles.filter((file) => !isUmiCssFile(file)),
+    ]),
+  ).filter((file) => !isUtoopackSingleCss(file));
 }
 
 function getSourceAssetMap(
@@ -213,9 +214,11 @@ export const generateBuildManifestFromStats = (api: IApi, stats: any) => {
     finalJsonObj.assets['umi.js'] = addPublicPath(publicPath, umiJs);
   }
 
-  const umiCss = findClientCssFile([...entryFiles, ...statsAssets]);
-  if (umiCss) {
-    finalJsonObj.assets['umi.css'] = addPublicPath(publicPath, umiCss);
+  const umiCssFiles = findClientCssFiles([...entryFiles, ...statsAssets]);
+  if (umiCssFiles.length) {
+    finalJsonObj.assets['umi.css'] = umiCssFiles.map((file) =>
+      addPublicPath(publicPath, file),
+    );
   }
 
   writeFileSync(buildFilePath, JSON.stringify(finalJsonObj, null, 2), {

--- a/packages/preset-umi/src/features/utoopack/utoopack.ts
+++ b/packages/preset-umi/src/features/utoopack/utoopack.ts
@@ -4,6 +4,7 @@ import { IApi, webpack } from '../../types';
 import {
   EntryAssets,
   extractEntryAssets,
+  extractEntryPointFilesFromStats,
 } from '../../utils/extractEntryAssets';
 
 function cleanVersionRange(version?: string) {
@@ -110,17 +111,9 @@ export default (api: IApi) => {
   });
 
   api.onDevCompileDone(({ stats }: { stats: webpack.StatsCompilation }) => {
-    const entryPointFiles = new Set<string>();
-
-    for (const chunk of stats.entrypoints?.['umi']?.chunks || []) {
-      const files =
-        (stats?.chunks || []).find((c) => c?.id === chunk)?.files || [];
-      for (const file of files) {
-        entryPointFiles.add(file);
-      }
-    }
-
-    const entryAssets = extractEntryAssets(Array.from(entryPointFiles));
+    const entryAssets = extractEntryAssets(
+      extractEntryPointFilesFromStats(stats),
+    );
     Object.entries(entryAssets).forEach(([ext, files]) => {
       if (!Array.isArray(assets[ext])) {
         assets[ext] = [];
@@ -130,17 +123,9 @@ export default (api: IApi) => {
   });
 
   api.onBuildComplete(({ stats }: { stats: webpack.StatsCompilation }) => {
-    const entryPointFiles = new Set<string>();
-
-    for (const chunk of stats.entrypoints?.['umi']?.chunks || []) {
-      const files =
-        (stats?.chunks || []).find((c) => c?.id === chunk)?.files || [];
-      for (const file of files) {
-        entryPointFiles.add(file);
-      }
-    }
-
-    const entryAssets = extractEntryAssets(Array.from(entryPointFiles));
+    const entryAssets = extractEntryAssets(
+      extractEntryPointFilesFromStats(stats),
+    );
     Object.entries(entryAssets).forEach(([ext, files]) => {
       if (!Array.isArray(assets[ext])) {
         assets[ext] = [];

--- a/packages/preset-umi/src/utils/extractEntryAssets.test.ts
+++ b/packages/preset-umi/src/utils/extractEntryAssets.test.ts
@@ -1,0 +1,45 @@
+import {
+  extractEntryAssets,
+  extractEntryPointFilesFromStats,
+} from './extractEntryAssets';
+
+test('extractEntryPointFilesFromStats includes entrypoint assets', () => {
+  const files = extractEntryPointFilesFromStats({
+    entrypoints: {
+      umi: {
+        assets: [
+          { name: '_project___0a0d53fb.05e0d5fb.css' },
+          { name: '_project___76bef3ab.cf435efa.css' },
+          { name: 'umi.429d95d4.js' },
+        ],
+        chunks: ['umi.429d95d4.js'],
+      },
+    },
+    chunks: [{ id: 'umi.429d95d4.js', files: ['umi.429d95d4.js'] }],
+  });
+
+  expect(files).toEqual([
+    '_project___0a0d53fb.05e0d5fb.css',
+    '_project___76bef3ab.cf435efa.css',
+    'umi.429d95d4.js',
+  ]);
+
+  expect(extractEntryAssets(files).css).toEqual([
+    '_project___0a0d53fb.05e0d5fb.css',
+    '_project___76bef3ab.cf435efa.css',
+  ]);
+});
+
+test('extractEntryPointFilesFromStats includes chunk files', () => {
+  expect(
+    extractEntryPointFilesFromStats({
+      entrypoints: {
+        umi: {
+          assets: [],
+          chunks: ['umi'],
+        },
+      },
+      chunks: [{ id: 'umi', files: ['umi.js', 'umi.css'] }],
+    }),
+  ).toEqual(['umi.js', 'umi.css']);
+});

--- a/packages/preset-umi/src/utils/extractEntryAssets.ts
+++ b/packages/preset-umi/src/utils/extractEntryAssets.ts
@@ -4,6 +4,39 @@ export type EntryAssets = {
   [key: string]: string[];
 };
 
+function getAssetName(asset: any) {
+  return typeof asset === 'string' ? asset : asset?.name;
+}
+
+export function extractEntryPointFilesFromStats(
+  stats: any,
+  entryName = 'umi',
+): string[] {
+  const statsJson = stats?.toJson ? stats.toJson() : stats || {};
+  const entrypoint = statsJson.entrypoints?.[entryName];
+  const files = new Set<string>();
+
+  for (const asset of entrypoint?.assets || []) {
+    const name = getAssetName(asset);
+    if (name) {
+      files.add(name);
+    }
+  }
+
+  for (const chunkId of entrypoint?.chunks || []) {
+    const chunk = (statsJson.chunks || []).find((item: any) => {
+      return item?.id === chunkId || item?.names?.includes?.(chunkId);
+    });
+    for (const file of chunk?.files || []) {
+      if (file) {
+        files.add(file);
+      }
+    }
+  }
+
+  return Array.from(files);
+}
+
 export function extractEntryAssets(entryPointFiles: string[]): EntryAssets {
   const assets: {
     js: string[];


### PR DESCRIPTION
## Summary

- collect utoopack entry assets from both `entrypoints.umi.assets` and chunk files
- write all client CSS assets into the SSR build manifest so pre-rendered HTML can inject them before hydration
- refresh the utoopack SSR client manifest before static HTML generation

## Test

- `pnpm --filter @umijs/preset-umi test -- extractEntryAssets.test.ts utils.test.ts`
- `pnpm --filter @umijs/renderer-react test -- html.test.ts`
- `pnpm --filter umi... build`
- `UTOOPACK=/Users/zoomdong/umi/packages/bundler-utoopack npx -y node@24 /Users/zoomdong/.nvm/versions/node/v22.21.1/bin/pnpm --filter @umijs/docs build`