### PR TITLE
feat(utoopack): support WebSocket proxy in dev server

### DIFF
--- a/examples/with-utoopack-websocket-proxy/.umirc.ts
+++ b/examples/with-utoopack-websocket-proxy/.umirc.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'umi';
+
+export default defineConfig({
+  // utoopack: {},
+  mako: {},
+  proxy: {
+    '/ws': {
+      target: 'ws://127.0.0.1:3000',
+      changeOrigin: true,
+      ws: true,
+    },
+  },
+});

--- a/examples/with-utoopack-websocket-proxy/README.md
+++ b/examples/with-utoopack-websocket-proxy/README.md
@@ -1,0 +1,23 @@
+# Utoopack WebSocket proxy
+
+From the repository root, build the local Utoopack adapter once:
+
+```bash
+pnpm --filter @umijs/bundler-utoopack build
+```
+
+Start the WebSocket backend:
+
+```bash
+pnpm --filter @example/with-utoopack-websocket-proxy backend
+```
+
+In another terminal, start the Umi example:
+
+```bash
+pnpm --filter @example/with-utoopack-websocket-proxy dev
+```
+
+Open <http://127.0.0.1:8000>. The page should show `connected` and
+`connected through the Umi proxy`. The backend terminal should report exactly
+one connection to `/ws`.

--- a/examples/with-utoopack-websocket-proxy/package.json
+++ b/examples/with-utoopack-websocket-proxy/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@example/with-utoopack-websocket-proxy",
+  "private": true,
+  "scripts": {
+    "backend": "node ./scripts/ws-server.mjs",
+    "build": "umi build",
+    "dev": "umi dev",
+    "start": "npm run dev"
+  },
+  "dependencies": {
+    "umi": "workspace:*"
+  }
+}

--- a/examples/with-utoopack-websocket-proxy/pages/index.tsx
+++ b/examples/with-utoopack-websocket-proxy/pages/index.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+export default function HomePage() {
+  const [status, setStatus] = useState('connecting');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const socket = new WebSocket(`${protocol}//${location.host}/ws`);
+
+    socket.onopen = () => setStatus('connected');
+    socket.onmessage = (event) => setMessage(String(event.data));
+    socket.onerror = () => setStatus('error');
+    socket.onclose = () => setStatus('closed');
+
+    return () => socket.close();
+  }, []);
+
+  return (
+    <main>
+      <h1>Utoopack WebSocket proxy</h1>
+      <p>
+        Status: <strong data-testid="status">{status}</strong>
+      </p>
+      <p>
+        Backend message: <strong>{message || 'waiting'}</strong>
+      </p>
+    </main>
+  );
+}

