### PR TITLE
chore(utoopack): enable Rust React Compiler example

### DIFF
--- a/examples/with-react-19/.umirc.ts
+++ b/examples/with-react-19/.umirc.ts
@@ -2,8 +2,9 @@ export default {
   plugins: ['@umijs/plugins/dist/initial-state', '@umijs/plugins/dist/model'],
   routes: [{ path: '/', component: 'index' }],
   npmClient: 'pnpm',
-  reactCompiler: true,
-  utoopack: {},
+  utoopack: {
+    reactCompiler: true,
+  },
   initialState: {},
   model: {},
   mfsu: false,


### PR DESCRIPTION
## Summary

- configure the React 19 example to enable React Compiler through `utoopack.reactCompiler`
- remove the top-level `reactCompiler` option so the example uses Utoopack's native Rust transform instead of the Babel path

## Verification

- `pnpm --filter @example/with-react-19 build`
- verified generated output contains `useMemoCache` and `react.memo_cache_sentinel`
- verified in dev that updating `name` re-renders `HomePage` without re-rendering `ExpensiveComponent`