### PR TITLE
ci: fix qiankun preview startup on windows

### DIFF
--- a/examples/with-utoopack-qiankun-master/scripts/start-preview.js
+++ b/examples/with-utoopack-qiankun-master/scripts/start-preview.js
@@ -1,7 +1,8 @@
 const { spawn } = require('child_process');
 const path = require('path');
 
-const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const isWindows = process.platform === 'win32';
+const npm = isWindows ? 'npm.cmd' : 'npm';
 const root = path.resolve(__dirname, '..');
 let shuttingDown = false;
 
@@ -21,6 +22,7 @@ const children = apps.map((app) => {
     cwd: app.cwd,
     stdio: 'inherit',
     env: process.env,
+    shell: isWindows,
   });
 
   child.on('exit', (code, signal) => {


### PR DESCRIPTION
## What changed

- Run the utoopack qiankun preview launcher through the Windows shell when spawning npm.

## Why

The Windows qiankun CI job fails before Cypress starts because `start-preview.js` directly spawns `npm.cmd`, which can throw `spawn EINVAL` on the Windows runner. Running the command through the shell follows Node's recommended path for `.cmd` files.

## Validation

- `node -c examples/with-utoopack-qiankun-master/scripts/start-preview.js`
- `git diff --check`