### PR TITLE
fix: avoid pruning utoopack overlay entry imports

### DIFF
--- a/packages/bundler-utoopack/src/config.test.ts
+++ b/packages/bundler-utoopack/src/config.test.ts
@@ -303,8 +303,10 @@ describe('utoopack alias config', () => {
     expect(overlayEntry).toEqual(
       expect.stringContaining('/utoopack-overlay/umi.js'),
     );
-    expect(overlayEntryContent).toContain('import "./client.js";');
+    expect(overlayEntryContent).toContain('void import("./client.js")');
+    expect(overlayEntryContent).toContain('.then(() => import(');
     expect(overlayEntryContent).toContain('src/.umi/umi.ts');
+    expect(overlayEntryContent).not.toContain('import "./client.js";');
   });
 
   test('uses separate utoopack error overlay wrapper files for multiple development entries', async () => {

--- a/packages/bundler-utoopack/src/config.ts
+++ b/packages/bundler-utoopack/src/config.ts
@@ -305,6 +305,16 @@ function getOverlayEntryPath(cwd: string, entryName: string) {
   );
 }
 
+function createDynamicImportChain(imports: string[]) {
+  return `void ${imports
+    .map((item, index) =>
+      index === 0
+        ? `import(${JSON.stringify(item)})`
+        : `.then(() => import(${JSON.stringify(item)}))`,
+    )
+    .join('')};\n`;
+}
+
 function writeUtoopackOverlayEntry(opts: {
   cwd: string;
   entryName: string;
@@ -318,14 +328,12 @@ function writeUtoopackOverlayEntry(opts: {
   fs.copyFileSync(UTOOPACK_OVERLAY_CLIENT_ENTRY, overlayClientPath);
   fs.writeFileSync(
     entryPath,
-    [
+    createDynamicImportChain([
       getRelativeImportSpecifier(entryPath, overlayClientPath),
       ...opts.imports.map((item) =>
         getOverlayEntryImport(item, opts.cwd, entryPath),
       ),
-    ]
-      .map((item) => `import ${JSON.stringify(item)};`)
-      .join('\n') + '\n',
+    ]),
     'utf-8',
   );
   return entryPath;


### PR DESCRIPTION
## Summary

- Generate the utoopack error overlay wrapper with ordered dynamic imports instead of static side-effect imports.
- Keep the overlay client loaded before the real application entry.
- Update the bundler-utoopack config test to assert the dynamic import wrapper shape.

## Root Cause

Projects such as ant-design can set package-level `sideEffects` to a narrow list. The generated utoopack overlay entry previously used only static side-effect imports, so the real Umi entry could be treated as tree-shakeable and pruned, leaving the dev page blank.

## Validation

```bash
pnpm prettier --write packages/bundler-utoopack/src/config.ts packages/bundler-utoopack/src/config.test.ts
pnpm --filter @umijs/bundler-utoopack test config.test.ts
```
