### PR TITLE
feat(utoopack): support babel react compiler

### DIFF
--- a/docs/docs/docs/api/config.en-US.md
+++ b/docs/docs/docs/api/config.en-US.md
@@ -712,7 +712,7 @@ reactCompiler: {
 
 Note:
 
-1. reactCompiler is currently incompatible with mfsu, mako, and utoopack. If they are enabled together, an error will be thrown.
+1. reactCompiler is currently incompatible with mfsu and mako. If they are enabled together, an error will be thrown; utoopack passes the React Compiler plugin config through babel-loader.
 2. reactCompiler targets React 19 by default. Please install react@19 and react-dom@19 as project dependencies. To use React 17 or 18, configure the matching `target` and install react-compiler-runtime.
 3. The old `forget` config is still accepted for compatibility, but it is deprecated. Please migrate to `reactCompiler`.
 

--- a/docs/docs/docs/api/config.md
+++ b/docs/docs/docs/api/config.md
@@ -711,7 +711,7 @@ reactCompiler: {
 
 注意：
 
-1、reactCompiler 和 mfsu、mako、utoopack 暂时不兼容，如果同时打开会抛错。
+1、reactCompiler 和 mfsu、mako 暂时不兼容，如果同时打开会抛错；utoopack 会通过 babel-loader 传递 React Compiler 插件配置。
 2、reactCompiler 默认面向 React 19，使用时请安装 react@19 和 react-dom@19 到项目依赖。如果需要配合 React 17 或 18 使用，请配置对应的 `target` 并安装 react-compiler-runtime。
 3、旧配置项 `forget` 仍可兼容使用，但已废弃，请迁移到 `reactCompiler`。
 

--- a/examples/with-react-19/.umirc.ts
+++ b/examples/with-react-19/.umirc.ts
@@ -3,6 +3,7 @@ export default {
   routes: [{ path: '/', component: 'index' }],
   npmClient: 'pnpm',
   reactCompiler: true,
+  utoopack: {},
   initialState: {},
   model: {},
   mfsu: false,

--- a/packages/bundler-utoopack/src/config.test.ts
+++ b/packages/bundler-utoopack/src/config.test.ts
@@ -450,17 +450,17 @@ describe('utoopack extra babel config', () => {
     } as any);
 
     const rules = config.config.module?.rules || {};
-    const rule = rules['**/src/**/*.tsx'] as any;
+    const rule = rules['**/*.tsx'] as any;
     const loader = rule.loaders[0];
 
     expect(Object.keys(rules)).toEqual(
       expect.arrayContaining([
-        '**/src/**/*.js',
-        '**/src/**/*.mjs',
-        '**/src/**/*.cjs',
-        '**/src/**/*.jsx',
-        '**/src/**/*.ts',
-        '**/src/**/*.tsx',
+        '**/*.js',
+        '**/*.mjs',
+        '**/*.cjs',
+        '**/*.jsx',
+        '**/*.ts',
+        '**/*.tsx',
       ]),
     );
     expect(rule.as).toBe('*.js');
@@ -520,6 +520,29 @@ describe('utoopack extra babel config', () => {
     expect(config.config.styles?.emotion).toBe(true);
   });
 
+  test('adds babel-loader rules for reactCompiler without utoopack babelLoader', async () => {
+    const reactCompilerPlugin = [
+      'babel-plugin-react-compiler',
+      { target: '18' },
+    ];
+    const config = await getProdUtooPackConfig({
+      ...baseOpts,
+      beforeBabelPlugins: [reactCompilerPlugin],
+      config: {
+        reactCompiler: {
+          target: '18',
+        },
+        utoopack: {},
+      },
+    } as any);
+
+    const rule = config.config.module?.rules?.['**/*.tsx'] as any;
+    const loader = rule.loaders[0];
+
+    expect(loader.loader).toContain('babel-loader');
+    expect(loader.options.plugins).toEqual([reactCompilerPlugin]);
+  });
+
   test('keeps native babel plugin adapters when babelLoader is enabled', async () => {
     const config = await getDevUtooPackConfig({
       ...baseOpts,
@@ -538,7 +561,7 @@ describe('utoopack extra babel config', () => {
       },
     } as any);
 
-    const rule = config.config.module?.rules?.['**/src/**/*.tsx'] as any;
+    const rule = config.config.module?.rules?.['**/*.tsx'] as any;
     const loader = rule.loaders[0];
 
     expect(loader.options.plugins).toEqual(['babel-plugin-istanbul']);

--- a/packages/bundler-utoopack/src/config.ts
+++ b/packages/bundler-utoopack/src/config.ts
@@ -185,6 +185,20 @@ function isSerializableBabelItem(item: any) {
   }
 }
 
+function isReactCompilerEnabled(config: Record<string, any>) {
+  if ('reactCompiler' in config) {
+    return config.reactCompiler !== false;
+  }
+
+  return 'forget' in config;
+}
+
+function shouldAddBabelLoaderRules(config: Record<string, any>) {
+  return (
+    config.utoopack?.babelLoader === true || isReactCompilerEnabled(config)
+  );
+}
+
 function getExtraBabelModuleRules(opts: {
   babelPreset?: any;
   beforeBabelPlugins?: any[];
@@ -193,7 +207,7 @@ function getExtraBabelModuleRules(opts: {
   extraBabelPresets?: any[];
   config: Record<string, any>;
 }) {
-  if (opts.config.utoopack?.babelLoader !== true) {
+  if (!shouldAddBabelLoaderRules(opts.config)) {
     return {};
   }
 
@@ -242,7 +256,7 @@ function getExtraBabelModuleRules(opts: {
     module: {
       rules: Object.fromEntries(
         ['js', 'mjs', 'cjs', 'jsx', 'ts', 'tsx'].map((ext) => [
-          `**/src/**/*.${ext}`,
+          `**/*.${ext}`,
           rule,
         ]),
       ),

--- a/packages/preset-umi/src/features/reactCompiler/reactCompiler.ts
+++ b/packages/preset-umi/src/features/reactCompiler/reactCompiler.ts
@@ -58,11 +58,6 @@ export default (api: IApi) => {
         `reactCompiler is not compatible with mako, please disable mako first.`,
       );
     }
-    if (api.config.utoopack) {
-      throw new Error(
-        `reactCompiler is not compatible with utoopack, please disable utoopack first.`,
-      );
-    }
   });
 
   api.onCheck(() => {


### PR DESCRIPTION
## Summary

- allow `reactCompiler` to be used together with `utoopack`
- have utoopack emit babel-loader rules automatically when React Compiler is enabled
- apply the babel-loader rules to project JS/TS files outside `src`, such as Umi's root `pages/` directory
- enable utoopack in the existing `with-react-19` example to cover the combined setup
- document that utoopack passes React Compiler config through babel-loader

## Test

- `pnpm --filter @umijs/bundler-utoopack test -- config.test.ts`
- `pnpm --filter @umijs/bundler-utoopack build`
- `pnpm --filter @example/with-react-19 build`
- inspected `examples/with-react-19/dist/pages_index_tsx_js_*.async.js` and confirmed React Compiler memo cache output (`c(...)` / `react.memo_cache_sentinel`)
- `git diff --check`