### PR TITLE
ci(core): enable oidc publish for all umi packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24.x
-          registry-url: 'https://registry.npmjs.org/'
           cache: 'pnpm'
 
       - name: Check npm version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24.x
+          registry-url: 'https://registry.npmjs.org/'
           cache: 'pnpm'
 
       - name: Check npm version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+env:
+  NODE_OPTIONS: --max-old-space-size=6144
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, '-canary.')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          registry-url: 'https://registry.npmjs.org/'
+          cache: 'pnpm'
+
+      - name: Check npm version
+        run: |
+          npm --version
+          node -e "const v = require('child_process').execSync('npm --version').toString().trim().split('.').map(Number); if (v[0] < 11 || (v[0] === 11 && (v[1] < 5 || (v[1] === 5 && v[2] < 1)))) throw new Error('npm 11.5.1 or later is required for trusted publishing')"
+
+      - name: Install dependencies
+        run: pnpm i --frozen-lockfile
+
+      - name: Check package files
+        run: pnpm check:packageFiles
+
+      - name: Build packages
+        run: pnpm build:release
+
+      - name: Publish packages
+        run: pnpm release:publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,11 +47,11 @@ jobs:
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
 
-      - name: Check package files
-        run: pnpm check:packageFiles
-
       - name: Build packages
         run: pnpm build:release
+
+      - name: Check package files
+        run: pnpm check:packageFiles
 
       - name: Publish packages
         run: pnpm release:publish

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "workspaces": ["packages/*"]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "workspaces": ["packages/*"]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "workspaces": ["packages/*"]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "workspaces": ["packages/*"]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "workspaces": ["packages/*"]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "workspaces": ["packages/*"]
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jest": "jest",
     "prepare": "husky install",
     "release": "umi-scripts release",
+    "release:publish": "umi-scripts releasePublish",
     "setup": "pnpm --filter @umijs/ui run setup",
     "setup:webstorm": "umi-scripts setupWebStorm",
     "sync:mako": "umi-scripts syncMako",
@@ -124,10 +125,10 @@
     "umi-scripts": "workspace:*",
     "zx": "^7.1.1"
   },
