### PR TITLE
dep(@umijs/bundler-utoopack): @utoo/pack@1.4.26

### DIFF
--- a/packages/bundler-utoopack/package.json
+++ b/packages/bundler-utoopack/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@umijs/bundler-utils": "workspace:*",
     "@umijs/bundler-webpack": "workspace:*",
-    "@utoo/pack": "1.4.25",
+    "@utoo/pack": "1.4.26",
     "compression": "^1.7.4",
     "connect-history-api-fallback": "^2.0.0",
     "cors": "^2.8.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2053,8 +2053,8 @@ importers:
         specifier: workspace:*
         version: link:../bundler-webpack
       '@utoo/pack':
-        specifier: 1.4.25
-        version: 1.4.25(less-loader@11.1.0)(less@4.1.3)(postcss@8.4.35)(resolve-url-loader@5.0.0)(sass-loader@13.2.0)(sass@1.54.0)
+        specifier: 1.4.26
+        version: 1.4.26(less-loader@11.1.0)(less@4.1.3)(postcss@8.4.35)(resolve-url-loader@5.0.0)(sass-loader@13.2.0)(sass@1.54.0)
       compression:
         specifier: ^1.7.4
         version: 1.7.4
@@ -2114,7 +2114,7 @@ importers:
         version: 4.1.3
       postcss-preset-env:
         specifier: 7.5.0
-        version: 7.5.0(postcss@8.4.21)
+        version: 7.5.0(postcss@8.4.35)
       rollup-plugin-visualizer:
         specifier: 5.9.0
         version: 5.9.0(rollup@3.7.0)
@@ -12400,7 +12400,6 @@ packages:
       '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.35)
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
-    dev: true
 
   /@csstools/postcss-font-format-keywords@1.0.0(postcss@8.4.21):
     resolution: {integrity: sha512-oO0cZt8do8FdVBX8INftvIA4lUrKUSCcWUf9IwH9IPWOgKT22oAZFXeHLoDK7nhB2SmkNycp5brxfNMRLIhd6Q==}
@@ -12426,7 +12425,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
-    dev: true
 
   /@csstools/postcss-hwb-function@1.0.1(postcss@8.4.21):
     resolution: {integrity: sha512-AMZwWyHbbNLBsDADWmoXT9A5yl5dsGEBeJSJRUJt8Y9n8Ziu7Wstt4MC8jtPW7xjcLecyfJwtnUTNSmOzcnWeg==}
@@ -12452,7 +12450,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
-    dev: true
 
   /@csstools/postcss-ic-unit@1.0.0(postcss@8.4.21):
     resolution: {integrity: sha512-i4yps1mBp2ijrx7E96RXrQXQQHm6F4ym1TOD0D69/sjDjZvQ22tqiEvaNw7pFZTUO5b9vWRHzbHzP9+UKuw+bA==}
@@ -12480,7 +12477,6 @@ packages:
       '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.35)
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
-    dev: true
 
   /@csstools/postcss-is-pseudo-class@2.0.5(postcss@8.4.21):
     resolution: {integrity: sha512-Ek+UFI4UP2hB9u0N1cJd6KgSF1rL0J3PT4is0oSStuus8+WzbGGPyJNMOKQ0w/tyPjxiCnOI4RdSMZt3nks64g==}
@@ -12508,7 +12504,6 @@ packages:
       '@csstools/selector-specificity': 2.0.1(postcss-selector-parser@6.0.10)(postcss@8.4.35)
       postcss: 8.4.35
       postcss-selector-parser: 6.0.10
-    dev: true
 
   /@csstools/postcss-normalize-display-values@1.0.0(postcss@8.4.21):
     resolution: {integrity: sha512-bX+nx5V8XTJEmGtpWTO6kywdS725t71YSLlxWt78XoHUbELWgoCXeOFymRJmL3SU1TLlKSIi7v52EWqe60vJTQ==}
@@ -12534,7 +12529,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
-    dev: true
 
   /@csstools/postcss-oklab-function@1.1.0(postcss@8.4.21):
     resolution: {integrity: sha512-e/Q5HopQzmnQgqimG9v3w2IG4VRABsBq3itOcn4bnm+j4enTgQZ0nWsaH/m9GV2otWGQ0nwccYL5vmLKyvP1ww==}
