### PR TITLE
feat(lint): use utoo-lint for JavaScript and TypeScript

### DIFF
--- a/docs/docs/docs/api/commands.en-US.md
+++ b/docs/docs/docs/api/commands.en-US.md
@@ -162,7 +162,7 @@ Used to check and correct code to match rules.
 $ umi lint
 Usage: umi lint
 
- Support for validation of js, ts, tsx, jsx type files only: umi lint --eslint-only
+ Validate js, ts, tsx, and jsx files with utoo-lint only: umi lint --eslint-only
 
  Support for validation of css, less and other style files only: umi lint --stylelint-only
 

--- a/docs/docs/docs/api/commands.md
+++ b/docs/docs/docs/api/commands.md
@@ -160,7 +160,7 @@ Details:
 $ umi lint
 Usage: umi lint
 
- 支持只校验 js、ts、tsx、jsx 类型文件： umi lint --eslint-only
+ 使用 utoo-lint 只校验 js、ts、tsx、jsx 类型文件： umi lint --eslint-only
 
  支持只校验 css、less 等样式文件： umi lint --stylelint-only
 
@@ -305,4 +305,3 @@ npx --no-install umi verify-commit $1
 $ umi version
 4.0.0
 ```
-

--- a/docs/docs/docs/guides/lint.en-US.md
+++ b/docs/docs/docs/guides/lint.en-US.md
@@ -6,17 +6,17 @@ translated_at: '2024-03-17T10:29:06.038Z'
 
 # Coding Standards
 
-We often use ESLint and Stylelint in projects to help us control coding quality. To achieve low-cost, high-performance, and more stable integration of the above tools, Umi provides out-of-the-box Lint capabilities, including the following features:
+We often use JavaScript/TypeScript linting and Stylelint to control code quality. Umi provides an out-of-the-box lint workflow with the following features:
 
-1. **Recommended Configurations**: Provides ESLint and Stylelint recommended configurations that can be directly inherited and used
-2. **Unified CLI**: Provides `umi lint` CLI, integrating calls to ESLint and Stylelint
+1. **Recommended Rules**: Provides ready-to-use rules for JavaScript, TypeScript, and style files
+2. **Unified CLI**: Uses utoo-lint for JavaScript/TypeScript and Stylelint for styles through `umi lint`
 3. **Stable Rules**: Always ensures the stability of rules to avoid situations where upstream configuration updates cause lint failures in existing projects
 
-The ESLint configuration has the following characteristics:
+JavaScript/TypeScript linting has the following characteristics:
 
 1. **Quality-Related Only**: We have selected dozens of quality-related rules from hundreds of rules to whitelist, returning to the essence of Lint, without conflict with Prettier's rules
-2. **Performance Priority**: Some TypeScript rules are of low practicability but incur high project-wide compilation costs, so we disable these rules to improve performance
-3. **Built-in Common Plugins**: Includes react, react-hooks, @typescript/eslint, jest, meeting daily needs
+2. **Performance Priority**: Runs on the native utoo-lint engine and applies a separate rule override to TypeScript files
+3. **Progressive Compatibility**: Enables the Umi recommended rules currently supported by utoo-lint and expands coverage as upstream support lands
 
 Additionally, the Stylelint configuration also includes built-in support for CSS-in-JS, allowing for the detection of stylesheet syntax errors in JS files. Sounds attractive? Let's see how to integrate it.
 
@@ -31,30 +31,31 @@ $ npm i @umijs/lint -D
 $ pnpm add @umijs/lint -D
 ```
 
-Then install ESLint and Stylelint:
+Then install Stylelint:
 
 > The current version of `stylelint` used by `@umijs/lint` is v14  
 
 ```bash
-$ npm i -D eslint "stylelint@^14"
+$ npm i -D "stylelint@^14"
 # or
-$ pnpm add -D eslint "stylelint@^14"
+$ pnpm add -D "stylelint@^14"
 ```
 
 ### Enable Configuration
 
