### PR TITLE
fix: prevent dev server path traversal

### DIFF
--- a/packages/bundler-webpack/src/server/server.ts
+++ b/packages/bundler-webpack/src/server/server.ts
@@ -11,6 +11,7 @@ import http from 'http';
 import { extname, join } from 'path';
 import { MESSAGE_TYPE } from '../constants';
 import { IConfig } from '../types';
+import { resolvePathWithinRoot } from './utils';
 import { createWebSocketServer } from './ws';
 
 interface IOpts {
@@ -52,7 +53,14 @@ export async function createServer(opts: IOpts): Promise<any> {
   // debug all js file
   app.use((req, res, next) => {
     const file = req.path;
-    const filePath = join(opts.cwd, file);
+    const filePath = resolvePathWithinRoot(opts.cwd, file);
+    if (!filePath) {
+      if (extname(file) === '.js') {
+        res.status(403).end('Forbidden');
+        return;
+      }
+      return next();
+    }
     const ext = extname(filePath);
 
     if (ext === '.js' && existsSync(filePath)) {

--- a/packages/bundler-webpack/src/server/utils.test.ts
+++ b/packages/bundler-webpack/src/server/utils.test.ts
@@ -1,0 +1,20 @@
+import { join, resolve } from 'path';
+import { resolvePathWithinRoot } from './utils';
+
+test('resolve path within root', () => {
+  const root = resolve('/tmp/umi-app');
+
+  expect(resolvePathWithinRoot(root, '/src/index.js')).toEqual(
+    join(root, 'src/index.js'),
+  );
+  expect(resolvePathWithinRoot(root, '/src/../index.js')).toEqual(
+    join(root, 'index.js'),
+  );
+});
+
+test('reject path traversal outside root', () => {
+  const root = resolve('/tmp/umi-app');
+
+  expect(resolvePathWithinRoot(root, '/../secret.js')).toBe(null);
+  expect(resolvePathWithinRoot(root, '/../umi-app2/secret.js')).toBe(null);
+});

--- a/packages/bundler-webpack/src/server/utils.test.ts
+++ b/packages/bundler-webpack/src/server/utils.test.ts
@@ -10,6 +10,9 @@ test('resolve path within root', () => {
   expect(resolvePathWithinRoot(root, '/src/../index.js')).toEqual(
     join(root, 'index.js'),
   );
+  expect(resolvePathWithinRoot(root, '/..foo.js')).toEqual(
+    join(root, '..foo.js'),
+  );
 });
 
 test('reject path traversal outside root', () => {

--- a/packages/bundler-webpack/src/server/utils.ts
+++ b/packages/bundler-webpack/src/server/utils.ts
@@ -1,11 +1,15 @@
-import { isAbsolute, relative, resolve } from 'path';
+import { isAbsolute, relative, resolve, sep } from 'path';
 
 export function resolvePathWithinRoot(root: string, file: string) {
   const resolvedRoot = resolve(root);
   const filePath = resolve(resolvedRoot, `.${file}`);
   const relativePath = relative(resolvedRoot, filePath);
 
-  if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+  if (
+    relativePath === '..' ||
+    relativePath.startsWith(`..${sep}`) ||
+    isAbsolute(relativePath)
+  ) {
     return null;
   }
 

--- a/packages/bundler-webpack/src/server/utils.ts
+++ b/packages/bundler-webpack/src/server/utils.ts
@@ -1,0 +1,13 @@
+import { isAbsolute, relative, resolve } from 'path';
+
+export function resolvePathWithinRoot(root: string, file: string) {
+  const resolvedRoot = resolve(root);
+  const filePath = resolve(resolvedRoot, `.${file}`);
+  const relativePath = relative(resolvedRoot, filePath);
+
+  if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+    return null;
+  }
+
+  return filePath;
+}


### PR DESCRIPTION
## Summary

Fixes #13350.

This prevents the `@umijs/bundler-webpack` dev server debug `.js` middleware from serving JavaScript files outside the configured `cwd` when the request path contains `..` segments.

## Root Cause

The middleware previously joined `opts.cwd` with `req.path` and called `res.sendFile` when the resulting path existed and ended in `.js`. A path like `/../secret.js` could resolve to a sibling file outside the project root.

## Changes

- Resolve requested paths against the configured root with `path.resolve`.
- Validate containment with `path.relative` before serving files.
- Return `403 Forbidden` for `.js` requests that resolve outside `cwd`.
- Add regression coverage for normal paths, normalized in-root paths, sibling traversal, and similar-prefix directories.

## Verification

```bash
pnpm jest packages/bundler-webpack/src/server/utils.test.ts --runInBand --detectOpenHandles
```