### PR TITLE
fix(plugins): skip reset css for antd 6

### DIFF
--- a/packages/plugins/src/antd.ts
+++ b/packages/plugins/src/antd.ts
@@ -30,6 +30,7 @@ export default (api: IApi) => {
     // 两者都还在维护周期中，允许使用预发布版本. eg. 6.1.0-alpha.0
     { includePrerelease: true },
   );
+  const isV6 = semver.major(antdVersion) === 6;
 
   /** v4 */
   const isLegacy = semver.satisfies(antdVersion, '^4.0.0');
@@ -450,8 +451,10 @@ export const AntdConfigContextSetter = React.createContext<React.Dispatch<React.
     > = [];
 
     if (isModern) {
-      // import reset style
-      imports.push({ source: 'antd/dist/reset.css' });
+      if (!isV6) {
+        // import antd@5 reset style
+        imports.push({ source: 'antd/dist/reset.css' });
+      }
     } else if (!api.config.antd.import || api.appData.vite) {
       // import antd@4 style if antd.import is not configured
       imports.push({


### PR DESCRIPTION
## Summary

- stop automatically importing `antd/dist/reset.css` when the project uses antd 6
- preserve the existing automatic reset import for antd 5
- leave the antd 4 stylesheet behavior unchanged

## Why

Umi currently imports `antd/dist/reset.css` as an unlayered stylesheet for both antd 5 and antd 6. Unlayered normal styles take precedence over named cascade layers, so antd 6 users cannot place the reset styles in their intended `reset` layer as recommended by Ant Design.

With this change, antd 6 users can import `reset.css` themselves using `@import ... layer(reset)`, while existing antd 5 behavior remains compatible.

Closes #13404

## Testing

- `pnpm exec prettier packages/plugins/src/antd.ts --check`
- `pnpm --filter @umijs/plugins build`
- `pnpm --filter @example/with-antd-6 build` — generated entry does not import `antd/dist/reset.css`
- `pnpm --filter @example/with-antd-5 build` — generated entry still imports `antd/dist/reset.css`
