### PR TITLE
ci: deploy v3 docs to Cloudflare Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-latest, macos-13, windows-latest]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Use Node.js ${{ matrix.node_version }}
@@ -29,7 +29,7 @@ jobs:
           node-version: ${{ matrix.node_version }}
       - name: restore lerna
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             node_modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         node_version: [12, 14]
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-15-intel, windows-latest]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -1,0 +1,50 @@
+name: Deploy Umi v3 docs to Cloudflare Pages
+
+on:
+  push:
+    branches:
+      - 3.x
+  workflow_dispatch:
+
+concurrency:
+  group: cloudflare-pages-umi-v3
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js 14 for the legacy build
+        uses: actions/setup-node@v4
+        with:
+          node-version: 14.21.3
+
+      - name: Build documentation
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
+        run: |
+          yarn --version
+          yarn install --ignore-engines --frozen-lockfile
+          yarn build
+          yarn docs:build
+
+      - name: Use Node.js 22 for deployment
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=umi-v3 --branch=3.x
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -1,6 +1,9 @@
 name: Deploy Umi v3 docs to Cloudflare Pages
 
 on:
+  pull_request:
+    branches:
+      - 3.x
   push:
     branches:
       - 3.x
@@ -42,6 +45,7 @@ jobs:
           node-version: 22
 
       - name: Deploy to Cloudflare Pages
+        if: github.event_name != 'pull_request'
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary

- build the Umi v3 documentation with its supported Node.js 14 toolchain
- switch to Node.js 22 after the static files are generated
- deploy `dist` to the existing `umi-v3` Cloudflare Pages project with Wrangler
- support both deployments from pushes to `3.x` and manual deployments
- validate the legacy documentation build on pull requests without deploying
- update the v3 CI workflow to supported cache and macOS runner versions

## Why

Cloudflare Pages' automatic build environment installs a current Corepack release before running the repository build. That Corepack release no longer supports Node.js 14 and fails while replacing the bundled Corepack shim, so the Umi v3 build command is never reached.

The v3 source build still needs its legacy Node.js 14 toolchain. Building it directly with a modern Node.js release also fails in the old Father/source-map pipeline. GitHub Actions lets us keep Node.js 14 for the static build and use Node.js 22 only for the current Wrangler CLI.

## Repository configuration

The following GitHub Actions repository secrets are configured:

- `CLOUDFLARE_ACCOUNT_ID`
- `CLOUDFLARE_API_TOKEN` with **Account / Cloudflare Pages / Edit** permission

The workflow expects an existing Cloudflare Pages project named `umi-v3`.

After the first successful Actions deployment, Cloudflare's automatic Git builds for this Pages project can be disabled to avoid duplicate and failing builds.

## Validation

- parsed the workflow as valid YAML
- ran `git diff --check`
- verified the build commands and `dist` output against the existing v3 deployment workflow and `now.json`
- completed the full Node.js 14 documentation build successfully in GitHub Actions
- verified that Cloudflare deployment is skipped for pull requests
- completed the full Node.js 12/14 × Linux/macOS/Windows CI matrix successfully
