### PR TITLE
ci: use npm to install Wrangler

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -50,5 +50,6 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          packageManager: npm
           command: pages deploy dist --project-name=umi-v3 --branch=3.x
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changed

- Configure `cloudflare/wrangler-action@v3` to install and run Wrangler with npm.

## Why

The first production deployment after #13400 built the v3 documentation successfully, but the deploy step failed because Wrangler Action inferred Yarn from the repository lockfile and ran `yarn add wrangler@3.90.0`. Yarn rejected adding that dependency at the workspace root.

Using the action's supported `packageManager: npm` input avoids the Yarn workspace-root check while leaving the legacy documentation build on Yarn.

## Validation

- Workflow YAML parses successfully.
- `git diff --check` passes.
- Confirmed `packageManager` is an input supported by `cloudflare/wrangler-action@v3`.

After this PR merges, the push workflow on `3.x` will retry the production deployment to the `umi-v3` Cloudflare Pages project.