-Inherit the configuration provided by Umi in your `.eslintrc.js` and `.stylelintrc.js`:
+`umi lint` includes the JavaScript/TypeScript recommended rules, so no configuration file is required. To override rules, add `utlint.config.json` to the project root:
+
+```json
+{
+  "rules": {
+    "no-console": "warn"
+  }
+}
+```
+
+Style linting still requires the Umi configuration in `.stylelintrc.js`:
 
 ```js
-// .eslintrc.js
-module.exports = {
-  // For Umi projects
-  extends: require.resolve('umi/eslint'),
-
-  // For Umi Max projects
-  extends: require.resolve('@umijs/max/eslint'),
-}
-
 // .stylelintrc.js
 module.exports = {
   // For Umi projects
@@ -65,7 +66,7 @@ module.exports = {
 }
 ```
 
-After the configuration files are created, we can already use the `eslint` and `stylelint` commands to execute lint, but we still recommend using the `umi lint` command for a more convenient experience.
+If you still need to run ESLint directly, install `eslint` and keep extending `umi/eslint` or `@umijs/max/eslint` from `.eslintrc.js`. This compatibility configuration affects the standalone `eslint` command only; `umi lint` uses utoo-lint for JavaScript and TypeScript.
 
 ### CLI
 
@@ -80,8 +81,8 @@ Parameters explanation:
 ```bash
   [glob]: Optional, specify the files to lint, default is `{src,test}/**/*.{js,jsx,ts,tsx,css,less}`
   --quiet: Optional, disable reporting of `warn` rules, only output `error`
-  --fix: Optional, auto-fix lint errors
-  --eslint-only: Optional, execute ESLint only
+  --fix: Optional, auto-fix errors supported by utoo-lint or Stylelint
+  --eslint-only: Optional, lint JavaScript/TypeScript with utoo-lint only (name retained for compatibility)
   --stylelint-only: Optional, execute Stylelint only
   --cssinjs: Optional, enable CSS-in-JS support for Stylelint
 ```
@@ -142,5 +143,6 @@ Refer to the Prettier documentation to configure it with lint-staged: https://pr
 
 ## Appendix
 
-1. ESLint rules built into Umi: https://github.com/umijs/umi/blob/master/packages/lint/src/config/eslint/rules/recommended.ts
-2. Stylelint configuration built into Umi: https://github.com/umijs/umi/blob/master/packages/lint/src/config/stylelint/index.ts
+1. JavaScript/TypeScript rules built into Umi: https://github.com/umijs/umi/blob/master/packages/lint/src/config/eslint/rules/recommended.ts
+2. Umi utoo-lint configuration: https://github.com/umijs/umi/blob/master/packages/lint/src/config/utoo/index.ts
+3. Stylelint configuration built into Umi: https://github.com/umijs/umi/blob/master/packages/lint/src/config/stylelint/index.ts

--- a/docs/docs/docs/guides/lint.md
+++ b/docs/docs/docs/guides/lint.md
@@ -4,17 +4,17 @@ toc: content
 ---
 # 编码规范
 
-我们通常会在项目中使用 ESLint、Stylelint 来协助我们把控编码质量，为了实现低成本、高性能、更稳定地接入上述工具，Umi 提供了开箱即用的 Lint 能力，包含以下特性：
+我们通常会在项目中使用 JavaScript/TypeScript Lint 与 Stylelint 来协助我们把控编码质量。为了实现低成本、高性能、更稳定的接入，Umi 提供了开箱即用的 Lint 能力，包含以下特性：
 
-1. **推荐配置**：提供 ESLint 及 Stylelint 推荐配置，可以直接继承使用
-2. **统一的 CLI**：提供 `umi lint` CLI，集成式调用 ESLint 和 Stylelint
+1. **推荐规则**：为 JavaScript、TypeScript 及样式文件提供开箱即用的推荐规则
+2. **统一的 CLI**：提供 `umi lint` CLI，使用 utoo-lint 检查 JavaScript/TypeScript，使用 Stylelint 检查样式
 3. **规则稳定**：始终确保规则的稳定性，不会出现上游配置更新导致存量项目 lint 失败的情况
 
