### PR TITLE
chore: update release doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Core Maintainers are community members who have contributed significantly to the
 
 * [sorrycc](https://github.com/sorrycc)
 * [xiaohuoni](https://github.com/xiaohuoni)
+* [fireairforce](https://github.com/fireairforce)
 
 ### Maintainers
 

--- a/docs/docs/docs/introduce/contributing.en-US.md
+++ b/docs/docs/docs/introduce/contributing.en-US.md
@@ -175,11 +175,13 @@ $ pnpm build:deps --dep webpack-manifest-plugin
 
 ## Release
 
-Only Core Maintainers can carry out releases.
+Only Core Maintainers can carry out releases. Umi now uses npm Trusted Publishing/OIDC, so the local release command only bumps versions, creates and pushes the release commit/tag, and no longer runs `npm publish` locally.
 
 ```bash
 $ pnpm release
 ```
+
+After the push, the GitHub Actions Release workflow obtains npm publishing permission through OIDC, runs `pnpm release:publish`, and publishes packages to npm with `--provenance`.
 
 ## Rolling Back through dist-tag
 

--- a/docs/docs/docs/introduce/contributing.md
+++ b/docs/docs/docs/introduce/contributing.md
@@ -174,11 +174,13 @@ $ pnpm build:deps --dep webpack-manifest-plugin
 
 ## 发布
 
-只有 Core Maintainer 才能执行发布。
+只有 Core Maintainer 才能执行发布。Umi 已切换到 npm Trusted Publishing/OIDC，本地发布命令只负责 bump version、生成 release commit/tag 并推送，不再直接执行 `npm publish`。
 
 ```bash
 $ pnpm release
 ```
+
+推送后，GitHub Actions 的 Release workflow 会通过 OIDC 获取 npm 发布权限，执行 `pnpm release:publish`，并带上 `--provenance` 将 package 发布到 npm。
 
 ## 通过 dist-tag 回滚
 


### PR DESCRIPTION
umi 已切换至 npm trusted publish，更新发包使用文档