@@ -12562,7 +12556,6 @@ packages:
       '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.35)
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
-    dev: true
 
   /@csstools/postcss-progressive-custom-properties@1.3.0(postcss@8.4.21):
     resolution: {integrity: sha512-ASA9W1aIy5ygskZYuWams4BzafD12ULvSypmaLJT2jvQ8G0M3I8PRQhC0h7mG0Z3LI05+agZjqSR9+K9yaQQjA==}
@@ -12588,7 +12581,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
-    dev: true
 
   /@csstools/postcss-stepped-value-functions@1.0.0(postcss@8.4.21):
     resolution: {integrity: sha512-q8c4bs1GumAiRenmFjASBcWSLKrbzHzWl6C2HcaAxAXIiL2rUlUWbqQZUjwVG5tied0rld19j/Mm90K3qI26vw==}
@@ -12614,7 +12606,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
-    dev: true
 
   /@csstools/postcss-unset-value@1.0.1(postcss@8.4.21):
     resolution: {integrity: sha512-f1G1WGDXEU/RN1TWAxBPQgQudtLnLQPyiWdtypkPC+mVYNKFKH/HYXSxH4MVNqwF8M0eDsoiU7HumJHCg/L/jg==}
@@ -12638,7 +12629,6 @@ packages:
         optional: true
     dependencies:
       postcss: 8.4.35
-    dev: true
 
   /@csstools/selector-specificity@2.0.1(postcss-selector-parser@6.0.10)(postcss@8.4.21):
     resolution: {integrity: sha512-aG20vknL4/YjQF9BSV7ts4EWm/yrjagAN7OWBNmlbEOUiu0llj4OGrFoOKK3g2vey4/p2omKCoHrWtPxSwV3HA==}
@@ -12666,7 +12656,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-selector-parser: 6.0.10
-    dev: true
 
   /@ctrl/tinycolor@3.4.1:
     resolution: {integrity: sha512-ej5oVy6lykXsvieQtqZxCOaLT+xD4+QNarq78cIYISHmZXshCvROLudpQN3lfL8G0NL7plMSSK+zlyvCaIJ4Iw==}
