### PR TITLE
chore: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are provided for the latest stable major version of Umi.
+
+Please make sure you are using the latest available release before reporting a vulnerability.
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in Umi, please report it privately through GitHub's vulnerability reporting flow:
+
+https://github.com/umijs/umi/security/advisories/new
+
+Please do not report suspected security vulnerabilities through public GitHub issues, discussions, or pull requests.
+
+When submitting a report, include as much detail as possible:
+
+- A description of the vulnerability and its impact
+- Steps to reproduce or a minimal reproduction
+- Affected versions, packages, and environments
+- Any known mitigations or workarounds
+
+The maintainers will review the report and coordinate any fixes or disclosure through GitHub Security Advisories.


### PR DESCRIPTION
## Summary

- add `SECURITY.md` with private vulnerability reporting guidance
- direct security researchers away from public issues for suspected vulnerabilities
- enable GitHub Private Vulnerability Reporting for the repository

Refs #13350

## Test

- `pnpm exec prettier --check SECURITY.md`