### PR TITLE
docs: fix micro frontend documentation

### DIFF
--- a/docs/docs/docs/max/micro-frontend.en-US.md
+++ b/docs/docs/docs/max/micro-frontend.en-US.md
@@ -1,14 +1,14 @@
 ---
 order: 9
 toc: content
-translated_at: '2024-03-17T08:50:33.783Z'
+translated_at: '2026-08-17T03:38:01.000Z'
 ---
 
 # Micro Frontends
 
 `@umi/max` has a built-in **Qiankun Micro Frontends** [plugin](https://github.com/umijs/umi/blob/master/packages/plugins/src/qiankun.ts), which can enable the Qiankun micro frontend development mode with one click, helping you easily integrate Qiankun micro applications in your Umi project, and build a production-ready micro frontend architecture system.
 
-For more information about Qiankun Micro Frontends, please refer to [this page](https://qiankun.umijs.org/zh/guide).
+For more information about Qiankun Micro Frontends, please refer to [this page](https://qiankun.umijs.org/guide).
 
 ## Micro Frontend Example
 
@@ -98,9 +98,9 @@ export const qiankun = {
 
 Child applications need to export necessary lifecycle hooks for the parent application to call at the appropriate time.
 
-Assuming your child application project is **developed based on Umi** and **the `qiankun` [plugin](https://github.com/umijs/umi/blob/master/packages/plugins/src/qiankun.ts) is introduced**. If not, you can follow [this tutorial](https://qiankun.umijs.org/zh/guide/getting-started#%E5%BE%AE%E5%BA%94%E7%94%A8) to configure.
+Assuming your child application project is **developed based on Umi** and **the `qiankun` [plugin](https://github.com/umijs/umi/blob/master/packages/plugins/src/qiankun.ts) is introduced**. If not, you can follow [this tutorial](https://qiankun.umijs.org/guide/getting-started#sub-application) to configure.
 
-:::warning{title=Utoopack compatibility}
+:::warning{title="Utoopack compatibility"}
 If the child application is built with utoopack and the parent application uses qiankun 2, upgrade qiankun in the parent application to `2.10.17-beta.0` or later. Earlier versions do not provide `document.currentScript` correctly while executing entry scripts, which prevents the child application from loading. For more details, see the Utoo blog post [When Turbopack Meets qiankun: Adapting Utoopack for Micro Frontends](https://utoo.land/en/docs/blog/utoopack-qiankun).
 :::
 
@@ -471,4 +471,347 @@ export const qiankun = {
 };
 ```
 
-The child application can obtain and consume the `props` properties in the lifecycle hooks [configured according to the requirements](#
+The child application can obtain and use the passed `props` in lifecycle hooks by [implementing the corresponding lifecycle hooks](#child-application-configures-lifecycle-hooks) as needed.
+
+## Custom Child Applications
+
+When a loading indicator or error boundary is enabled for a child application, the child application receives an additional `wrapperClassName` CSS class. The rendered structure is as follows:
+
+```tsx
+<div style={{ position: 'relative' }} className={wrapperClassName}>
+  <MicroAppLoader loading={loading} />
+  <ErrorBoundary error={e} />
+  <MicroApp className={className} />
+</div>
+```
+
+### Child Application Loading Indicator
+
+After this capability is enabled, a loading indicator is displayed automatically while the child application is loading. When the child application finishes mounting and reaches the `MOUNTED` state, the loading state ends and the child application content is displayed.
+
+#### antd-based Loading Indicator
+
+If your project uses antd, pass the `autoSetLoading` property to the child application to enable its loading indicator. The plugin automatically uses antd's [`<Spin />` component](https://ant.design/components/spin) as the loader.
+
+When introducing a child application through routing, configure it as follows:
+
+```ts
+// .umirc.ts
+export default {
+  routes: [
+    {
+      path: '/app1',
+      microApp: 'app1',
+      microAppProps: {
+        autoSetLoading: true,
+      },
+    },
+  ],
+};
+```
+
+When introducing a child application through a component, pass `autoSetLoading` directly:
+
+```tsx
+import { MicroApp } from 'umi';
+
+export default function Page() {
+  return <MicroApp name="app1" autoSetLoading />;
+}
+```
+
+#### Custom Loading Indicator
+
+If your project does not use antd, or if you want to override the default loading style, provide a custom `loader` component for the child application.
+
+Child applications introduced through routing support this option only in runtime configuration:
+
+```tsx
+// .app.tsx
+import CustomLoader from 'src/components/CustomLoader';
+
+export const qiankun = () => ({
+  routes: [
+    {
+      path: '/app1',
+      microApp: 'app1',
+      microAppProps: {
+        loader: (loading) => <CustomLoader loading={loading} />,
+      },
+    },
+  ],
+});
+```
+
+When introducing a child application through a component, pass `loader` directly:
+
+```tsx
+import CustomLoader from '@/components/CustomLoader';
+import { MicroApp } from 'umi';
+
+export default function Page() {
+  return (
+    <MicroApp
+      name="app1"
+      loader={(loading) => <CustomLoader loading={loading} />}
+    />
+  );
+}
+```
+
+The `loading` parameter is a `boolean`: `true` means that the child application is still loading, and `false` means that loading has finished.
+
+To share one custom loading indicator across multiple child applications, configure `defaultLoader` in the parent application:
+
+```ts
+// .umirc.ts
+qiankun: {
+  master: {
+    defaultLoader: '@/defaultLoader',
+  },
+},
+```
+
+`defaultLoader` is a file path. By convention, place the file in the [src directory](../guides/directory-structure#src-directory). In Umi, `@` represents the `src` directory.
+
+`defaultLoader` has the same implementation as `loader` and receives a `boolean` `loading` parameter.
+
+```tsx
+// defaultLoader.tsx
+import { Spin } from 'antd';
+
+export default function (loading: boolean) {
+  return <Spin spinning={loading} />;
+}
+```
+
+Note: `loader` takes precedence over `defaultLoader`.
+
+### Child Application Error Handling
+
+After this capability is enabled, error information is displayed automatically when a child application fails to load.
+
+#### antd-based Error Boundary
+
+If your project uses antd, pass the `autoCaptureError` property to the child application to enable error handling. The plugin automatically uses antd's [`<Result />` component](https://ant.design/components/result) as the error boundary.
+
+For example, the displayed language automatically follows the Umi locale configuration: <img src="https://mdn.alipayobjects.com/huamei_zvchwx/afts/img/A*gAAVRrAJJNEAAAAAAAAAAAAADuWEAQ/original">
+
+When introducing a child application through routing, configure it as follows:
+
+```ts
+// .umirc.ts
+export default {
+  routes: [
+    {
+      path: '/app1',
+      microApp: 'app1',
+      microAppProps: {
+        autoCaptureError: true,
+      },
+    },
+  ],
+};
+```
+
+When introducing a child application through a component, pass `autoCaptureError` directly:
+
+```tsx
+import { MicroApp } from 'umi';
+
+export default function Page() {
+  return <MicroApp name="app1" autoCaptureError />;
+}
+```
+
+#### Custom Error Boundary
+
+If your project does not use antd, or if you want to override the default error boundary style, provide a custom `errorBoundary` component for the child application.
+
+Child applications introduced through routing support this option only in runtime configuration:
+
+```tsx
+// .app.tsx
+import CustomErrorBoundary from '@/components/CustomErrorBoundary';
+
+export const qiankun = () => ({
+  routes: [
+    {
+      path: '/app1',
+      microApp: 'app1',
+      microAppProps: {
+        errorBoundary: (error) => <CustomErrorBoundary error={error} />,
+      },
+    },
+  ],
+});
+```
+
+When introducing a child application through a component, pass `errorBoundary` directly:
+
+```tsx
+import CustomErrorBoundary from '@/components/CustomErrorBoundary';
+import { MicroApp } from 'umi';
+
+export default function Page() {
+  return (
+    <MicroApp
+      name="app1"
+      errorBoundary={(error) => <CustomErrorBoundary error={error} />}
+    />
+  );
+}
+```
+
+The `error` parameter is an `Error` object.
+
+To share one custom error boundary across multiple child applications, configure `defaultErrorBoundary` in the parent application:
+
+```ts
+// .umirc.ts
+qiankun: {
+  master: {
+    defaultErrorBoundary: '@/defaultErrorBoundary',
+  },
+},
+```
+
+`defaultErrorBoundary` is a file path. By convention, place the file in the [src directory](../guides/directory-structure#src-directory). In Umi, `@` represents the `src` directory.
+
+`defaultErrorBoundary` has the same implementation as `errorBoundary` and receives an `Error` parameter.
+
+```tsx
+// defaultErrorBoundary.tsx
+export default function (error: Error) {
+  return <div>{error?.message}</div>;
+}
+```
+
+Note: `errorBoundary` takes precedence over `defaultErrorBoundary`.
+
+## Environment Variables
+
+If you have configuration that cannot be written explicitly in `.umirc.ts` or `src/app.ts`, store it in an environment variable file. For example, define the parent application's `.env` file as follows:
+
+```plaintext
+INITIAL_QIANKUN_MASTER_OPTIONS="{\"apps\":[{\"name\":\"app1\",\"entry\":\"//localhost:7001\"},{\"name\":\"app2\",\"entry\":\"//localhost:7002\"}]}"
+```
+
+Internally, the micro frontend plugin runs `JSON.parse(process.env.INITIAL_QIANKUN_MASTER_OPTIONS)` and merges the result with the existing configuration. The environment variable above is equivalent to the following merged configuration:
+
+```ts
+export default {
+  qiankun: {
+    master: {
+      apps: [
+        {
+          name: 'app1',
+          entry: '//localhost:7001',
+        },
+        {
+          name: 'app2',
+          entry: '//localhost:7002',
+        },
+      ],
+      // ...other configuration from .umirc.ts
+    },
+  },
+};
+```
+
+When the same option exists in both places, such as `apps`, the value in `.umirc.ts` **overrides** the value from the environment variable.
+
+Similarly, a child application can define the following `.env` file:
+
+```plaintext
+INITIAL_QIANKUN_SLAVE_OPTIONS="{\"enable\":false}"
+```
+
+This is equivalent to the following configuration:
+
+```ts
+export default {
+  qiankun: {
+    slave: {
+      enable: false,
+      // ...other configuration from .umirc.ts
+    },
+  },
+};
+```
+
+## API
+
+### MasterOptions
+
+| Property | Required | Description | Type | Default |
+| --- | --- | --- | --- | --- |
+| `enable` | No | Enables the Qiankun micro application plugin; set it to `false` to disable the plugin | `boolean` | `undefined` |
+| `apps` | Yes | Micro application configuration | [`App[]`](#app) | `undefined` |
+| `routes` | No | Runtime routes for micro applications | [`Route[]`](#route) | `undefined` |
+| `defaultErrorBoundary` | No | Default error boundary for child applications, specified as a file path | `string` | - |
+| `defaultLoader` | No | Default loading indicator for child applications, specified as a file path | `string` | - |
+| `sandbox` | No | Whether to enable sandbox mode | `boolean \| { strictStyleIsolation: boolean, experimentalStyleIsolation: boolean }` | `true` |
+| `prefetch` | No | Whether to prefetch micro applications | `boolean \| 'all' \| string[] \| (( apps: RegistrableApp[] ) => { criticalAppNames: string[]; minorAppsName: string[] })` | `true` |
+
+For more information about sandboxing and prefetching, see the [Qiankun API documentation](https://qiankun.umijs.org/api/#startopts).
+
+### SlaveOptions
+
+| Property | Required | Description | Type | Default |
+| --- | --- | --- | --- | --- |
+| `enable` | No | Enables the Qiankun micro application plugin; set it to `false` to disable the plugin | `boolean` | `undefined` |
+
+### App
+
+| Property | Required | Description | Type | Default |
+| --- | --- | --- | --- | --- |
+| `name` | Yes | Name of the micro application | `string` | - |
+| `entry` | Yes | HTML address of the micro application | `string` | `{ script: string[], styles: [] }` |
+| `credentials` | No | Whether to include cookies when fetching the micro application; see the [Qiankun FAQ](https://qiankun.umijs.org/faq/) | `boolean` | `false` |
+| `props` | No | Data passed from the parent application to the micro application; see [Communication Between Parent and Child Applications](#communication-between-parent-and-child-applications) | `object` | `{}` |
+
+### Route
+
+| Property | Required | Description | Type | Default |
+| --- | --- | --- | --- | --- |
+| `path` | Yes | Route path | `string` | - |
+| `microApp` | Yes | Name of the associated micro application | `string` | - |
+| `microAppProps` | No | Micro application configuration | [`MicroAppProps`](#microappprops) | `{}` |
+
+### MicroAppProps
+
+| Property | Required | Description | Type | Default |
+| --- | --- | --- | --- | --- |
+| `autoSetLoading` | No | Automatically manages the micro application's loading state | `boolean` | `false` |
+| `loader` | No | Custom loading-state component for the micro application | `(loading) => React.ReactNode` | `undefined` |
+| `autoCaptureError` | No | Automatically captures micro application errors | `boolean` | `false` |
+| `errorBoundary` | No | Custom error boundary component for the micro application | `(error: any) => React.ReactNode` | `undefined` |
+| `className` | No | CSS class for the micro application | `string` | `undefined` |
+| `wrapperClassName` | No | CSS class for the wrapper around the loader, error boundary, and micro application; applies only when a loader or error boundary is enabled | `string` | `undefined` |
+
+## FAQ
+
+### Child Application Lifecycle Hooks Load, but the Page Does Not Render
+
+If the page reports no errors and the child application's root DOM node exists but is empty, the current URL most likely does not match any route in the child application.
+
+For example, suppose the parent application contains this configuration:
+
+```js
+{
+  path: '/app1',
+  microApp: 'app1',
+}
+```
+
+And the child application contains this route:
+
+```js
+{
+  path: '/user',
+  component: './User',
+}
+```
+
+You must visit `/app1/user` to access the child application's user page.

--- a/docs/docs/docs/max/micro-frontend.md
+++ b/docs/docs/docs/max/micro-frontend.md
@@ -99,11 +99,11 @@ export const qiankun = {
 
 假设您的子应用项目**基于 Umi 开发**且**引入了 `qiankun` [插件](https://github.com/umijs/umi/blob/master/packages/plugins/src/qiankun.ts)**。如果没有，可以按照[此教程](https://qiankun.umijs.org/zh/guide/getting-started#%E5%BE%AE%E5%BA%94%E7%94%A8)进行配置。
 
-:::warning{title=Utoopack 兼容性}
+:::warning{title="Utoopack 兼容性"}
 如果子应用使用 utoopack 构建，且主应用使用 qiankun 2，请将主应用的 qiankun 升级至 `2.10.17-beta.0` 或更高版本。更早的版本无法在执行入口脚本时正确提供 `document.currentScript`，会导致子应用加载失败。更多适配原理请参阅 Utoo 官网博客[《当 Turbopack 遇上 qiankun：Utoopack 的微前端适配实践》](https://utoo.land/zh/docs/blog/utoopack-qiankun)。
 :::
 
-修改子应用的 Umi 的配置文件，添加如下内容：
+修改子应用的 Umi 配置文件，添加如下内容：
 
 ```ts
 // .umirc.ts
@@ -430,7 +430,7 @@ function MyPage(props) {
 export default connectMaster(MyPage);
 ```
 
-子应用也可以在生命周期钩子中能够获取并消费得到的 `props` 属性，根据需求[实现对应的生命周期钩子](#子应用配置生命周期钩子)即可。
+子应用也可以在生命周期钩子中获取并使用传入的 `props` 属性，根据需求[实现对应的生命周期钩子](#子应用配置生命周期钩子)即可。
 
 特别的，当父应用使用 `<MicroApp />` 或 `<MicroAppWithMemoHistory />` 组件的方式引入子应用时，会额外向子应用传递一个 `setLoading()` 方法，允许子应用在合适的时机执行，标记子应用加载为完成状态：
 
@@ -470,7 +470,7 @@ export const qiankun = {
 };
 ```
 
-子应用在生命周期钩子中能够获取并消费得到的 `props` 属性，根据需求[实现对应的生命周期钩子](#子应用配置生命周期钩子)即可。
+子应用可以在生命周期钩子中获取并使用传入的 `props` 属性，根据需求[实现对应的生命周期钩子](#子应用配置生命周期钩子)即可。
 
 ## 自定义子应用
 


### PR DESCRIPTION
## Summary

- fix the Utoopack warning container rendering and Chinese wording
- restore the truncated English micro-frontend guide and use English documentation links

## Checks

- `pnpm --filter @umijs/docs build`
- `pnpm exec prettier --check docs/docs/docs/max/micro-frontend.md docs/docs/docs/max/micro-frontend.en-US.md`