@@ -21387,8 +21376,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-darwin-arm64@1.4.25:
-    resolution: {integrity: sha512-jKtEPccaVgHjEUqq+6tQGpqINuxGu2GHI12ASio4WRQ8pJAH02cH2m5Chah4aTBQ7JpvY4HGo4PqYkKLk9EhYA==}
+  /@utoo/pack-darwin-arm64@1.4.26:
+    resolution: {integrity: sha512-wPjHOT0R4jyzeLgtemyn4Fc2+nw60KNDOypy9YmNkr4vt0S0pzXNfLccf5Ij/UkaeQjzeoki6vuM+lU3R4HuYg==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
@@ -21414,8 +21403,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-darwin-x64@1.4.25:
-    resolution: {integrity: sha512-tSXXsN4OhiuOkApXBzPGBQBoSAHhGdRdUH57BnOb1awoPOs0pblmGkWaWnLfIZ+U9226fJ2kJWmqwNnJhDhSMw==}
+  /@utoo/pack-darwin-x64@1.4.26:
+    resolution: {integrity: sha512-ycI40AVkWQy6fSpDdYzZk1lIVBtHyA38zSu10ExNdN2mcJlFc3p4VKcfC3/PfrkkEZa5JscjhvFZTZgY4yUXgw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
@@ -21441,8 +21430,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-linux-arm64-gnu@1.4.25:
-    resolution: {integrity: sha512-W/db5UdNe0+DrIu1+8epz5vLuVYlx9kNjuEwVQ0hDOPJRZyxox1uUcOgxkBObBDJ+PeTeKMbGteHopZIA5rkRA==}
+  /@utoo/pack-linux-arm64-gnu@1.4.26:
+    resolution: {integrity: sha512-D4soaMT7LthwlEpvc13K5RbB7SdgzvKhq7/kIqxorTmdaOQqn9ybDqEdubk7EJOvCZYJM3ET8m+Llqsc9cL9aA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -21468,8 +21457,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-linux-arm64-musl@1.4.25:
-    resolution: {integrity: sha512-i+JzJ7c/JGwRcJcjaQdQCISmHLsNaps8JK/YMTLo+rsjl6kJdycR6bHnfL9WIdgBdY5RPA83nF88vh8SphNgZA==}
+  /@utoo/pack-linux-arm64-musl@1.4.26:
+    resolution: {integrity: sha512-23zFIAINYpsBbwzNoxH4B/vBnp9ISKluKTI32Us1YcGh0QK1h49UMl77ECy9Ob1jinxpgMZFEDsZKdkkOeKH8g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -21495,8 +21484,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-linux-x64-gnu@1.4.25:
-    resolution: {integrity: sha512-Si1WuDA3Cki1jUSfWd5B7NbtxY35Haq3K21lfM/uGDFHxsugJulVlKptG5KXVo4bGDv9d5U/aigKxfasWm4yLg==}
+  /@utoo/pack-linux-x64-gnu@1.4.26:
+    resolution: {integrity: sha512-bMGCQEZLdGYa8xDtP05nbxd18Px83QBB3gMlUsS0pOs2qKA7A0RFx4Fa09ppyAxR7USbkktXVPe3UPj+nUm1Hw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -21522,8 +21511,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-linux-x64-musl@1.4.25:
-    resolution: {integrity: sha512-HZz5i2dIO84duCW0GEdDb9OUFnQn3bNtyTIuwqqSneBEI5AW5Swh5dmcecoyC3kZGkbe4dcIVrDmdl+TDHzWeQ==}
+  /@utoo/pack-linux-x64-musl@1.4.26:
+    resolution: {integrity: sha512-xL1r2ilwB8zd2bbaWZsMnC3ZQVLlx+2pKU+5PSjTqXYwgWPqu6W0HV55/bNpIvei685rSym3DnS38eJW0qNCDg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -21547,8 +21536,8 @@ packages:
       picocolors: 1.1.1
     dev: true
 
-  /@utoo/pack-shared@1.4.25:
-    resolution: {integrity: sha512-f7WOz0d+LwlNGNqG6zUGgmSILxxjpPsE6RM0eSSw+DSi+xOMHftcYZP/IZsvI8emcFMmjXWVvoVc+vmNRTjoGQ==}
+  /@utoo/pack-shared@1.4.26:
+    resolution: {integrity: sha512-+Nzb0fH/7TVSXlGOr/MkMzSIaJbtlYPKOGik9Toil0sxy8Zy2UcIARr0ujdtM2axCntacZBkd8PtjrY7V3tqqA==}
     engines: {node: '>= 20'}
     dependencies:
       '@babel/code-frame': 7.22.5
@@ -21573,8 +21562,8 @@ packages:
     dev: true
     optional: true
 
-  /@utoo/pack-win32-x64-msvc@1.4.25:
-    resolution: {integrity: sha512-vSIMbYGxHKG/jlC59Jv8qwYb9/mlhs6MWiox1dv9MH3rdcg8lOyyG94+M238jIPS4lJeEzTVSAhud3eVMzvrsw==}
+  /@utoo/pack-win32-x64-msvc@1.4.26:
+    resolution: {integrity: sha512-PGnnmpSHl3LVN6yWgKPuytRfwA4UF2kG+IFtFXg5GqBF81d/OQJj41pygSTg1DVK2ZvuV+QohsM3RcjmEw8oMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
@@ -21674,8 +21663,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@utoo/pack@1.4.25(less-loader@11.1.0)(less@4.1.3)(postcss@8.4.35)(resolve-url-loader@5.0.0)(sass-loader@13.2.0)(sass@1.54.0):
-    resolution: {integrity: sha512-QwRBloV7RH9dTEZuA1OuUCnrj1Y38SA1TdeP5n7WPt4vN35cCq2Z37kBwB1hThqd2KOC7omw/mz9RUDlBnQV5w==}
+  /@utoo/pack@1.4.26(less-loader@11.1.0)(less@4.1.3)(postcss@8.4.35)(resolve-url-loader@5.0.0)(sass-loader@13.2.0)(sass@1.54.0):
+    resolution: {integrity: sha512-sUymyaN4svt08vqfrzFl6sWEE2LgnIe10TRNquNlg7/BBTCUreUp6m3zh3eTf7vfrDyC0+uFogWazNO+wNmSGA==}
     engines: {node: '>= 20'}
     peerDependencies:
       less: ^4.0.0
@@ -21693,7 +21682,7 @@ packages:
       '@hono/node-server': 1.19.11(hono@4.12.7)
       '@hono/node-ws': 1.3.0(@hono/node-server@1.19.11)(hono@4.12.7)
       '@swc/helpers': 0.5.15
-      '@utoo/pack-shared': 1.4.25
+      '@utoo/pack-shared': 1.4.26
       domparser-rs: 0.0.7
       find-up: 4.1.0
       get-port: 5.1.1
@@ -21710,13 +21699,13 @@ packages:
       send: 0.17.1
       ws: 8.18.3
     optionalDependencies:
-      '@utoo/pack-darwin-arm64': 1.4.25
-      '@utoo/pack-darwin-x64': 1.4.25
-      '@utoo/pack-linux-arm64-gnu': 1.4.25
-      '@utoo/pack-linux-arm64-musl': 1.4.25
-      '@utoo/pack-linux-x64-gnu': 1.4.25
-      '@utoo/pack-linux-x64-musl': 1.4.25
-      '@utoo/pack-win32-x64-msvc': 1.4.25
+      '@utoo/pack-darwin-arm64': 1.4.26
+      '@utoo/pack-darwin-x64': 1.4.26
+      '@utoo/pack-linux-arm64-gnu': 1.4.26
+      '@utoo/pack-linux-arm64-musl': 1.4.26
+      '@utoo/pack-linux-x64-gnu': 1.4.26
+      '@utoo/pack-linux-x64-musl': 1.4.26
+      '@utoo/pack-win32-x64-msvc': 1.4.26
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -23991,7 +23980,6 @@ packages:
       picocolors: 1.0.0
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
-    dev: true
 
   /autoprefixer@9.8.8:
     resolution: {integrity: sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==}
@@ -26393,7 +26381,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-selector-parser: 6.0.10
-    dev: true
 
   /css-color-keywords@1.0.0:
     resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
@@ -26453,7 +26440,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-selector-parser: 6.0.10
-    dev: true
 
   /css-in-js-utils@2.0.1:
     resolution: {integrity: sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==}
@@ -26542,7 +26528,6 @@ packages:
         optional: true
     dependencies:
       postcss: 8.4.35
-    dev: true
 
   /css-select-base-adapter@0.1.1:
     resolution: {integrity: sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==}
@@ -38576,7 +38561,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-selector-parser: 6.0.10
-    dev: true
 
   /postcss-calc@8.2.4(postcss@8.4.21):
     resolution: {integrity: sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==}
@@ -38629,7 +38613,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
-    dev: true
 
   /postcss-color-functional-notation@4.2.3(postcss@8.4.21):
     resolution: {integrity: sha512-5fbr6FzFzjwHXKsVnkmEYrJYG8VNNzvD1tAXaPPWR97S6rhKI5uh2yOfV5TAzhDkZoq4h+chxEplFDc8GeyFtw==}
@@ -38655,7 +38638,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
-    dev: true
 
   /postcss-color-hex-alpha@8.0.4(postcss@8.4.21):
     resolution: {integrity: sha512-nLo2DCRC9eE4w2JmuKgVA3fGL3d01kGq752pVALF68qpGLmx2Qrk91QTKkdUqqp45T1K1XV8IhQpcu1hoAQflQ==}
@@ -38681,7 +38663,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
-    dev: true
 
   /postcss-color-rebeccapurple@7.1.0(postcss@8.4.21):
     resolution: {integrity: sha512-1jtE5AKnZcKq4pjOrltFHcbEM2/IvtbD1OdhZ/wqds18//bh0UmQkffcCkzDJU+/vGodfIsVQeKn+45CJvX9Bw==}
@@ -38707,7 +38688,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
-    dev: true
 
   /postcss-colormin@5.3.0(postcss@8.4.21):
     resolution: {integrity: sha512-WdDO4gOFG2Z8n4P8TWBpshnL3JpmNmJwdnfP2gbk2qBA8PWwOYcmjmI/t3CmMeL72a7Hkd+x/Mg9O2/0rD54Pg==}
@@ -38793,7 +38773,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
-    dev: true
 
   /postcss-custom-properties@12.1.8(postcss@8.4.21):
     resolution: {integrity: sha512-8rbj8kVu00RQh2fQF81oBqtduiANu4MIxhyf0HbbStgPtnFlWn0yiaYTpLHrPnJbffVY1s9apWsIoVZcc68FxA==}
@@ -38819,7 +38798,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
-    dev: true
 
   /postcss-custom-selectors@6.0.3(postcss@8.4.21):
     resolution: {integrity: sha512-fgVkmyiWDwmD3JbpCmB45SvvlCD6z9CG6Ie6Iere22W5aHea6oWa7EM2bpnv2Fj3I94L3VbtvX9KqwSi5aFzSg==}
@@ -38845,7 +38823,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-selector-parser: 6.0.10
-    dev: true
 
   /postcss-dir-pseudo-class@6.0.4(postcss@8.4.21):
     resolution: {integrity: sha512-I8epwGy5ftdzNWEYok9VjW9whC4xnelAtbajGv4adql4FIF09rnrxnA9Y8xSHN47y7gqFIv10C5+ImsLeJpKBw==}
@@ -38871,7 +38848,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-selector-parser: 6.0.10
-    dev: true
 
   /postcss-discard-comments@5.1.2(postcss@8.4.21):
     resolution: {integrity: sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==}
@@ -38995,7 +38971,6 @@ packages:
       '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.35)
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
-    dev: true
 
   /postcss-env-function@4.0.6(postcss@8.4.21):
     resolution: {integrity: sha512-kpA6FsLra+NqcFnL81TnsU+Z7orGtDTxcOhl6pwXeEq1yFPpRMkCDpHhrz8CFQDr/Wfm0jLiNQ1OsGGPjlqPwA==}
@@ -39021,7 +38996,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
-    dev: true
 
   /postcss-flexbugs-fixes@5.0.2(postcss@8.4.21):
     resolution: {integrity: sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==}
@@ -39068,7 +39042,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-selector-parser: 6.0.10
-    dev: true
 
   /postcss-focus-within@5.0.4(postcss@8.4.21):
     resolution: {integrity: sha512-vvjDN++C0mu8jz4af5d52CB184ogg/sSxAFS+oUJQq2SuCe7T5U2iIsVJtsCp2d6R4j0jr5+q3rPkBVZkXD9fQ==}
@@ -39094,7 +39067,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-selector-parser: 6.0.10
-    dev: true
 
   /postcss-font-variant@5.0.0(postcss@8.4.21):
     resolution: {integrity: sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==}
@@ -39116,7 +39088,6 @@ packages:
         optional: true
     dependencies:
       postcss: 8.4.35
-    dev: true
 
   /postcss-gap-properties@3.0.3(postcss@8.4.21):
     resolution: {integrity: sha512-rPPZRLPmEKgLk/KlXMqRaNkYTUpE7YC+bOIQFN5xcu1Vp11Y4faIXv6/Jpft6FMnl6YRxZqDZG0qQOW80stzxQ==}
@@ -39140,7 +39111,6 @@ packages:
         optional: true
     dependencies:
       postcss: 8.4.35
-    dev: true
 
   /postcss-html@0.36.0(postcss-syntax@0.36.2)(postcss@7.0.39):
     resolution: {integrity: sha512-HeiOxGcuwID0AFsNAL0ox3mW6MHH5cstWN1Z3Y+n6H+g12ih7LHdYxWwEA/QmrebctLjo79xz9ouK3MroHwOJw==}
@@ -39180,7 +39150,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
-    dev: true
 
   /postcss-import@14.1.0(postcss@8.4.21):
     resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
@@ -39216,7 +39185,6 @@ packages:
         optional: true
     dependencies:
       postcss: 8.4.35
-    dev: true
 
   /postcss-js@4.0.0(postcss@8.4.21):
     resolution: {integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==}
@@ -39256,7 +39224,6 @@ packages:
       '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.4.35)
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
-    dev: true
 
   /postcss-less@3.1.4:
     resolution: {integrity: sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==}
@@ -39387,7 +39354,6 @@ packages:
         optional: true
     dependencies:
       postcss: 8.4.35
-    dev: true
 
   /postcss-media-minmax@5.0.0(postcss@8.4.21):
     resolution: {integrity: sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==}
@@ -39411,7 +39377,6 @@ packages:
         optional: true
     dependencies:
       postcss: 8.4.35
-    dev: true
 
   /postcss-media-query-parser@0.2.3:
     resolution: {integrity: sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==}
@@ -39676,7 +39641,6 @@ packages:
       '@csstools/selector-specificity': 2.0.1(postcss-selector-parser@6.0.10)(postcss@8.4.35)
       postcss: 8.4.35
       postcss-selector-parser: 6.0.10
-    dev: true
 
   /postcss-normalize-charset@5.1.0(postcss@8.4.21):
     resolution: {integrity: sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==}
@@ -39967,7 +39931,6 @@ packages:
         optional: true
     dependencies:
       postcss: 8.4.35
-    dev: true
 
   /postcss-page-break@3.0.4(postcss@8.4.21):
     resolution: {integrity: sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==}
@@ -39989,7 +39952,6 @@ packages:
         optional: true
     dependencies:
       postcss: 8.4.35
-    dev: true
 
   /postcss-place@7.0.4(postcss@8.4.21):
     resolution: {integrity: sha512-MrgKeiiu5OC/TETQO45kV3npRjOFxEHthsqGtkh3I1rPbZSbXGD/lZVi9j13cYh+NA8PIAPyk6sGjT9QbRyvSg==}
@@ -40015,7 +39977,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
-    dev: true
 
   /postcss-prefix-selector@1.16.0(postcss@8.4.21):
     resolution: {integrity: sha512-rdVMIi7Q4B0XbXqNUEI+Z4E+pueiu/CS5E6vRCQommzdQ/sgsS4dK42U7GX8oJR+TJOtT+Qv3GkNo6iijUMp3Q==}
@@ -40151,7 +40112,6 @@ packages:
       postcss-replace-overflow-wrap: 4.0.0(postcss@8.4.35)
       postcss-selector-not: 5.0.0(postcss@8.4.35)
       postcss-value-parser: 4.2.0
-    dev: true
 
   /postcss-pseudo-class-any-link@7.1.4(postcss@8.4.21):
     resolution: {integrity: sha512-JxRcLXm96u14N3RzFavPIE9cRPuOqLDuzKeBsqi4oRk4vt8n0A7I0plFs/VXTg7U2n7g/XkQi0OwqTO3VWBfEg==}
@@ -40177,7 +40137,6 @@ packages:
     dependencies:
       postcss: 8.4.35
       postcss-selector-parser: 6.0.10
-    dev: true
 
   /postcss-reduce-initial@5.1.0(postcss@8.4.21):
     resolution: {integrity: sha512-5OgTUviz0aeH6MtBjHfbr57tml13PuedK/Ecg8szzd4XRMbYxH4572JFG067z+FqBIf6Zp/d+0581glkvvWMFw==}
@@ -40253,7 +40212,6 @@ packages:
         optional: true
     dependencies:
       postcss: 8.4.35
-    dev: true
 
   /postcss-resolve-nested-selector@0.1.1:
     resolution: {integrity: sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw==}
@@ -40313,7 +40271,6 @@ packages:
     dependencies:
       balanced-match: 1.0.2
       postcss: 8.4.35
-    dev: true
 
   /postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}


### PR DESCRIPTION
## Summary

- bump `@utoo/pack` from 1.4.25 to 1.4.26 in `@umijs/bundler-utoopack`
- refresh the pnpm lockfile and native platform packages

## Why

Umi already exposes and forwards `utoopack.watch.nodeModulesRegexes`, but `@utoo/pack@1.4.25` predates the native watcher implementation. Version 1.4.26 includes that runtime support, allowing selected dependencies under `node_modules` to trigger recompilation.

## Validation

- `corepack pnpm --filter @umijs/bundler-utoopack test` — 47 tests passed
- `corepack pnpm --filter @umijs/bundler-utoopack build`
- `corepack pnpm exec prettier --check packages/bundler-utoopack/package.json pnpm-lock.yaml`
- started `examples/with-utoopack-emotion` with `nodeModulesRegexes: ['rc-.*']`, confirmed the page initially rendered `watch-value-before`, changed `node_modules/rc-watch-target`, observed recompilation in 13ms, and confirmed the rebuilt chunk contained `watch-value-after`
