### PR TITLE
fix(utoopack): alias prevent self-reference

### DIFF
--- a/packages/bundler-utoopack/src/config.test.ts
+++ b/packages/bundler-utoopack/src/config.test.ts
@@ -428,6 +428,37 @@ describe('utoopack alias config', () => {
     expect(config.config.resolve?.alias).not.toHaveProperty('lodash');
   });
 
+  test('drops self-referencing wildcard aliases to prevent infinite recursion', async () => {
+    mockedGetConfig.mockResolvedValueOnce(
+      createWebpackConfig(undefined, {
+        '@scope/pkg': '@scope/pkg/pc',
+        '@': '/project/src',
+      }),
+    );
+
+    const config = await getDevUtooPackConfig({
+      ...baseOpts,
+      rootDir: '/project',
+      config: {},
+    } as any);
+
+    // The bare alias should be preserved
+    expect(config.config.resolve?.alias).toHaveProperty(
+      '@scope/pkg',
+      '@scope/pkg/pc',
+    );
+    // The wildcard alias must NOT be generated because the value
+    // `@scope/pkg/pc/*` starts with the key `@scope/pkg/`,
+    // which would cause the resolver to infinitely recurse.
+    expect(config.config.resolve?.alias).not.toHaveProperty('@scope/pkg/*');
+    // Normal aliases should still get wildcard aliases as usual
+    expect(config.config.resolve?.alias).toHaveProperty('@', '/project/src');
+    expect(config.config.resolve?.alias).toHaveProperty(
+      '@/*',
+      '/project/src/*',
+    );
+  });
+
   test('prepends utoopack error overlay client to development entries', async () => {
     mockedGetConfig.mockImplementationOnce(async (opts) =>
       createWebpackConfig(undefined, {}, opts.entry),

--- a/packages/bundler-utoopack/src/config.ts
+++ b/packages/bundler-utoopack/src/config.ts
@@ -468,8 +468,25 @@ function getNormalizedAlias(
       // If unresolved or confirmed as a file, preserve the original skip behavior.
       if (!isDirectory) continue;
     }
-    // Add wildcard version for directory aliases
-    newAlias[`${key}/*`] = `${value}/*`;
+
+    // Add wildcard version for directory aliases.
+    //
+    // Self-reference guard: skip when value starts with `key + '/'`.
+    // Without this, the generated wildcard creates an infinite recursion:
+    //
+    //   Given             : key = '@scope/pkg', value = '@scope/pkg/pc'
+    //   Wildcard would be : @scope/pkg/* -> @scope/pkg/pc/*
+    //   Resolver chain    : @scope/pkg/foo
+    //        → (match /*) → @scope/pkg/pc/foo
+    //        → (match /*) → @scope/pkg/pc/pc/foo
+    //        → (match /*) → @scope/pkg/pc/pc/pc/foo → ...
+    //   The resolved output always re-matches the wildcard key.
+    //
+    // This mirrors webpack's AliasPlugin, which checks
+    // `request.startsWith(alias.value)` to prevent self-reference.
+    if (!value.startsWith(key + '/')) {
+      newAlias[`${key}/*`] = `${value}/*`;
+    }
   }
 
   newAlias[`${normalizedRootDir}/*`] = `${normalizedRootDir}/*`;


### PR DESCRIPTION
The following alias configurations will be recursively matched.
```js
{
  '@scope/foo$': '@scope/foo/pc',
}
```