### PR TITLE
feat: support event-filtered tmp file watchers

### DIFF
--- a/packages/preset-umi/src/commands/dev/dev.ts
+++ b/packages/preset-umi/src/commands/dev/dev.ts
@@ -14,7 +14,7 @@ import { basename, join } from 'path';
 import { Worker } from 'worker_threads';
 import { DEFAULT_HOST, DEFAULT_PORT } from '../../constants';
 import { LazySourceCodeCache } from '../../libs/folderCache/LazySourceCodeCache';
-import type { GenerateFilesFn, IApi } from '../../types';
+import type { GenerateFilesFn, IApi, ITmpGenerateWatcher } from '../../types';
 import { getProjectFileList } from '../../utils/projectFileList';
 import { createRouteMiddleware } from './createRouteMiddleware';
 import { faviconMiddleware } from './faviconMiddleware';
@@ -24,6 +24,7 @@ import { printMemoryUsage } from './printMemoryUsage';
 import {
   addUnWatch,
   createDebouncedHandler,
+  createEventFilteredHandler,
   expandCSSPaths,
   expandJSPaths,
   unwatch,
@@ -119,31 +120,48 @@ PORT=8888 umi dev
         isFirstTime: true,
       });
       const { absPagesPath, absSrcPath } = api.paths;