-其中，ESLint 配置具备如下特点：
+其中，JavaScript/TypeScript Lint 具备如下特点：
 
 1. **仅质量相关**：我们从数百条规则中筛选出数十条与编码质量相关的规则进行白名单开启，回归 Lint 本质，且不会与 Prettier 的规则冲突
-2. **性能优先**：部分 TypeScript 的规则实用性低但项目全量编译的成本却很高，我们对这些规则进行禁用以提升性能
-3. **内置常用插件**：包含 react、react-hooks、@typescript/eslint、jest，满足日常所需
+2. **性能优先**：基于原生实现的 utoo-lint 执行，并为 TypeScript 文件应用独立的规则覆盖
+3. **渐进兼容**：仅启用当前 utoo-lint 已支持的 Umi 推荐规则，后续随上游能力逐步补齐
 
 另外，Stylelint 配置还内置 CSS-in-JS 支持，可以检测出 JS 文件中的样式表语法错误。听起来很有吸引力？来看看如何接入吧。
 
@@ -29,30 +29,31 @@ $ npm i @umijs/lint -D
 $ pnpm add @umijs/lint -D
 ```
 
-然后安装 ESLint 及 Stylelint：
+然后安装 Stylelint：
 
 > 目前 `@umijs/lint` 使用的 `stylelint` 版本是 v14  
 
 ```bash
-$ npm i -D eslint "stylelint@^14"
+$ npm i -D "stylelint@^14"
 # or
-$ pnpm add -D eslint "stylelint@^14"
+$ pnpm add -D "stylelint@^14"
 ```
 
 ### 启用配置
 
-在 `.eslintrc.js` 及 `.stylelintrc.js` 里继承 Umi 提供的配置：
+`umi lint` 已内置 JavaScript/TypeScript 推荐规则，无需创建配置文件。如需覆盖规则，可在项目根目录添加 `utlint.config.json`：
+
+```json
+{
+  "rules": {
+    "no-console": "warn"
+  }
+}
+```
+
+样式检查仍需在 `.stylelintrc.js` 中继承 Umi 提供的配置：
 
 ```js
