### PR TITLE
ci: isolate Wrangler from the v3 workspace

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -44,12 +44,22 @@ jobs:
         with:
           node-version: 22
 
+      - name: Install Wrangler outside the workspace
+        if: github.event_name != 'pull_request'
+        run: |
+          npm install \
+            --prefix "$RUNNER_TEMP/wrangler" \
+            --no-save \
+            --no-audit \
+            --no-fund \
+            wrangler@3.90.0
+
       - name: Deploy to Cloudflare Pages
         if: github.event_name != 'pull_request'
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          packageManager: npm
-          command: pages deploy dist --project-name=umi-v3 --branch=3.x
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          "$RUNNER_TEMP/wrangler/node_modules/.bin/wrangler" pages deploy dist \
+            --project-name=umi-v3 \
+            --branch=3.x


### PR DESCRIPTION
## What changed

- Remove `cloudflare/wrangler-action` from the v3 docs deployment step.
- Install the pinned `wrangler@3.90.0` package under `$RUNNER_TEMP/wrangler`.
- Run that isolated Wrangler binary with the existing Cloudflare repository secrets.

## Why

The deployment introduced in #13400 built the documentation successfully, but Wrangler Action installed Wrangler inside the legacy Yarn workspace. Yarn rejected a workspace-root install; switching the action to npm then caused npm to resolve the entire old workspace and fail on historical peer dependency conflicts.

Installing Wrangler under `RUNNER_TEMP` keeps deployment tooling independent from Umi v3 dependencies and lockfiles.

## Validation

- YAML parsing and `git diff --check` pass.
- An isolated local install of `wrangler@3.90.0` completed without modifying the repository.
- Full workflow-dispatch validation passed: https://github.com/umijs/umi/actions/runs/29979733348
  - Umi v3 documentation build passed.
  - Isolated Wrangler installation passed.
  - Cloudflare Pages deployment passed.
- Verified deployment: https://0a4739fa.umi-v3.pages.dev

After merge, pushes to `3.x` will use this same verified deployment path.