### PR TITLE
docs: add utoopack qiankun 2 version requirement

### DIFF
--- a/docs/docs/docs/api/config.en-US.md
+++ b/docs/docs/docs/api/config.en-US.md
@@ -1531,6 +1531,8 @@ Use rust bundler [utoopack](http://github.com/utooland/utoo) to improve the perf
 
 This capability can be enabled through configuration, utoopack currently supports most of the framework's features.
 
+When building a qiankun child application with utoopack, if the parent application uses qiankun 2, the qiankun version must be `2.10.17-beta.0` or later. Earlier versions do not provide `document.currentScript` correctly while executing entry scripts, which prevents the child application from loading. For more details about the integration, see the Utoo blog post [When Turbopack Meets qiankun: Adapting Utoopack for Micro Frontends](https://utoo.land/en/docs/blog/utoopack-qiankun).
+
 ## verifyCommit
 
 - Type: `{ scope: string[]; allowEmoji: boolean }`

--- a/docs/docs/docs/api/config.md
+++ b/docs/docs/docs/api/config.md
@@ -1568,6 +1568,8 @@ $ npm install @babel/runtime --save-dev
 
 通过配置来启用这个能力，目前 utoopack 对框架中大部分功能已经支持。
 
+使用 utoopack 构建 qiankun 子应用时，如果主应用使用 qiankun 2，qiankun 版本需为 `2.10.17-beta.0` 或更高。更早的版本无法在执行入口脚本时正确提供 `document.currentScript`，会导致子应用加载失败。更多适配原理请参阅 Utoo 官网博客[《当 Turbopack 遇上 qiankun：Utoopack 的微前端适配实践》](https://utoo.land/zh/docs/blog/utoopack-qiankun)。
+
 ## verifyCommit
 
 - 类型：`{ scope: string[]; allowEmoji: boolean }`

--- a/docs/docs/docs/max/micro-frontend.en-US.md
+++ b/docs/docs/docs/max/micro-frontend.en-US.md
@@ -100,6 +100,10 @@ Child applications need to export necessary lifecycle hooks for the parent appli
 
 Assuming your child application project is **developed based on Umi** and **the `qiankun` [plugin](https://github.com/umijs/umi/blob/master/packages/plugins/src/qiankun.ts) is introduced**. If not, you can follow [this tutorial](https://qiankun.umijs.org/zh/guide/getting-started#%E5%BE%AE%E5%BA%94%E7%94%A8) to configure.
 
+:::warning{title=Utoopack compatibility}
+If the child application is built with utoopack and the parent application uses qiankun 2, upgrade qiankun in the parent application to `2.10.17-beta.0` or later. Earlier versions do not provide `document.currentScript` correctly while executing entry scripts, which prevents the child application from loading. For more details, see the Utoo blog post [When Turbopack Meets qiankun: Adapting Utoopack for Micro Frontends](https://utoo.land/en/docs/blog/utoopack-qiankun).
+:::
+
 Modify the Umi configuration file of the child application and add the following content:
 
 ```ts

--- a/docs/docs/docs/max/micro-frontend.md
+++ b/docs/docs/docs/max/micro-frontend.md
@@ -99,6 +99,10 @@ export const qiankun = {
 
 假设您的子应用项目**基于 Umi 开发**且**引入了 `qiankun` [插件](https://github.com/umijs/umi/blob/master/packages/plugins/src/qiankun.ts)**。如果没有，可以按照[此教程](https://qiankun.umijs.org/zh/guide/getting-started#%E5%BE%AE%E5%BA%94%E7%94%A8)进行配置。
 
+:::warning{title=Utoopack 兼容性}
+如果子应用使用 utoopack 构建，且主应用使用 qiankun 2，请将主应用的 qiankun 升级至 `2.10.17-beta.0` 或更高版本。更早的版本无法在执行入口脚本时正确提供 `document.currentScript`，会导致子应用加载失败。更多适配原理请参阅 Utoo 官网博客[《当 Turbopack 遇上 qiankun：Utoopack 的微前端适配实践》](https://utoo.land/zh/docs/blog/utoopack-qiankun)。
+:::
+
 修改子应用的 Umi 的配置文件，添加如下内容：
 
 ```ts


### PR DESCRIPTION
## Summary

- document the minimum qiankun 2 version required when loading utoopack-built child applications in the utoopack config reference
- add the same compatibility notice to the qiankun integration guide in both Chinese and English
- explain the `document.currentScript` compatibility requirement and link to the Utoo integration blog

## Related issue

https://github.com/umijs/umi/issues/13413
