### PR TITLE
fix: force child process runtime for utoopack SSR

### DIFF
--- a/packages/bundler-utoopack/src/config.test.ts
+++ b/packages/bundler-utoopack/src/config.test.ts
@@ -203,6 +203,7 @@ describe('utoopack ssr config', () => {
     expect(rules['*.jpg']).toBeUndefined();
     expect(rules['*.woff']).toBeUndefined();
     expect(config.config.output?.clean).toBe(true);
+    expect(config.config.pluginRuntimeStrategy).toBe('childProcesses');
   });
 });
 

--- a/packages/bundler-utoopack/src/config.ts
+++ b/packages/bundler-utoopack/src/config.ts
@@ -923,6 +923,7 @@ export async function getSSRUtooPackConfig(
     target: 'node',
     sourceMaps: false,
     stats: true,
+    pluginRuntimeStrategy: 'childProcesses',
     nodePolyfill: false,
     optimization: {
       ...utooBundlerOpts.config.optimization,


### PR DESCRIPTION
## What changed

- Force utoopack SSR builds to use `pluginRuntimeStrategy: 'childProcesses'` from the Umi adapter layer.
- Add a config test to lock the SSR runtime strategy.

## Why

`@utoo/pack` can default to the `workerThreads` plugin runtime on newer Node 24 versions. The docs SSR build path can hit a native segfault after utoopack compilation when that runtime is used. For SSR builds, forcing `childProcesses` keeps plugin/loader execution isolated and avoids the Node 24 worker/N-API crash path.

## Validation

- `pnpm --filter umi... build`
- `pnpm --filter @umijs/bundler-utoopack test -- config.test.ts`