### PR TITLE
ci: sync packages to TNPM after publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,9 @@ jobs:
 
       - name: Publish packages
         run: pnpm release:publish
+
+      - name: Install TNPM
+        run: npm install --global tnpm@10.6.2 --registry https://registry.antgroup-inc.cn
+
+      - name: Sync packages to TNPM
+        run: pnpm sync:tnpm

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "setup": "pnpm --filter @umijs/ui run setup",
     "setup:webstorm": "umi-scripts setupWebStorm",
     "sync:mako": "umi-scripts syncMako",
+    "sync:tnpm": "umi-scripts syncTnpm",
     "sync:utoo": "umi-scripts syncUtoo",
     "test": "jest",
     "test:clean": "umi-scripts turbo test --no-cache --parallel -- --clearCache",

--- a/scripts/syncTnpm.ts
+++ b/scripts/syncTnpm.ts
@@ -1,0 +1,20 @@
+import * as logger from '@umijs/utils/src/logger';
+import 'zx/globals';
+import { PATHS } from './.internal/constants';
+import { getPkgs } from './.internal/utils';
+
+(async () => {
+  const pkgs = getPkgs();
+  logger.info(`pkgs: ${pkgs.join(', ')}`);
+
+  logger.event('sync tnpm');
+  $.verbose = false;
+  await Promise.all(
+    pkgs.map(async (pkg) => {
+      const { name } = require(path.join(PATHS.PACKAGES, pkg, 'package.json'));
+      logger.info(`sync ${name}`);
+      await $`tnpm sync ${name}`;
+    }),
+  );
+  $.verbose = true;
+})();


### PR DESCRIPTION
## Summary

- restore the sync:tnpm command and package synchronization script
- install the internal TNPM CLI from the Ant Group registry
- sync all Umi packages after the OIDC npm publish step completes

This provides an explicit fallback for the internal registry synchronization delay.

## Validation

- pnpm exec prettier --check package.json .github/workflows/release.yml scripts/syncTnpm.ts
- pnpm exec utoo-lint scripts/syncTnpm.ts
- pnpm tsc:check
- git diff --check

The TNPM sync itself was not triggered locally.