--- a/examples/with-utoopack-websocket-proxy/scripts/ws-server.mjs
+++ b/examples/with-utoopack-websocket-proxy/scripts/ws-server.mjs
@@ -1,0 +1,42 @@
+import { createHash } from 'node:crypto';
+import { createServer } from 'node:http';
+
+const sockets = new Set();
+const server = createServer((_req, res) => {
+  res.writeHead(426, { 'Content-Type': 'text/plain' });
+  res.end('WebSocket upgrade required.');
+});
+
+server.on('upgrade', (req, socket) => {
+  if (req.url !== '/ws' || !req.headers['sec-websocket-key']) {
+    socket.destroy();
+    return;
+  }
+
+  const accept = createHash('sha1')
+    .update(
+      `${req.headers['sec-websocket-key']}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`,
+    )
+    .digest('base64');
+  const message = Buffer.from('connected through the Umi proxy');
+
+  sockets.add(socket);
+  socket.on('close', () => sockets.delete(socket));
+  socket.write(
+    'HTTP/1.1 101 Switching Protocols\r\n' +
+      'Upgrade: websocket\r\n' +
+      'Connection: Upgrade\r\n' +
+      `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+  );
+  socket.write(Buffer.concat([Buffer.from([0x81, message.length]), message]));
+  console.log(`[backend] WebSocket connected: ${req.url}`);
+});
+
+server.listen(3000, '127.0.0.1', () => {
+  console.log('[backend] listening at ws://127.0.0.1:3000/ws');
+});
+
+process.on('SIGINT', () => {
+  sockets.forEach((socket) => socket.destroy());
+  server.close(() => process.exit(0));
+});

--- a/packages/bundler-utoopack/src/dev.test.ts
+++ b/packages/bundler-utoopack/src/dev.test.ts
@@ -1,0 +1,219 @@
+jest.mock('@umijs/bundler-webpack', () => ({
+  getConfig: jest.fn(async (opts) => ({
+    entry: opts.entry,
+    output: {},
+    plugins: [],
+    resolve: {
+      alias: {},
+    },
+  })),
+}));
+
+jest.mock('@utoo/pack', () => ({
+  compatOptionsFromWebpack: jest.fn((webpackConfig) => ({
+    config: {
+      entry: webpackConfig.entry,
+      output: {},
+      resolve: {
+        alias: webpackConfig.resolve?.alias || {},
+      },
+    },
+  })),
+  findRootDir: jest.fn((cwd) => cwd),
+  serve: jest.fn(),
+}));
+
+import { serve } from '@utoo/pack';
+import fs from 'fs';
+import http from 'http';
+import net from 'net';
+import path from 'path';
+import { dev } from './index';
+
+const mockedServe = serve as jest.Mock;
+type CreateServer = typeof import('http')['createServer'];
+type HttpServer = ReturnType<CreateServer>;
+type Socket = import('net').Socket;
+const serverSockets = new WeakMap<HttpServer, Set<Socket>>();
+
+function trackSockets(server: HttpServer) {
+  if (serverSockets.has(server)) return server;
+
+  const sockets = new Set<Socket>();
+  serverSockets.set(server, sockets);
+  server.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+  return server;
+}
+
+function listen(server: HttpServer, port = 0) {
+  return new Promise<number>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve((server.address() as { port: number }).port);
+    });
+  });
+}
+
+function close(server: HttpServer) {
+  return new Promise<void>((resolve, reject) => {
+    if (!server.listening) {
+      resolve();
+      return;
+    }
+
+    serverSockets.get(server)?.forEach((socket) => socket.destroy());
+    server.closeAllConnections?.();
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+async function getAvailablePortPair(): Promise<number> {
+  const first = http.createServer();
+  const firstPort = await listen(first);
+  const second = http.createServer();
+
+  try {
+    await listen(second, firstPort + 1);
+  } catch {
+    await close(first);
+    return getAvailablePortPair();
+  }
+
+  await Promise.all([close(first), close(second)]);
+  return firstPort;
+}
+
+function createBackend(upgrades: string[]) {
+  const server = trackSockets(
+    http.createServer((_req, res) => {
+      res.end('ok');
+    }),
+  );
+
+  server.on('upgrade', (req, socket) => {
+    upgrades.push(req.url || '');
+    socket.end(
+      'HTTP/1.1 101 Switching Protocols\r\n' +
+        'Upgrade: websocket\r\n' +
+        'Connection: Upgrade\r\n\r\n',
+    );
+  });
+
+  return server;
+}
+
+function request(port: number) {
+  return new Promise<void>((resolve, reject) => {
+    http
+      .get(`http://127.0.0.1:${port}/`, (res) => {
+        res.resume();
+        res.on('end', resolve);
+      })
+      .on('error', reject);
+  });
+}
+
+function upgrade(port: number, pathname: string) {
+  return new Promise<void>((resolve, reject) => {
+    const socket = net.connect(port, '127.0.0.1');
+    const timeout = setTimeout(() => {
+      socket.destroy();
+      reject(new Error(`Timed out upgrading ${pathname}`));
+    }, 1000);
+
+    socket.on('connect', () => {
+      socket.write(
+        `GET ${pathname} HTTP/1.1\r\n` +
+          `Host: 127.0.0.1:${port}\r\n` +
+          'Connection: Upgrade\r\n' +
+          'Upgrade: websocket\r\n' +
+          'Sec-WebSocket-Version: 13\r\n' +
+          'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n',
+      );
+    });
+    socket.on('data', () => {
+      clearTimeout(timeout);
+      socket.destroy();
+      resolve();
+    });
+    socket.on('error', (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+  });
+}
+
+test('routes WebSocket upgrades to the matching proxy only', async () => {
+  const businessUpgrades: string[] = [];
+  const utooUpgrades: string[] = [];
+  const businessServer = createBackend(businessUpgrades);
+  const businessPort = await listen(businessServer);
+  const port = await getAvailablePortPair();
+  const createdServers: HttpServer[] = [];
+  const createServer = http.createServer.bind(http);
+  const createServerSpy = jest.spyOn(http, 'createServer').mockImplementation(((
+    ...args: Parameters<CreateServer>
+  ) => {
+    const server = trackSockets(createServer(...args));
+    createdServers.push(server);
+    return server;
+  }) as CreateServer);
+
+  mockedServe.mockImplementation(async (_config, _cwd, _rootDir, opts) => {
+    const server = createBackend(utooUpgrades);
+    await listen(server, opts.port);
+    opts.onReady?.({ clientPaths: [] });
+  });
+
+  try {
+    await dev({
+      cwd: process.cwd(),
+      rootDir: process.cwd(),
+      entry: {
+        umi: './src/index.tsx',
+      },
+      config: {
+        publicPath: '/',
+        utoopack: {},
+        proxy: {
+          '/ws': {
+            target: `ws://127.0.0.1:${businessPort}`,
+            ws: true,
+          },
+        },
+      },
+      host: '127.0.0.1',
+      ip: '127.0.0.1',
+      port,
+    });
+
+    // http-proxy-middleware subscribes user WebSocket proxies while handling
+    // the first regular HTTP request.
+    await request(port);
+    await upgrade(port, '/ws');
+    await upgrade(port, '/turbopack-hmr');
+
+    expect(businessUpgrades).toEqual(['/ws']);
+    expect(utooUpgrades).toEqual(['/turbopack-hmr']);
+  } finally {
+    createServerSpy.mockRestore();
+    await Promise.all([
+      close(businessServer),
+      ...createdServers.map((server) => close(server)),
+    ]);
+    fs.rmSync(path.join(process.cwd(), 'node_modules/.cache/umi'), {
+      recursive: true,
+      force: true,
+    });
+  }
+});

--- a/packages/bundler-utoopack/src/index.ts
+++ b/packages/bundler-utoopack/src/index.ts
@@ -247,7 +247,7 @@ export async function dev(opts: IDevOpts) {
   (opts.beforeMiddlewares || []).forEach((m) => app.use(m));
 
   // proxy ws to utoopack server
-  const wsProxy = createProxyMiddleware({
+  const wsProxy = createProxyMiddleware('/turbopack-hmr', {
     target: `http://127.0.0.1:${utooServePort}`,
     ws: true,
     logLevel: 'silent',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1768,6 +1768,12 @@ importers:
         specifier: ^7.0.3
         version: 7.0.3
 
+  examples/with-utoopack-websocket-proxy:
+    dependencies:
+      umi:
+        specifier: workspace:*
+        version: link:../../packages/umi
+
   examples/with-valtio:
     dependencies:
       '@umijs/plugins':


### PR DESCRIPTION
## Summary

- scope the Utoopack HMR proxy to `/turbopack-hmr`
- add a real WebSocket upgrade regression test for HMR and user proxy routing
- add a runnable Utoopack WebSocket proxy example

## Why

The Utoopack dev server registers the HMR proxy's `upgrade` handler directly on the HTTP server. That bypasses the Express mount path, and the contextless proxy therefore matched every WebSocket upgrade request. A user request such as `/ws` could be handled by both the internal Utoopack server and the configured business proxy.

Passing `/turbopack-hmr` as the proxy context applies the intended path boundary during the upgrade phase as well.

## Impact

This only changes WebSocket routing in the Utoopack dev server. Utoopack HMR continues to use `/turbopack-hmr`, while other WebSocket paths are left to user proxy configuration. Production builds and other bundlers are unaffected.

Related: ant-design/ant-design-pro#11914

## Verification

- `pnpm --filter @umijs/bundler-utoopack test -- --runInBand` — 48 tests passed
- `pnpm exec tsc --noEmit -p packages/bundler-utoopack/tsconfig.json`
- `pnpm --filter @example/with-utoopack-websocket-proxy build`
- `pnpm install --frozen-lockfile --offline --ignore-scripts`
- manual Chrome verification: HMR and `/ws` both connected, while the business backend received exactly one `/ws` upgrade
