### PR TITLE
fix: improve React 19 compatibility

### DIFF
--- a/docs/docs/docs/api/config.en-US.md
+++ b/docs/docs/docs/api/config.en-US.md
@@ -706,8 +706,8 @@ forget: {
 
 Note:
 
-1. forget is currently incompatible with mfsu and mako. If forget is enabled while mfsu or mako is on, an error will be thrown.
-2. forget requires react 19. When using it, please manually install react@rc and react-dom@rc as project dependencies.
+1. forget is currently incompatible with mfsu, mako, and utoopack. If forget is enabled while mfsu, mako, or utoopack is on, an error will be thrown.
+2. forget requires React 19. When using it, please manually install react@19 and react-dom@19 as project dependencies.
 
 ## forkTSChecker
 

--- a/docs/docs/docs/api/config.md
+++ b/docs/docs/docs/api/config.md
@@ -705,8 +705,8 @@ forget: {
 
 注意：
 
-1、forget 和 mfsu、mako 暂时不兼容，如果开启了 forget，同时 mfsu、mako 有打开时会抛错。
-2、forget 需要 react 19，使用时，请手动安装 react@rc 和 react-dom@rc 到项目依赖。
+1、forget 和 mfsu、mako、utoopack 暂时不兼容，如果开启了 forget，同时 mfsu、mako、utoopack 有打开时会抛错。
+2、forget 需要 React 19，使用时，请手动安装 react@19 和 react-dom@19 到项目依赖。
 
 ## forkTSChecker
 

--- a/examples/with-react-19/.umirc.ts
+++ b/examples/with-react-19/.umirc.ts
@@ -1,6 +1,9 @@
 export default {
+  plugins: ['@umijs/plugins/dist/initial-state', '@umijs/plugins/dist/model'],
   routes: [{ path: '/', component: 'index' }],
   npmClient: 'pnpm',
   forget: {},
+  initialState: {},
+  model: {},
   mfsu: false,
 };

--- a/examples/with-react-19/app.ts
+++ b/examples/with-react-19/app.ts
@@ -1,0 +1,10 @@
+async function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function getInitialState() {
+  await delay(50);
+  return {
+    name: 'React 19',
+  };
+}

--- a/examples/with-react-19/package.json
+++ b/examples/with-react-19/package.json
@@ -9,6 +9,7 @@
     "start": "npm run dev"
   },
   "dependencies": {
+    "@umijs/plugins": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "umi": "workspace:*"

--- a/examples/with-react-19/pages/index.tsx
+++ b/examples/with-react-19/pages/index.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react';
+// @ts-ignore
+import { useModel } from 'umi';
 
 // 创建一个子组件来测试 React Compiler 的优化
 function ExpensiveComponent({ count }: { count: number }) {
@@ -9,6 +11,7 @@ function ExpensiveComponent({ count }: { count: number }) {
 }
 
 export default function HomePage() {
+  const { initialState, loading } = useModel('@@initialState');
   const [count, setCount] = useState(0);
   const [name, setName] = useState('Umi');
 
@@ -21,6 +24,9 @@ export default function HomePage() {
   return (
     <div>
       <h1>React: {React.version}</h1>
+      <p>
+        Initial State: {loading ? 'loading' : initialState?.name || 'unknown'}
+      </p>
       <p>Forget (React Compiler) is enabled</p>
       <div>
         <input

--- a/packages/bundler-utoopack/src/config.test.ts
+++ b/packages/bundler-utoopack/src/config.test.ts
@@ -303,8 +303,10 @@ describe('utoopack alias config', () => {
     expect(overlayEntry).toEqual(
       expect.stringContaining('/utoopack-overlay/umi.js'),
     );
-    expect(overlayEntryContent).toContain('import "./client.js";');
+    expect(overlayEntryContent).toContain('void import("./client.js")');
+    expect(overlayEntryContent).toContain('.then(() => import(');
     expect(overlayEntryContent).toContain('src/.umi/umi.ts');
+    expect(overlayEntryContent).not.toContain('import "./client.js";');
   });
 
   test('uses separate utoopack error overlay wrapper files for multiple development entries', async () => {

--- a/packages/bundler-utoopack/src/config.ts
+++ b/packages/bundler-utoopack/src/config.ts
@@ -305,6 +305,16 @@ function getOverlayEntryPath(cwd: string, entryName: string) {
   );
 }
 
+function createDynamicImportChain(imports: string[]) {
+  return `void ${imports
+    .map((item, index) =>
+      index === 0
+        ? `import(${JSON.stringify(item)})`
+        : `.then(() => import(${JSON.stringify(item)}))`,
+    )
+    .join('')};\n`;
+}
+
 function writeUtoopackOverlayEntry(opts: {
   cwd: string;
   entryName: string;
@@ -318,14 +328,12 @@ function writeUtoopackOverlayEntry(opts: {
   fs.copyFileSync(UTOOPACK_OVERLAY_CLIENT_ENTRY, overlayClientPath);
   fs.writeFileSync(
     entryPath,
-    [
+    createDynamicImportChain([
       getRelativeImportSpecifier(entryPath, overlayClientPath),
       ...opts.imports.map((item) =>
         getOverlayEntryImport(item, opts.cwd, entryPath),
       ),
-    ]
-      .map((item) => `import ${JSON.stringify(item)};`)
-      .join('\n') + '\n',
+    ]),
     'utf-8',
   );
   return entryPath;

--- a/packages/plugins/libs/qiankun/slave/lifecycles.ts
+++ b/packages/plugins/libs/qiankun/slave/lifecycles.ts
@@ -146,14 +146,14 @@ export function genUnmount(mountElementId: string) {
   return async (props: any) => {
     const root = __getRoot();
 
-    // support react 18 unmount
+    // support react 18+ unmount
     if (typeof root?.unmount === 'function') {
       root.unmount();
     } else {
       const container = props?.container
         ? props.container.querySelector(`#${mountElementId}`)
         : document.getElementById(mountElementId);
-      if (container) {
+      if (container && typeof ReactDOM.unmountComponentAtNode === 'function') {
         ReactDOM.unmountComponentAtNode(container);
       }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1464,6 +1464,9 @@ importers:
 
   examples/with-react-19:
     dependencies:
+      '@umijs/plugins':
+        specifier: workspace:*
+        version: link:../../packages/plugins
       react:
         specifier: ^19.0.0
         version: 19.2.0


### PR DESCRIPTION
## Summary
- extend the React 19 example to cover initialState/model runtime usage
- guard qiankun slave unmount against the legacy ReactDOM.unmountComponentAtNode API removed in React 19
- update forget docs to reference stable React 19 and include utoopack in the incompatibility note

## Test
- pnpm --dir examples/with-react-19 build
- pnpm --filter @umijs/plugins build
- Playwright smoke test against examples/with-react-19 preview: page rendered React 19.2.0 + Initial State, no pageerror

Closes #13114