### PR TITLE
chore: move umi lint to dev dependency

### DIFF
--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -41,7 +41,6 @@
     "@umijs/bundler-utils": "workspace:*",
     "@umijs/bundler-webpack": "workspace:*",
     "@umijs/core": "workspace:*",
-    "@umijs/lint": "workspace:*",
     "@umijs/preset-umi": "workspace:*",
     "@umijs/renderer-react": "workspace:*",
     "@umijs/server": "workspace:*",
@@ -49,6 +48,9 @@
     "@umijs/utils": "workspace:*",
     "prettier-plugin-organize-imports": "^3.2.2",
     "prettier-plugin-packagejson": "2.4.3"
+  },
+  "devDependencies": {
+    "@umijs/lint": "workspace:*"
   },
   "engines": {
     "node": ">=14"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2860,9 +2860,6 @@ importers:
       '@umijs/core':
         specifier: workspace:*
         version: link:../core
-      '@umijs/lint':
-        specifier: workspace:*
-        version: link:../lint
       '@umijs/preset-umi':
         specifier: workspace:*
         version: link:../preset-umi
@@ -2884,6 +2881,10 @@ importers:
       prettier-plugin-packagejson:
         specifier: 2.4.3
         version: 2.4.3(prettier@2.8.4)
+    devDependencies:
+      '@umijs/lint':
+        specifier: workspace:*
+        version: link:../lint
 
   packages/utils:
     dependencies:


### PR DESCRIPTION
## Summary

Fixes #13103.

Moves `@umijs/lint` out of `umi`'s production dependencies and keeps it as a package-level dev dependency for workspace development. This matches the existing lint guide, which says plain Umi users should install `@umijs/lint` themselves, while Umi Max continues to include lint support through `@umijs/max`.

## Impact

Projects that install `umi` indirectly, such as through `dumi`, no longer pull `@umijs/lint` as a production dependency from `umi`, reducing unnecessary lint-related dependency installation and peer warnings.

## Validation

- `git diff --check`
- Verified `packages/umi/package.json` no longer lists `@umijs/lint` under `dependencies`
- Verified `pnpm-lock.yaml` moves `@umijs/lint` from the `packages/umi` importer dependencies to devDependencies

Note: full frozen lockfile validation is currently blocked by an existing unrelated mismatch for `packages/bundler-utoopack` (`@utoo/pack` alpha.1 in package.json vs alpha.0 in the lockfile baseline).