### PR TITLE
feat(utoopack): watch selected node_modules packages

### DIFF
--- a/packages/bundler-utoopack/src/config.test.ts
+++ b/packages/bundler-utoopack/src/config.test.ts
@@ -103,6 +103,47 @@ describe('utoopack dev stats config', () => {
   });
 });
 
+describe('utoopack watch config', () => {
+  test('passes user watch options to the top-level dev bundle options', async () => {
+    const config = await getDevUtooPackConfig({
+      ...baseOpts,
+      config: {
+        utoopack: {
+          watch: {
+            pollIntervalMs: 500,
+            ignored: ['dist', '!node_modules/rc-.*'],
+            nodeModulesRegexes: ['rc-.*', '.*cssinjs.*', '@rc-component/.*'],
+          },
+        },
+      },
+    } as any);
+
+    expect(config.watch).toEqual({
+      pollIntervalMs: 500,
+      ignored: ['dist', '!node_modules/rc-.*'],
+      nodeModulesRegexes: ['rc-.*', '.*cssinjs.*', '@rc-component/.*'],
+      enable: true,
+    });
+    expect(config.config).not.toHaveProperty('watch');
+  });
+
+  test('does not pass watch options into the production pack config', async () => {
+    const config = await getProdUtooPackConfig({
+      ...baseOpts,
+      config: {
+        utoopack: {
+          watch: {
+            nodeModulesRegexes: ['rc-.*'],
+          },
+        },
+      },
+    } as any);
+
+    expect(config.watch).toBeUndefined();
+    expect(config.config).not.toHaveProperty('watch');
+  });
+});
+
 describe('utoopack mdx config', () => {
   test('allows user css output filename override', async () => {
     const prodConfig = await getProdUtooPackConfig({

--- a/packages/bundler-utoopack/src/config.ts
+++ b/packages/bundler-utoopack/src/config.ts
@@ -754,6 +754,7 @@ function getUserUtoopackConfig(
   const userUtoopackConfig = lodash.omit(utoopackConfig, [
     'babelLoader',
     'root',
+    'watch',
   ]);
   const packageImports = userUtoopackConfig.optimization?.packageImports || [];
 
@@ -1106,6 +1107,7 @@ export async function getDevUtooPackConfig(
       userUtoopackConfig,
     ),
     watch: {
+      ...opts.config.utoopack?.watch,
       enable: true,
     },
     dev: true,

--- a/packages/bundler-utoopack/src/index.ts
+++ b/packages/bundler-utoopack/src/index.ts
@@ -17,7 +17,7 @@ import type { IOpts } from './types';
 import { getBuildBanner, getDevBanner } from './util';
 export { findRootDir } from '@utoo/pack';
 export * from './config';
-export type { IUtoopackUserConfig } from './types';
+export type { IUtoopackUserConfig, IUtoopackWatchConfig } from './types';
 
 export function isUtoopackProxyStartupError(error: any, utooServePort: number) {
   return (

--- a/packages/bundler-utoopack/src/types.ts
+++ b/packages/bundler-utoopack/src/types.ts
@@ -1,9 +1,16 @@
 import type { IOpts as IConfigOpts } from '@umijs/bundler-webpack';
 import type { ConfigComplete } from '@utoo/pack';
 
+export type IUtoopackWatchConfig = {
+  pollIntervalMs?: number;
+  ignored?: string[];
+  nodeModulesRegexes?: string[];
+};
+
 export type IUtoopackUserConfig = ConfigComplete & {
   babelLoader?: boolean;
   root?: string;
+  watch?: IUtoopackWatchConfig;
 };
 
 export type IOpts = {

--- a/packages/preset-umi/src/features/utoopack/utoopack.ts
+++ b/packages/preset-umi/src/features/utoopack/utoopack.ts
@@ -52,6 +52,13 @@ export default (api: IApi) => {
           zod
             .object({
               root: zod.string(),
+              watch: zod
+                .object({
+                  pollIntervalMs: zod.number(),
+                  ignored: zod.array(zod.string()),
+                  nodeModulesRegexes: zod.array(zod.string()),
+                })
+                .partial(),
             })
             .partial(),
         ]);


### PR DESCRIPTION
## Summary

- expose utoopack filesystem watch options in the user config type and preset schema
- forward `utoopack.watch` to top-level `BundleOptions.watch` during development
- keep watch-only options out of the production pack config
- add regression coverage for development forwarding and production filtering

## Why

`@utoo/pack` reads filesystem watcher options from top-level `BundleOptions.watch`. Umi previously merged the entire `utoopack` user config into `BundleOptions.config` and hardcoded the development watcher to `{ enable: true }`, so options such as `nodeModulesRegexes` never reached the native watcher.

This enables configurations such as:

```ts
utoopack: {
  watch: {
    nodeModulesRegexes: ['rc-.*', '.*cssinjs.*', '@rc-component/.*'],
  },
},
```

## Validation

- `pnpm --filter @umijs/bundler-utoopack test -- --runInBand`
- `pnpm --filter @umijs/bundler-utoopack build`
- `pnpm --filter @umijs/preset-umi build`
- local dumi fixture using utoo commit `cde7c3e8`: changing `node_modules/rc-watch-fixture` triggered recompilation in 206 ms and updated the generated chunks

## Dependency

Requires an `@utoo/pack` release containing utooland/utoo#3238 (`cde7c3e8`). The currently published `1.4.25` tag predates that commit, so the dependency version should be bumped after the next pack release.
