### PR TITLE
fix: keep tailwindcss watch alive in dev

### DIFF
--- a/packages/plugins/src/tailwindcss.ts
+++ b/packages/plugins/src/tailwindcss.ts
@@ -99,7 +99,7 @@ export default (api: IApi) => {
           inputPath,
           '-o',
           generatedPath,
-          api.env === 'development' ? '--watch' : '',
+          api.env === 'development' ? '--watch=always' : '',
         ],
         {
           stdio: 'inherit',


### PR DESCRIPTION
## Summary

- use `--watch=always` for the Tailwind CSS CLI in development mode
- keep the Tailwind watcher alive when the parent process stdin closes

## Why

The Tailwind CLI may exit its watch process when stdin ends. In Umi's Tailwind v3 path, that can stop `.umi/plugin-tailwindcss/tailwind.css` from being generated or updated during dev. Passing `--watch=always` makes the intended long-running dev watcher explicit.

## Validation

- `pnpm --filter @umijs/plugins build`