-      const watcherPaths: string[] = await api.applyPlugins({
-        key: 'addTmpGenerateWatcherPaths',
-        initialValue: [
-          absPagesPath,
-          !api.config.routes && api.config.conventionRoutes?.base,
-          join(absSrcPath, 'layouts'),
-          ...expandJSPaths(join(absSrcPath, 'loading')),
-          ...expandJSPaths(join(absSrcPath, 'app')),
-          ...expandJSPaths(join(absSrcPath, 'global')),
-          ...expandCSSPaths(join(absSrcPath, 'global')),
-          ...expandCSSPaths(join(absSrcPath, 'overrides')),
-        ].filter(Boolean),
-      });
-      lodash.uniq<string>(watcherPaths.map(winPath)).forEach((p: string) => {
-        watch({
-          path: p,
-          addToUnWatches: true,
-          onChange: createDebouncedHandler({
+      const watcherPaths: Array<string | ITmpGenerateWatcher> =
+        await api.applyPlugins({
+          key: 'addTmpGenerateWatcherPaths',
+          initialValue: [
+            absPagesPath,
+            !api.config.routes && api.config.conventionRoutes?.base,
+            join(absSrcPath, 'layouts'),
+            ...expandJSPaths(join(absSrcPath, 'loading')),
+            ...expandJSPaths(join(absSrcPath, 'app')),
+            ...expandJSPaths(join(absSrcPath, 'global')),
+            ...expandCSSPaths(join(absSrcPath, 'global')),
+            ...expandCSSPaths(join(absSrcPath, 'overrides')),
+          ].filter(Boolean),
+        });
+      lodash
+        .uniqBy(
+          watcherPaths.map((watcher) => {
+            const normalized =
+              typeof watcher === 'string' ? { path: watcher } : watcher;
+
+            return { ...normalized, path: winPath(normalized.path) };
+          }),
+          ({ events, path }) =>
+            `${path}:${events ? [...events].sort().join(',') : '*'}`,
+        )
+        .forEach(({ events, path: watcherPath }) => {
+          const onChange = createDebouncedHandler({
             timeout: 2000,
             async onChange(opts) {
               await generate({ files: opts.files, isFirstTime: false });
             },
-          }),
+          });
+
+          watch({
+            path: watcherPath,
+            addToUnWatches: true,
+            onChange: createEventFilteredHandler({
+              events,
+              onChange,
+            }),
+          });
         });
-      });
 
       // watch package.json change
       const pkgPath = join(api.cwd, 'package.json');

--- a/packages/preset-umi/src/commands/dev/watch.test.ts
+++ b/packages/preset-umi/src/commands/dev/watch.test.ts
@@ -1,0 +1,31 @@
+import { createEventFilteredHandler } from './watch';
+
+test('event filtered handler only forwards selected events', () => {
+  const events: string[] = [];
+  const handler = createEventFilteredHandler({
+    events: ['add', 'unlink'],
+    onChange(event) {
+      events.push(event);
+    },
+  });
+
+  handler('change', '/tmp/index.md');
+  handler('add', '/tmp/new.md');
+  handler('unlink', '/tmp/old.md');
+
+  expect(events).toEqual(['add', 'unlink']);
+});
+
+test('event filtered handler forwards every event by default', () => {
+  const events: string[] = [];
+  const handler = createEventFilteredHandler({
+    onChange(event) {
+      events.push(event);
+    },
+  });
+
+  handler('change', '/tmp/index.md');
+  handler('add', '/tmp/new.md');
+
+  expect(events).toEqual(['change', 'add']);
+});

--- a/packages/preset-umi/src/commands/dev/watch.ts
+++ b/packages/preset-umi/src/commands/dev/watch.ts
@@ -25,6 +25,17 @@ export function watch(opts: {
   return watcher;
 }
 
+export function createEventFilteredHandler(opts: {
+  events?: ReadonlyArray<string>;
+  onChange: (event: string, path: string) => void;
+}) {
+  return (event: string, path: string) => {
+    if (!opts.events || opts.events.includes(event)) {
+      opts.onChange(event, path);
+    }
+  };
+}
+
 export function createDebouncedHandler(opts: {
   timeout?: number;
   onChange: (opts: {

--- a/packages/preset-umi/src/types.ts
+++ b/packages/preset-umi/src/types.ts
@@ -14,9 +14,9 @@ import type WebpackChain from '@umijs/bundler-webpack/compiled/webpack-5-chain';
 import { createWebSocketServer } from '@umijs/bundler-webpack/dist/server/ws';
 import type {
   IAdd,
+  IRoute as ICoreRoute,
   IEvent,
   IModify,
-  IRoute as ICoreRoute,
   IServicePluginAPI,
   PluginAPI,
 } from '@umijs/core';
@@ -29,7 +29,7 @@ import type { IOnDemandInstallDep } from './features/depsOnDemand/depsOnDemand';
 import type CodeFrameError from './features/transform/CodeFrameError';
 export type { IUtoopackUserConfig } from '@umijs/bundler-utoopack';
 export { UmiApiRequest, UmiApiResponse } from './features/apiRoute';
-export { webpack, IConfig };
+export { IConfig, webpack };
 
 export type IScript =
   | Partial<{
@@ -81,6 +81,10 @@ export type IEntryImport = {
 };
 export type IRoute = ICoreRoute;
 export type IFileInfo = Array<{ event: string; path: string }>;
+export interface ITmpGenerateWatcher {
+  path: string;
+  events?: string[];
+}
 export interface IOnGenerateFiles {
   files?: IFileInfo | null;
   isFirstTime?: boolean;
@@ -143,7 +147,7 @@ export type IApi = PluginAPI &
     addPrepareBuildPlugins: IAdd<null, ESBuildPlugin>;
     addRuntimePlugin: IAdd<null, string>;
     addRuntimePluginKey: IAdd<null, string>;
-    addTmpGenerateWatcherPaths: IAdd<null, string>;
+    addTmpGenerateWatcherPaths: IAdd<null, string | ITmpGenerateWatcher>;
     addUIModules: IAdd<null, IUIModule[]>;
     chainWebpack: {
       (fn: {


### PR DESCRIPTION
## What changed

- allow `addTmpGenerateWatcherPaths` hooks to return either a path string or `{ path, events }`
- filter watcher events before the existing temporary-file regeneration debounce
- normalize and deduplicate watchers by path and event selection
- preserve the existing all-events behavior for string watcher paths

## Why

dumi currently registers Markdown route paths with Umi's temporary-file watcher. Editing an existing Markdown file therefore runs the global `onGenerateFiles` pipeline, even when the bundler can update that Markdown module through HMR. Regenerating global route and metadata modules expands a local content edit into a much larger compilation.

Plugins need to distinguish content changes from route-topology changes. With this API, dumi can regenerate temporary route files only for `add` and `unlink`, while leaving ordinary `change` events to the bundler's HMR pipeline.