-// .eslintrc.js
-module.exports = {
-  // Umi 项目
-  extends: require.resolve('umi/eslint'),
-
-  // Umi Max 项目
-  extends: require.resolve('@umijs/max/eslint'),
-}
-
 // .stylelintrc.js
 module.exports = {
   // Umi 项目
@@ -63,7 +64,7 @@ module.exports = {
 }
 ```
 
-在配置文件创建完毕后，我们其实已经可以通过 `eslint`、`stylelint` 命令来执行 lint 了，但我们仍然推荐使用 `umi lint` 命令，以获得更便捷的体验。
+如果仍需单独运行 ESLint，可以安装 `eslint` 并继续在 `.eslintrc.js` 中继承 `umi/eslint` 或 `@umijs/max/eslint`。该兼容配置只作用于独立的 `eslint` 命令；`umi lint` 的 JavaScript/TypeScript 检查由 utoo-lint 执行。
 
 ### CLI
 
@@ -78,8 +79,8 @@ $ umi lint [glob] [--fix] [--eslint-only] [--stylelint-only] [--cssinjs]
 ```bash
   [glob]: 可选，指定要 lint 的文件，默认为 `{src,test}/**/*.{js,jsx,ts,tsx,css,less}`
   --quiet: 可选，禁用 `warn` 规则的报告，仅输出 `error`
-  --fix: 可选，自动修复 lint 错误
-  --eslint-only: 可选，仅执行 ESLint
+  --fix: 可选，自动修复 utoo-lint 或 Stylelint 已支持修复的错误
+  --eslint-only: 可选，仅使用 utoo-lint 检查 JavaScript/TypeScript（参数名为兼容保留）
   --stylelint-only: 可选，仅执行 Stylelint
   --cssinjs: 可选，为 Stylelint 启用 CSS-in-JS 支持
 ```
@@ -140,5 +141,6 @@ Husky 用来绑定 Git Hooks、在指定时机（例如 `pre-commit`）执行我
 
 ## 附录
 
-1. Umi 内置的 ESLint 规则列表：https://github.com/umijs/umi/blob/master/packages/lint/src/config/eslint/rules/recommended.ts
-2. Umi 内置的 Stylelint 配置：https://github.com/umijs/umi/blob/master/packages/lint/src/config/stylelint/index.ts
+1. Umi 内置的 JavaScript/TypeScript 规则列表：https://github.com/umijs/umi/blob/master/packages/lint/src/config/eslint/rules/recommended.ts
+2. Umi 的 utoo-lint 配置：https://github.com/umijs/umi/blob/master/packages/lint/src/config/utoo/index.ts
+3. Umi 内置的 Stylelint 配置：https://github.com/umijs/umi/blob/master/packages/lint/src/config/stylelint/index.ts

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@umijs/plugins": "workspace:*",
     "@umijs/server": "workspace:*",
     "@umijs/utils": "workspace:*",
-    "@utoo/lint": "0.2.7",
+    "@utoo/lint": "0.2.9",
     "@vercel/ncc": "0.44.1",
     "browserslist": "4.28.2",
     "dts-packer": "^0.0.3",

--- a/packages/lint/README.md
+++ b/packages/lint/README.md
@@ -1,3 +1,5 @@
 # @umijs/lint
 
+Umi's lint integration uses [@utoo/lint](https://github.com/utooland/utoo-lint) for JavaScript and TypeScript, while retaining Stylelint for style files and the existing ESLint configuration exports for standalone ESLint usage.
+
 See our website [umijs](https://umijs.org) for more information.

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -28,6 +28,7 @@
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "@umijs/babel-preset-umi": "workspace:*",
+    "@utoo/lint": "0.2.9",
     "eslint-plugin-jest": "27.2.3",
     "eslint-plugin-react": "7.33.2",
     "eslint-plugin-react-hooks": "4.6.0",

--- a/packages/lint/src/config/eslint/index.ts
+++ b/packages/lint/src/config/eslint/index.ts
@@ -1,7 +1,4 @@
-import rules, {
-  jest as jestRules,
-  typescript as tsRules,
-} from './rules/recommended';
+import rules, { jestRules, typescript as tsRules } from './rules/recommended';
 import './setup';
 
 module.exports = {

--- a/packages/lint/src/config/eslint/rules/recommended.ts
+++ b/packages/lint/src/config/eslint/rules/recommended.ts
@@ -70,7 +70,7 @@ export default {
 /**
  * config-plugin-jest rules
  */
-export const jest = {
+export const jestRules = {
   'jest/no-conditional-expect': 2,
   'jest/no-deprecated-functions': 2,
   'jest/no-export': 2,
@@ -85,6 +85,9 @@ export const jest = {
   'jest/valid-expect': 2,
   'jest/valid-title': 2,
 };
+
+// Keep the historical named export for deep imports.
+export { jestRules as jest };
 
 /**
  * recommended enabled/disabled rules for typescript umi project

--- a/packages/lint/src/config/utoo/index.test.ts
+++ b/packages/lint/src/config/utoo/index.test.ts
@@ -1,0 +1,76 @@
+import { ESLint } from '@utoo/lint';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { basename, join } from 'path';
+import { getUtooLintConfig } from '.';
+
+describe('utoo-lint config', () => {
+  const projects: string[] = [];
+
+  afterEach(() => {
+    for (const project of projects.splice(0)) {
+      rmSync(project, { force: true, recursive: true });
+    }
+  });
+
+  it('keeps JavaScript and TypeScript rule scopes separate', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'umi-utoo-lint-'));
+    projects.push(cwd);
+    mkdirSync(join(cwd, 'src'));
+    writeFileSync(join(cwd, 'src/index.js'), 'var value = 1;\n');
+    writeFileSync(join(cwd, 'src/index.ts'), 'var value = 1;\n');
+
+    const results = await new ESLint({
+      baseConfig: getUtooLintConfig(),
+      cwd,
+      noConfig: true,
+    }).lintFiles(['src']);
+    const messages = Object.fromEntries(
+      results.map((result) => [
+        basename(result.filePath),
+        result.messages.map((message) => message.ruleId),
+      ]),
+    );
+
+    expect(messages['index.js']).toEqual(['no-var']);
+    expect(messages['index.ts']).toEqual([
+      'no-var',
+      '@typescript-eslint/no-unused-vars',
+    ]);
+  });
+
+  it('maps equivalent rules and omits unsupported rules', () => {
+    const [recommended, typescript, jest] = getUtooLintConfig();
+
+    expect(recommended.rules).toMatchObject({
+      'no-global-assign': 2,
+      'no-var': 2,
+    });
+    expect(recommended.rules).not.toHaveProperty('no-native-reassign');
+    expect(recommended.rules).not.toHaveProperty(
+      'react/no-direct-mutation-state',
+    );
+    expect(typescript.rules).not.toHaveProperty(
+      '@typescript-eslint/no-invalid-this',
+    );
+    expect(jest.rules).not.toHaveProperty('jest/no-focused-tests');
+  });
+
+  it('allows project config to override the built-in rules', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'umi-utoo-lint-'));
+    projects.push(cwd);
+    mkdirSync(join(cwd, 'src'));
+    writeFileSync(join(cwd, 'src/index.js'), 'var value = 1;\n');
+    writeFileSync(
+      join(cwd, 'utlint.config.json'),
+      JSON.stringify({ rules: { 'no-var': 'off' } }),
+    );
+
+    const results = await new ESLint({
+      baseConfig: getUtooLintConfig(),
+      cwd,
+    }).lintFiles(['src']);
+
+    expect(results[0].messages).toEqual([]);
+  });
+});

--- a/packages/lint/src/config/utoo/index.ts
+++ b/packages/lint/src/config/utoo/index.ts
@@ -1,0 +1,43 @@
+import type { ConfigObject, RuleConfig } from '@utoo/lint';
+import { Linter } from '@utoo/lint';
+import rules, {
+  jestRules,
+  typescript as typescriptRules,
+} from '../eslint/rules/recommended';
+
+type Rules = Record<string, RuleConfig>;
+
+const RULE_ALIASES: Record<string, string> = {
+  '@typescript-eslint/no-invalid-this': 'no-invalid-this',
+  'no-native-reassign': 'no-global-assign',
+};
+
+function getSupportedRules(rules: Rules, supportedRules: Set<string>): Rules {
+  return Object.fromEntries(
+    Object.entries(rules).flatMap(([rule, value]) => {
+      const resolvedRule = RULE_ALIASES[rule] || rule;
+      return supportedRules.has(resolvedRule) ? [[resolvedRule, value]] : [];
+    }),
+  );
+}
+
+export function getUtooLintConfig(): ConfigObject[] {
+  const supportedRules = new Set(new Linter().getRules().keys());
+
+  return [
+    {
+      name: 'umi/recommended',
+      rules: getSupportedRules(rules as Rules, supportedRules),
+    },
+    {
+      name: 'umi/typescript',
+      files: ['**/*.{ts,tsx}'],
+      rules: getSupportedRules(typescriptRules as Rules, supportedRules),
+    },
+    {
+      name: 'umi/jest',
+      files: ['**/*.{test,spec,unit,e2e}.{js,jsx,ts,tsx}'],
+      rules: getSupportedRules(jestRules as Rules, supportedRules),
+    },
+  ];
+}

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -2,13 +2,6 @@ import { EsLinter, StyleLinter } from './linter';
 import type { ILintArgs, ILinterOpts } from './types';
 
 const ES_EXTS = ['**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx'];
-const STYLE_EXTS = [
-  '**/*.less',
-  '**/*.css',
-  '**/*.sass',
-  '**/*.scss',
-  '**/*.styl',
-];
 export type { ILintArgs, ILinterOpts };
 
 export default (opts: ILinterOpts, args: ILintArgs) => {
@@ -28,11 +21,6 @@ export default (opts: ILinterOpts, args: ILintArgs) => {
   if (!args.stylelintOnly) {
     const eslint = new EsLinter(opts);
     const esArgs = { ...args, _: [...args._] };
-
-    for (const suffix of STYLE_EXTS) {
-      esArgs._.unshift('--ignore-pattern', suffix);
-    }
-
     eslint.run(esArgs);
   }
 };

--- a/packages/lint/src/linter/eslint.test.ts
+++ b/packages/lint/src/linter/eslint.test.ts
@@ -1,0 +1,70 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import EsLinter from './eslint';
+
+describe('EsLinter', () => {
+  const projects: string[] = [];
+
+  afterEach(() => {
+    process.exitCode = undefined;
+    for (const project of projects.splice(0)) {
+      rmSync(project, { force: true, recursive: true });
+    }
+    jest.restoreAllMocks();
+  });
+
+  it('passes lint targets to utoo-lint', () => {
+    const linter = new EsLinter({ cwd: process.cwd() });
+
+    expect(
+      linter.getRunArgs({
+        _: ['src/index.ts'],
+        fix: true,
+        quiet: true,
+      }),
+    ).toEqual(['src/index.ts']);
+  });
+
+  it('honors quiet for project warning overrides', () => {
+    const cwd = createProject({ 'no-var': 'warn' }, 'var value = 1;\n');
+    const stdout = jest
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+
+    new EsLinter({ cwd }).run({ _: ['src'], quiet: true });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(stdout).not.toHaveBeenCalledWith(expect.stringContaining('no-var'));
+  });
+
+  it('applies fixes supported by utoo-lint', () => {
+    const cwd = createProject(
+      { 'no-extra-semi': 'error', 'no-var': 'off' },
+      'const value = 1;;\n',
+    );
+    jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    new EsLinter({ cwd }).run({ _: ['src'], fix: true });
+
+    expect(readFileSync(join(cwd, 'src/index.js'), 'utf8')).toBe(
+      'const value = 1;\n',
+    );
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  function createProject(rules: Record<string, string>, source: string) {
+    const cwd = mkdtempSync(join(tmpdir(), 'umi-utoo-lint-'));
+    projects.push(cwd);
+    mkdirSync(join(cwd, 'src'));
+    writeFileSync(join(cwd, 'src/index.js'), source);
+    writeFileSync(join(cwd, 'utlint.config.json'), JSON.stringify({ rules }));
+    return cwd;
+  }
+});

--- a/packages/lint/src/linter/eslint.ts
+++ b/packages/lint/src/linter/eslint.ts
@@ -1,17 +1,36 @@
+import { CLIEngine } from '@utoo/lint';
+import { getUtooLintConfig } from '../config/utoo';
 import type { ILintArgs } from '../types';
 import BaseLinter from './base';
 
 /**
- * linter for drive eslint
+ * linter for JavaScript and TypeScript powered by utoo-lint
  */
 export default class Eslinter extends BaseLinter {
-  linter = 'eslint';
-
   getRunArgs(args: ILintArgs) {
-    return [
-      ...(args.quiet ? ['--quiet'] : []),
-      ...(args.fix ? ['--fix'] : []),
-      ...args._,
-    ];
+    return args._;
+  }
+
+  run(args: ILintArgs) {
+    const linter = new CLIEngine({
+      baseConfig: getUtooLintConfig(),
+      cwd: this.paths.cwd,
+      fix: args.fix,
+      quiet: args.quiet,
+    });
+    const report = linter.executeOnFiles(this.getRunArgs(args));
+
+    if (args.fix) {
+      CLIEngine.outputFixes(report);
+    }
+
+    const output = linter.getFormatter()(report.results);
+    if (output) {
+      process.stdout.write(`${output}\n`);
+    }
+
+    if (report.errorCount > 0) {
+      process.exitCode = 1;
+    }
   }
 }

--- a/packages/preset-umi/src/commands/lint.ts
+++ b/packages/preset-umi/src/commands/lint.ts
@@ -4,7 +4,7 @@ import { IApi } from '../types';
 export default (api: IApi) => {
   api.registerCommand({
     name: 'lint',
-    description: 'lint source code using eslint and stylelint',
+    description: 'lint source code using utoo-lint and stylelint',
     configResolveMode: 'loose',
     details: `
 umi lint
@@ -12,7 +12,7 @@ umi lint
 # lint for specific files, default is "{src,test}/**/*.{js,jsx,ts,tsx,less}"
 umi lint "**/*.{ts,scss}"
 
-# lint eslint-only or stylelint-only
+# lint JavaScript/TypeScript only or style files only
 umi lint --eslint-only
 umi lint --stylelint-only
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: workspace:*
         version: link:packages/utils
       '@utoo/lint':
-        specifier: 0.2.7
-        version: 0.2.7
+        specifier: 0.2.9
+        version: 0.2.9
       '@vercel/ncc':
         specifier: 0.44.1
         version: 0.44.1
@@ -2378,6 +2378,9 @@ importers:
       '@umijs/babel-preset-umi':
         specifier: workspace:*
         version: link:../babel-preset-umi
+      '@utoo/lint':
+        specifier: 0.2.9
+        version: 0.2.9
       eslint-plugin-jest:
         specifier: 27.2.3
         version: 27.2.3(@typescript-eslint/eslint-plugin@5.62.0)(@typescript/typescript6@6.0.2)(jest@29.7.0)
@@ -21951,59 +21954,53 @@ packages:
       react: 18.3.1
     dev: false
 
-  /@utoo/lint-darwin-arm64@0.2.7:
-    resolution: {integrity: sha512-PvAYD5GiQMSYrN9LTskdpWpTme8bLEQkImFjTs9gDmR9WsQhuRyFiOgXK38Q/R4t90vfSM7Kud4aUuI9iEvZoA==}
+  /@utoo/lint-darwin-arm64@0.2.9:
+    resolution: {integrity: sha512-IPVStMvHRj7xDfTgH4E030Ody5y82fGI6v+4AszTxov261tjZLKBBprdbQB6H3JljB+aLAobVRIzqM9DhWdjVw==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@utoo/lint-darwin-x64@0.2.7:
-    resolution: {integrity: sha512-q838A8hVZsGK4p6b0R4YO1PX5nkqZICZhYafP6DMI/Y0Pn5i2RQ00cmuq46Km7exnMwDUzHsYjZ35mCKeUOUIw==}
+  /@utoo/lint-darwin-x64@0.2.9:
+    resolution: {integrity: sha512-9kK6TTdFsygkSI/laszkEjjbJsHWphEkB5Q7fG8Yz6ts2jyNhen+vuVhpXlDov9TKO5bbK+CHbsRes6xtQjk0A==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@utoo/lint-linux-arm64@0.2.7:
-    resolution: {integrity: sha512-Qs0E01w0SE3IVawUgq3QPCY3VFBL0fSAw0QJEmj+dNzuBxerjMKOoFYLtb0HyWzTEAodiNWGthO717n2K1/h0A==}
+  /@utoo/lint-linux-arm64@0.2.9:
+    resolution: {integrity: sha512-LjG7LNQf7VVXIhleiWKt/tNn9Y7fxVjdQy9HtG8ng9bV6AjHQWe0HXmNPWPQCAc7CC06LLC0tlXRSHutDslF2g==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@utoo/lint-linux-x64@0.2.7:
-    resolution: {integrity: sha512-vjYEylaIP0Ndw+xx7rmS9bDc+pbabMgrxbnIw2Qam4JPwVrI2d2PNZByXkm7Q8oc7e+di4gGb32skSS2ylH4CA==}
+  /@utoo/lint-linux-x64@0.2.9:
+    resolution: {integrity: sha512-oS9Yz38rEFJw2sVYSFPkHT32SEjNm0cPgw0W8SeA/Pn1Rw269PpRJONBX1kR3HwmlOrN6STt+5zi9YWLyNoPsA==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@utoo/lint-win32-x64@0.2.7:
-    resolution: {integrity: sha512-7RuBwaRdbd55CY83j8A+YfW/tC1HrI8nViwJnr3SP4SAQOVGV4bUnOWlhDf5Pj0B5DZKzBDGPqv7IRnN46Df6A==}
+  /@utoo/lint-win32-x64@0.2.9:
+    resolution: {integrity: sha512-arTovHURrmyQE9zV2XX8b2nn6NZ/ASTKJPEFRG6eOFZZwk05J9eVtYlvjUDI8uHPefOrlFyg+UElft5fEc71uQ==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@utoo/lint@0.2.7:
-    resolution: {integrity: sha512-eL7fEQtd0zsmtmYNHHWqPeLD67u0j3GHQQOVSacKN8chX04rijYJze8FXLvWIsTnYAKzE/qb4DRx6Cthic1t6A==}
-    engines: {node: '>=18.0.0'}
+  /@utoo/lint@0.2.9:
+    resolution: {integrity: sha512-NsIAHxSxev4ASKn0fecz3oFNKvH5ic/ZvnkgzWEmYfL31290uVwoW48TvvrQ09McJ4NTAPE/hI2qKfb62yYmMQ==}
+    engines: {node: '>=20.0.0'}
     hasBin: true
     dependencies:
       jiti: 2.7.0
     optionalDependencies:
-      '@utoo/lint-darwin-arm64': 0.2.7
-      '@utoo/lint-darwin-x64': 0.2.7
-      '@utoo/lint-linux-arm64': 0.2.7
-      '@utoo/lint-linux-x64': 0.2.7
-      '@utoo/lint-win32-x64': 0.2.7
-    dev: true
+      '@utoo/lint-darwin-arm64': 0.2.9
+      '@utoo/lint-darwin-x64': 0.2.9
+      '@utoo/lint-linux-arm64': 0.2.9
+      '@utoo/lint-linux-x64': 0.2.9
+      '@utoo/lint-win32-x64': 0.2.9
 
   /@utoo/pack-darwin-arm64@1.4.22:
     resolution: {integrity: sha512-DJCCx/tekQ0dKxTJhIf5BY7l9uR6cuPqHB8RpulEEPWgvWUX7SpY472QlK7Y4uz8J7HqcvZ2eNRk156y737zyw==}


### PR DESCRIPTION
## Summary

- replace the JavaScript/TypeScript runner used by `umi lint` with `@utoo/lint@0.2.9`
- preserve the existing Stylelint flow and standalone `umi/eslint` compatibility exports
- translate the existing Umi recommended rules into scoped Utoo configs for base, TypeScript, and Jest files
- preserve `--quiet`, `--fix`, exit codes, and project overrides through `utlint.config.json`
- update the lint command help and Chinese/English documentation

`--eslint-only` is retained for CLI compatibility and now selects the Utoo-powered JavaScript/TypeScript path. Rules that are not available in Utoo yet are filtered from the built-in config; this currently affects the Jest rules and `react/no-direct-mutation-state`.

## Test plan

- `pnpm jest packages/lint/src/config/utoo/index.test.ts packages/lint/src/linter/eslint.test.ts --runInBand`
- `pnpm --filter @umijs/lint build`
- `pnpm lint`
- `pnpm --filter ./examples/lint exec umi lint --eslint-only`
- `pnpm --filter ./examples/lint exec umi lint --stylelint-only`
- `pnpm --filter ./examples/lint exec umi lint`
- package tarball inspection confirms the Utoo config, runner, and runtime dependency are published