-  "packageManager": "pnpm@8.11.0",
+  "packageManager": "pnpm@8.15.9",
   "engines": {
     "node": ">=14",
-    "pnpm": "^8.11.0"
+    "pnpm": "^8.15.9"
   },
   "volta": {
     "node": "20.18.1",

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/ast",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "description": "@umijs/ast",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/ast#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/ast",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "description": "@umijs/ast",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/ast#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/ast",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "description": "@umijs/ast",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/ast#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/ast",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "description": "@umijs/ast",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/ast#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -6,7 +6,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/ast"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/ast",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "description": "@umijs/ast",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/ast#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/ast",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "description": "@umijs/ast",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/ast#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/babel-preset-umi/package.json
+++ b/packages/babel-preset-umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/babel-preset-umi",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "description": "Official babel preset for umi.",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/babel-preset-umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/babel-preset-umi/package.json
+++ b/packages/babel-preset-umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/babel-preset-umi",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "description": "Official babel preset for umi.",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/babel-preset-umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/babel-preset-umi/package.json
+++ b/packages/babel-preset-umi/package.json
@@ -6,7 +6,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/babel-preset-umi"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/babel-preset-umi/package.json
+++ b/packages/babel-preset-umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/babel-preset-umi",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "description": "Official babel preset for umi.",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/babel-preset-umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/babel-preset-umi/package.json
+++ b/packages/babel-preset-umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/babel-preset-umi",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "description": "Official babel preset for umi.",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/babel-preset-umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/babel-preset-umi/package.json
+++ b/packages/babel-preset-umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/babel-preset-umi",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "description": "Official babel preset for umi.",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/babel-preset-umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/babel-preset-umi/package.json
+++ b/packages/babel-preset-umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/babel-preset-umi",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "description": "Official babel preset for umi.",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/babel-preset-umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/bundler-esbuild/package.json
+++ b/packages/bundler-esbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-esbuild",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "description": "@umijs/bundler-esbuild",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-esbuild#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/bundler-esbuild/package.json
+++ b/packages/bundler-esbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-esbuild",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "description": "@umijs/bundler-esbuild",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-esbuild#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/bundler-esbuild/package.json
+++ b/packages/bundler-esbuild/package.json
@@ -6,7 +6,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/bundler-esbuild"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/bundler-esbuild/package.json
+++ b/packages/bundler-esbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-esbuild",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "description": "@umijs/bundler-esbuild",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-esbuild#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/bundler-esbuild/package.json
+++ b/packages/bundler-esbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-esbuild",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "description": "@umijs/bundler-esbuild",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-esbuild#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/bundler-esbuild/package.json
+++ b/packages/bundler-esbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-esbuild",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "description": "@umijs/bundler-esbuild",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-esbuild#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/bundler-esbuild/package.json
+++ b/packages/bundler-esbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-esbuild",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "description": "@umijs/bundler-esbuild",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-esbuild#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/bundler-utils/package.json
+++ b/packages/bundler-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-utils",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-utils#readme",
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {

--- a/packages/bundler-utils/package.json
+++ b/packages/bundler-utils/package.json
@@ -5,7 +5,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/bundler-utils"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/bundler-utils/package.json
+++ b/packages/bundler-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-utils",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-utils#readme",
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {

--- a/packages/bundler-utils/package.json
+++ b/packages/bundler-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-utils",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-utils#readme",
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {

--- a/packages/bundler-utils/package.json
+++ b/packages/bundler-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-utils",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-utils#readme",
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {

--- a/packages/bundler-utils/package.json
+++ b/packages/bundler-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-utils",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-utils#readme",
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {

--- a/packages/bundler-utils/package.json
+++ b/packages/bundler-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-utils",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-utils#readme",
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {

--- a/packages/bundler-utoopack/package.json
+++ b/packages/bundler-utoopack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-utoopack",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "description": "@umijs/bundler-utoopack",
   "repository": {
     "type": "git",

--- a/packages/bundler-utoopack/package.json
+++ b/packages/bundler-utoopack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-utoopack",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "description": "@umijs/bundler-utoopack",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/bundler-utoopack/package.json
+++ b/packages/bundler-utoopack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-utoopack",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "description": "@umijs/bundler-utoopack",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/bundler-utoopack/package.json
+++ b/packages/bundler-utoopack/package.json
@@ -2,6 +2,11 @@
   "name": "@umijs/bundler-utoopack",
   "version": "4.6.70-alpha.2",
   "description": "@umijs/bundler-utoopack",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/bundler-utoopack"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/bundler-utoopack/package.json
+++ b/packages/bundler-utoopack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-utoopack",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "description": "@umijs/bundler-utoopack",
   "repository": {
     "type": "git",

--- a/packages/bundler-utoopack/package.json
+++ b/packages/bundler-utoopack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-utoopack",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "description": "@umijs/bundler-utoopack",
   "repository": {
     "type": "git",

--- a/packages/bundler-utoopack/package.json
+++ b/packages/bundler-utoopack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-utoopack",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "description": "@umijs/bundler-utoopack",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/bundler-vite/package.json
+++ b/packages/bundler-vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-vite",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "description": "@umijs/bundler-vite",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-vite#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/bundler-vite/package.json
+++ b/packages/bundler-vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-vite",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "description": "@umijs/bundler-vite",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-vite#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/bundler-vite/package.json
+++ b/packages/bundler-vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-vite",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "description": "@umijs/bundler-vite",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-vite#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/bundler-vite/package.json
+++ b/packages/bundler-vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-vite",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "description": "@umijs/bundler-vite",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-vite#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/bundler-vite/package.json
+++ b/packages/bundler-vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-vite",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "description": "@umijs/bundler-vite",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-vite#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/bundler-vite/package.json
+++ b/packages/bundler-vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-vite",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "description": "@umijs/bundler-vite",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-vite#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/bundler-vite/package.json
+++ b/packages/bundler-vite/package.json
@@ -6,7 +6,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/bundler-vite"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-webpack",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "description": "@umijs/bundler-webpack",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-webpack#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-webpack",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "description": "@umijs/bundler-webpack",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-webpack#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-webpack",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "description": "@umijs/bundler-webpack",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-webpack#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-webpack",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "description": "@umijs/bundler-webpack",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-webpack#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -6,7 +6,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/bundler-webpack"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-webpack",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "description": "@umijs/bundler-webpack",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-webpack#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/bundler-webpack/package.json
+++ b/packages/bundler-webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/bundler-webpack",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "description": "@umijs/bundler-webpack",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/bundler-webpack#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/core",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/core#readme",
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/core",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/core#readme",
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/core",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/core#readme",
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/core",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/core#readme",
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/core",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/core#readme",
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/core",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/core#readme",
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/core"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/create-umi/package.json
+++ b/packages/create-umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-umi",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "description": "create-umi",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/create-umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/create-umi/package.json
+++ b/packages/create-umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-umi",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "description": "create-umi",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/create-umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/create-umi/package.json
+++ b/packages/create-umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-umi",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "description": "create-umi",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/create-umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/create-umi/package.json
+++ b/packages/create-umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-umi",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "description": "create-umi",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/create-umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/create-umi/package.json
+++ b/packages/create-umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-umi",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "description": "create-umi",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/create-umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/create-umi/package.json
+++ b/packages/create-umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-umi",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "description": "create-umi",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/create-umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/create-umi/package.json
+++ b/packages/create-umi/package.json
@@ -6,7 +6,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/create-umi"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/lint",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "description": "@umijs/lint",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/lint#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -6,7 +6,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/lint"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/lint",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "description": "@umijs/lint",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/lint#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/lint",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "description": "@umijs/lint",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/lint#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/lint",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "description": "@umijs/lint",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/lint#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/lint",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "description": "@umijs/lint",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/lint#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/lint",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "description": "@umijs/lint",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/lint#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/max/package.json
+++ b/packages/max/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/max",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "description": "@umijs/max",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/max#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/max/package.json
+++ b/packages/max/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/max",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "description": "@umijs/max",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/max#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/max/package.json
+++ b/packages/max/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/max",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "description": "@umijs/max",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/max#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/max/package.json
+++ b/packages/max/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/max",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "description": "@umijs/max",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/max#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/max/package.json
+++ b/packages/max/package.json
@@ -6,7 +6,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/max"
   },
   "license": "MIT",
   "main": "index.js",

--- a/packages/max/package.json
+++ b/packages/max/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/max",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "description": "@umijs/max",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/max#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/max/package.json
+++ b/packages/max/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/max",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "description": "@umijs/max",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/max#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/mfsu/package.json
+++ b/packages/mfsu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/mfsu",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "description": "@umijs/mfsu",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/mfsu#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/mfsu/package.json
+++ b/packages/mfsu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/mfsu",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "description": "@umijs/mfsu",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/mfsu#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/mfsu/package.json
+++ b/packages/mfsu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/mfsu",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "description": "@umijs/mfsu",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/mfsu#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/mfsu/package.json
+++ b/packages/mfsu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/mfsu",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "description": "@umijs/mfsu",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/mfsu#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/mfsu/package.json
+++ b/packages/mfsu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/mfsu",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "description": "@umijs/mfsu",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/mfsu#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/mfsu/package.json
+++ b/packages/mfsu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/mfsu",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "description": "@umijs/mfsu",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/mfsu#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/mfsu/package.json
+++ b/packages/mfsu/package.json
@@ -6,7 +6,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/mfsu"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/plugin-docs/package.json
+++ b/packages/plugin-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/plugin-docs",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "description": "@umijs/plugin-docs",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/plugin-docs#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/plugin-docs/package.json
+++ b/packages/plugin-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/plugin-docs",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "description": "@umijs/plugin-docs",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/plugin-docs#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/plugin-docs/package.json
+++ b/packages/plugin-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/plugin-docs",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "description": "@umijs/plugin-docs",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/plugin-docs#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/plugin-docs/package.json
+++ b/packages/plugin-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/plugin-docs",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "description": "@umijs/plugin-docs",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/plugin-docs#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/plugin-docs/package.json
+++ b/packages/plugin-docs/package.json
@@ -6,7 +6,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/plugin-docs"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/plugin-docs/package.json
+++ b/packages/plugin-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/plugin-docs",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "description": "@umijs/plugin-docs",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/plugin-docs#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/plugin-docs/package.json
+++ b/packages/plugin-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/plugin-docs",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "description": "@umijs/plugin-docs",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/plugin-docs#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/plugin-run/package.json
+++ b/packages/plugin-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/plugin-run",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "description": "@umijs/plugin-run",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/plugin-run#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/plugin-run/package.json
+++ b/packages/plugin-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/plugin-run",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "description": "@umijs/plugin-run",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/plugin-run#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/plugin-run/package.json
+++ b/packages/plugin-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/plugin-run",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "description": "@umijs/plugin-run",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/plugin-run#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/plugin-run/package.json
+++ b/packages/plugin-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/plugin-run",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "description": "@umijs/plugin-run",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/plugin-run#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/plugin-run/package.json
+++ b/packages/plugin-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/plugin-run",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "description": "@umijs/plugin-run",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/plugin-run#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/plugin-run/package.json
+++ b/packages/plugin-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/plugin-run",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "description": "@umijs/plugin-run",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/plugin-run#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/plugin-run/package.json
+++ b/packages/plugin-run/package.json
@@ -6,7 +6,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/plugin-run"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/plugins",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "description": "@umijs/plugins",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/plugins#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/plugins",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "description": "@umijs/plugins",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/plugins#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/plugins",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "description": "@umijs/plugins",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/plugins#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -6,7 +6,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/plugins"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/plugins",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "description": "@umijs/plugins",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/plugins#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/plugins",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "description": "@umijs/plugins",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/plugins#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/plugins",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "description": "@umijs/plugins",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/plugins#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/preset-umi/package.json
+++ b/packages/preset-umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/preset-umi",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "description": "@umijs/preset-umi",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/preset-umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/preset-umi/package.json
+++ b/packages/preset-umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/preset-umi",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "description": "@umijs/preset-umi",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/preset-umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/preset-umi/package.json
+++ b/packages/preset-umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/preset-umi",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "description": "@umijs/preset-umi",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/preset-umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/preset-umi/package.json
+++ b/packages/preset-umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/preset-umi",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "description": "@umijs/preset-umi",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/preset-umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/preset-umi/package.json
+++ b/packages/preset-umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/preset-umi",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "description": "@umijs/preset-umi",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/preset-umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/preset-umi/package.json
+++ b/packages/preset-umi/package.json
@@ -6,7 +6,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/preset-umi"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/preset-umi/package.json
+++ b/packages/preset-umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/preset-umi",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "description": "@umijs/preset-umi",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/preset-umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/preset-vue/package.json
+++ b/packages/preset-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/preset-vue",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "description": "@umijs/preset-vue",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/preset-vue#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/preset-vue/package.json
+++ b/packages/preset-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/preset-vue",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "description": "@umijs/preset-vue",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/preset-vue#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/preset-vue/package.json
+++ b/packages/preset-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/preset-vue",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "description": "@umijs/preset-vue",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/preset-vue#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/preset-vue/package.json
+++ b/packages/preset-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/preset-vue",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "description": "@umijs/preset-vue",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/preset-vue#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/preset-vue/package.json
+++ b/packages/preset-vue/package.json
@@ -6,7 +6,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/preset-vue"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/preset-vue/package.json
+++ b/packages/preset-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/preset-vue",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "description": "@umijs/preset-vue",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/preset-vue#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/preset-vue/package.json
+++ b/packages/preset-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/preset-vue",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "description": "@umijs/preset-vue",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/preset-vue#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/renderer-react/package.json
+++ b/packages/renderer-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/renderer-react",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "description": "@umijs/renderer-react",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/renderer-react#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/renderer-react/package.json
+++ b/packages/renderer-react/package.json
@@ -6,7 +6,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/renderer-react"
   },
   "license": "MIT",
   "sideEffects": false,

--- a/packages/renderer-react/package.json
+++ b/packages/renderer-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/renderer-react",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "description": "@umijs/renderer-react",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/renderer-react#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/renderer-react/package.json
+++ b/packages/renderer-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/renderer-react",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "description": "@umijs/renderer-react",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/renderer-react#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/renderer-react/package.json
+++ b/packages/renderer-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/renderer-react",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "description": "@umijs/renderer-react",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/renderer-react#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/renderer-react/package.json
+++ b/packages/renderer-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/renderer-react",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "description": "@umijs/renderer-react",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/renderer-react#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/renderer-react/package.json
+++ b/packages/renderer-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/renderer-react",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "description": "@umijs/renderer-react",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/renderer-react#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/renderer-vue/package.json
+++ b/packages/renderer-vue/package.json
@@ -6,7 +6,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/renderer-vue"
   },
   "license": "MIT",
   "sideEffects": false,

--- a/packages/renderer-vue/package.json
+++ b/packages/renderer-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/renderer-vue",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "description": "@umijs/renderer-vue",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/renderer-vue#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/renderer-vue/package.json
+++ b/packages/renderer-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/renderer-vue",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "description": "@umijs/renderer-vue",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/renderer-vue#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/renderer-vue/package.json
+++ b/packages/renderer-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/renderer-vue",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "description": "@umijs/renderer-vue",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/renderer-vue#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/renderer-vue/package.json
+++ b/packages/renderer-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/renderer-vue",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "description": "@umijs/renderer-vue",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/renderer-vue#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/renderer-vue/package.json
+++ b/packages/renderer-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/renderer-vue",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "description": "@umijs/renderer-vue",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/renderer-vue#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/renderer-vue/package.json
+++ b/packages/renderer-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/renderer-vue",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "description": "@umijs/renderer-vue",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/renderer-vue#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/server",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "description": "@umijs/server",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/server#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/server",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "description": "@umijs/server",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/server#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/server",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "description": "@umijs/server",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/server#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/server",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "description": "@umijs/server",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/server#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,7 +6,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/server"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/server",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "description": "@umijs/server",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/server#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/server",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "description": "@umijs/server",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/server#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/test",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "description": "@umijs/test",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/testing#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -6,7 +6,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/testing"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/test",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "description": "@umijs/test",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/testing#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/test",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "description": "@umijs/test",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/testing#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/test",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "description": "@umijs/test",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/testing#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/test",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "description": "@umijs/test",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/testing#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/test",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "description": "@umijs/test",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/testing#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -6,7 +6,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/umi"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umi",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "description": "umi",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umi",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "description": "umi",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umi",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "description": "umi",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umi",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "description": "umi",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umi",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "description": "umi",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umi",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "description": "umi",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/umi#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/utils",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/utils#readme",
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/utils",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/utils#readme",
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/utils",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/utils#readme",
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/utils",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/utils#readme",
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/utils",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/utils#readme",
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/utils",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/utils#readme",
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/utils"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/zod2ts/package.json
+++ b/packages/zod2ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/zod2ts",
-  "version": "4.6.70-alpha.2",
+  "version": "4.6.70-alpha.3",
   "description": "@umijs/zod2ts",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/zod2ts#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/zod2ts/package.json
+++ b/packages/zod2ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/zod2ts",
-  "version": "4.6.70-alpha.0",
+  "version": "4.6.70-alpha.1",
   "description": "@umijs/zod2ts",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/zod2ts#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/zod2ts/package.json
+++ b/packages/zod2ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/zod2ts",
-  "version": "4.6.70-alpha.1",
+  "version": "4.6.70-alpha.2",
   "description": "@umijs/zod2ts",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/zod2ts#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/zod2ts/package.json
+++ b/packages/zod2ts/package.json
@@ -6,7 +6,8 @@
   "bugs": "https://github.com/umijs/umi/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/umijs/umi"
+    "url": "https://github.com/umijs/umi",
+    "directory": "packages/zod2ts"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/zod2ts/package.json
+++ b/packages/zod2ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/zod2ts",
-  "version": "4.6.69",
+  "version": "4.6.70-alpha.0",
   "description": "@umijs/zod2ts",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/zod2ts#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/zod2ts/package.json
+++ b/packages/zod2ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/zod2ts",
-  "version": "4.6.70-alpha.3",
+  "version": "4.6.70-alpha.4",
   "description": "@umijs/zod2ts",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/zod2ts#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/packages/zod2ts/package.json
+++ b/packages/zod2ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umijs/zod2ts",
-  "version": "4.6.70-alpha.4",
+  "version": "4.6.70-alpha.5",
   "description": "@umijs/zod2ts",
   "homepage": "https://github.com/umijs/umi/tree/master/packages/zod2ts#readme",
   "bugs": "https://github.com/umijs/umi/issues",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -37,28 +37,6 @@ import { assert, eachPkg, getPkgs } from './.internal/utils';
   const changed = (await $`lerna changed --loglevel error`).stdout.trim();
   assert(changed, `no package is changed`);
 
-  // check npm ownership
-  logger.event('check npm ownership');
-  const whoami = (await $`npm whoami`).stdout.trim();
-  try {
-    await Promise.all(
-      ['umi', '@umijs/core'].map(async (pkg) => {
-        const owners = (await $`npm owner ls ${pkg}`).stdout
-          .trim()
-          .split('\n')
-          .map((line) => {
-            return line.split(' ')[0];
-          });
-        assert(owners.includes(whoami), `${pkg} is not owned by ${whoami}`);
-      }),
-    );
-  } catch (e: any) {
-    // only throw ownership error
-    if (e.message.includes('is not owned by')) {
-      throw e;
-    }
-  }
-
   // check package.json
   logger.event('check package.json info');
   await $`npm run check:packageFiles`;
@@ -127,35 +105,7 @@ import { assert, eachPkg, getPkgs } from './.internal/utils';
   logger.event('git push');
   await $`git push origin ${branch} --tags`;
 
-  // pnpm publish
-  logger.event('pnpm publish');
-  $.verbose = false;
-  const innerPkgs = pkgs.filter((pkg) => !['umi', 'max'].includes(pkg));
-
-  // check 2fa config
-  let otpArg: string[] = [];
-  if (
-    (await $`npm profile get "two-factor auth"`).toString().includes('writes')
-  ) {
-    let code = '';
-    do {
-      // get otp from user
-      code = await question('This operation requires a one-time password: ');
-      // generate arg for zx command
-      // why use array? https://github.com/google/zx/blob/main/docs/quotes.md
-      otpArg = ['--otp', code];
-    } while (code.length !== 6);
-  }
-
-  await Promise.all(
-    innerPkgs.map(async (pkg) => {
-      await $`cd packages/${pkg} && pnpm publish --no-git-checks --tag ${tag} ${otpArg}`;
-      logger.info(`+ ${pkg}`);
-    }),
+  logger.ready(
+    `release commit pushed, GitHub Actions will publish with tag ${tag}`,
   );
-  await $`cd packages/umi && pnpm publish --no-git-checks --tag ${tag} ${otpArg}`;
-  logger.info(`+ umi`);
-  await $`cd packages/max && pnpm publish --no-git-checks --tag ${tag} ${otpArg}`;
-  logger.info(`+ @umijs/max`);
-  $.verbose = true;
 })();

--- a/scripts/releasePublish.ts
+++ b/scripts/releasePublish.ts
@@ -42,6 +42,7 @@ async function publishPackage(opts: {
   }
 
   const packDir = mkdtempSync(join(tmpdir(), 'umi-release-'));
+  const publishDir = mkdtempSync(join(tmpdir(), 'umi-release-publish-'));
   try {
     await $`cd ${opts.dir} && pnpm pack --pack-destination ${packDir}`;
     const tarballs = readdirSync(packDir).filter((file) =>
@@ -51,21 +52,26 @@ async function publishPackage(opts: {
       throw new Error(`Expected one tarball for ${opts.name}, got ${tarballs}`);
     }
     const tarball = join(packDir, tarballs[0]);
+    await $`tar -xzf ${tarball} --strip-components=1 -C ${publishDir}`;
     if (opts.dryRun) {
-      logger.info(`[dry-run] npm publish ${tarball} --tag ${opts.tag}`);
+      logger.info(
+        `[dry-run] cd ${publishDir} && npm publish --tag ${opts.tag}`,
+      );
       return;
     }
-    await $`npm publish ${tarball} --tag ${opts.tag} --access public --provenance`;
+    await $`cd ${publishDir} && npm publish --tag ${opts.tag} --access public --provenance`;
     logger.info(`+ ${opts.name}`);
   } finally {
     rmSync(packDir, { recursive: true, force: true });
+    rmSync(publishDir, { recursive: true, force: true });
   }
 }
 
 (async () => {
   const version = require(PATHS.LERNA_CONFIG).version;
   const tag = getNpmTag(version);
-  const dryRun = argv['dry-run'] || argv.dryRun;
+  const dryRun =
+    argv['dry-run'] || argv.dryRun || process.argv.includes('--dry-run');
   const pkgs = getPkgs();
   const orderedPkgs = [
     ...pkgs.filter((pkg) => !['umi', 'max'].includes(pkg)),

--- a/scripts/releasePublish.ts
+++ b/scripts/releasePublish.ts
@@ -1,0 +1,96 @@
+import * as logger from '@umijs/utils/src/logger';
+import { mkdtempSync, readdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import 'zx/globals';
+import { PATHS } from './.internal/constants';
+import { eachPkg, getPkgs } from './.internal/utils';
+
+function getNpmTag(version: string) {
+  if (
+    version.includes('-alpha.') ||
+    version.includes('-beta.') ||
+    version.includes('-rc.')
+  ) {
+    return 'next';
+  }
+  if (version.includes('-canary.')) return 'canary';
+  return 'latest';
+}
+
+async function isPublished(name: string, version: string) {
+  try {
+    const publishedVersion = (
+      await $`npm view ${`${name}@${version}`} version --registry https://registry.npmjs.org/`
+    ).stdout.trim();
+    return publishedVersion === version;
+  } catch {
+    return false;
+  }
+}
+
+async function publishPackage(opts: {
+  name: string;
+  dir: string;
+  version: string;
+  tag: string;
+  dryRun: boolean;
+}) {
+  if (await isPublished(opts.name, opts.version)) {
+    logger.info(`skip ${opts.name}@${opts.version}, already published`);
+    return;
+  }
+
+  const packDir = mkdtempSync(join(tmpdir(), 'umi-release-'));
+  try {
+    await $`cd ${opts.dir} && pnpm pack --pack-destination ${packDir}`;
+    const tarballs = readdirSync(packDir).filter((file) =>
+      file.endsWith('.tgz'),
+    );
+    if (tarballs.length !== 1) {
+      throw new Error(`Expected one tarball for ${opts.name}, got ${tarballs}`);
+    }
+    const tarball = join(packDir, tarballs[0]);
+    if (opts.dryRun) {
+      logger.info(`[dry-run] npm publish ${tarball} --tag ${opts.tag}`);
+      return;
+    }
+    await $`npm publish ${tarball} --tag ${opts.tag} --access public --provenance`;
+    logger.info(`+ ${opts.name}`);
+  } finally {
+    rmSync(packDir, { recursive: true, force: true });
+  }
+}
+
+(async () => {
+  const version = require(PATHS.LERNA_CONFIG).version;
+  const tag = getNpmTag(version);
+  const dryRun = argv['dry-run'] || argv.dryRun;
+  const pkgs = getPkgs();
+  const orderedPkgs = [
+    ...pkgs.filter((pkg) => !['umi', 'max'].includes(pkg)),
+    'umi',
+    'max',
+  ];
+  const publishInfos: { name: string; dir: string; version: string }[] = [];
+  eachPkg(
+    orderedPkgs,
+    ({ dir, pkgJson }) => {
+      publishInfos.push({
+        name: pkgJson.name,
+        dir,
+        version: pkgJson.version,
+      });
+    },
+    { base: PATHS.PACKAGES },
+  );
+
+  logger.event(`publish packages with npm tag ${tag}`);
+  for (const publishInfo of publishInfos) {
+    await publishPackage({
+      ...publishInfo,
+      tag,
+      dryRun,
+    });
+  }
+})();


### PR DESCRIPTION
use oidc to avoid tnpm block release:

<img width="1176" height="508" alt="image" src="https://github.com/user-attachments/assets/50c2b08c-e802-44e0-9077-0aafe5a7b355" />
