### PR TITLE
fix(bundler-utoopack): silence startup proxy ECONNREFUSED errors

### DIFF
--- a/packages/bundler-utoopack/src/index.test.ts
+++ b/packages/bundler-utoopack/src/index.test.ts
@@ -1,0 +1,42 @@
+import { isUtoopackProxyStartupError } from './index';
+
+describe('isUtoopackProxyStartupError', () => {
+  test('matches ECONNREFUSED from the utoopack dev server port', () => {
+    expect(
+      isUtoopackProxyStartupError(
+        {
+          code: 'ECONNREFUSED',
+          address: '127.0.0.1',
+          port: 8001,
+        },
+        8001,
+      ),
+    ).toBe(true);
+  });
+
+  test('does not match other ports', () => {
+    expect(
+      isUtoopackProxyStartupError(
+        {
+          code: 'ECONNREFUSED',
+          address: '127.0.0.1',
+          port: 9001,
+        },
+        8001,
+      ),
+    ).toBe(false);
+  });
+
+  test('does not match other proxy errors', () => {
+    expect(
+      isUtoopackProxyStartupError(
+        {
+          code: 'ECONNRESET',
+          address: '127.0.0.1',
+          port: 8001,
+        },
+        8001,
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/bundler-utoopack/src/index.ts
+++ b/packages/bundler-utoopack/src/index.ts
@@ -18,6 +18,14 @@ export { findRootDir } from '@utoo/pack';
 export * from './config';
 export type { IUtoopackUserConfig } from './types';
 
+export function isUtoopackProxyStartupError(error: any, utooServePort: number) {
+  return (
+    error?.code === 'ECONNREFUSED' &&
+    Number(error?.port) === utooServePort &&
+    (!error?.address || error.address === '127.0.0.1')
+  );
+}
+
 function getUtoopackRootDir(
   cwd: string,
   utoopackConfig: Record<string, any> | undefined,
@@ -243,6 +251,25 @@ export async function dev(opts: IDevOpts) {
       },
       skipToNextHandlerFilter: function (proxyRes: any) {
         return proxyRes.statusCode !== 200 && proxyRes.statusCode !== 304;
+      },
+      proxyErrorHandler: function (err: any, res: any, next: any) {
+        if (isUtoopackProxyStartupError(err, utooServePort)) {
+          if (!res.headersSent) {
+            res.writeHead(503, { 'Content-Type': 'text/plain' });
+          }
+          return res.end('Utoopack dev server is starting.');
+        }
+
+        if (err?.code === 'ECONNRESET') {
+          res.setHeader(
+            'X-Timeout-Reason',
+            'express-http-proxy reset the request.',
+          );
+          res.writeHead(504, { 'Content-Type': 'text/plain' });
+          return res.end();
+        }
+
+        return next(err);
       },
     }),
   );


### PR DESCRIPTION
Ignore the `ECONNREFUSED` error caused by utoopack's proxy devServer:

<img width="1278" height="608" alt="image" src="https://github.com/user-attachments/assets/b448eca9-62e3-4008-90cc-2bd835ccebe5" />
