### PR TITLE
dep(lint): upgrade @utoo/lint to 0.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@umijs/plugins": "workspace:*",
     "@umijs/server": "workspace:*",
     "@umijs/utils": "workspace:*",
-    "@utoo/lint": "0.2.9",
+    "@utoo/lint": "0.3.4",
     "@vercel/ncc": "0.44.1",
     "browserslist": "4.28.2",
     "dts-packer": "^0.0.3",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -28,7 +28,7 @@
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "@umijs/babel-preset-umi": "workspace:*",
-    "@utoo/lint": "0.2.9",
+    "@utoo/lint": "0.3.4",
     "eslint-plugin-jest": "27.2.3",
     "eslint-plugin-react": "7.33.2",
     "eslint-plugin-react-hooks": "4.6.0",

--- a/packages/lint/src/config/utoo/index.test.ts
+++ b/packages/lint/src/config/utoo/index.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { basename, join } from 'path';
 import { getUtooLintConfig } from '.';
+import { jestRules } from '../eslint/rules/recommended';
 
 describe('utoo-lint config', () => {
   const projects: string[] = [];
@@ -39,21 +40,68 @@ describe('utoo-lint config', () => {
     ]);
   });
 
-  it('maps equivalent rules and omits unsupported rules', () => {
+  it('runs the newly supported React and Jest rules', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'umi-utoo-lint-'));
+    projects.push(cwd);
+    mkdirSync(join(cwd, 'src'));
+    writeFileSync(
+      join(cwd, 'src/component.jsx'),
+      [
+        `import React from 'react';`,
+        'class Component extends React.Component {',
+        '  method() { this.state.value = 1; }',
+        '  render() { return null; }',
+        '}',
+      ].join('\n'),
+    );
+    writeFileSync(
+      join(cwd, 'src/example.test.js'),
+      `describe.only('suite', () => {});\n`,
+    );
+
+    const results = await new ESLint({
+      baseConfig: getUtooLintConfig(),
+      cwd,
+      noConfig: true,
+    }).lintFiles(['src']);
+    const messages = Object.fromEntries(
+      results.map((result) => [
+        basename(result.filePath),
+        result.messages.map((message) => message.ruleId),
+      ]),
+    );
+
+    expect(messages['component.jsx']).toEqual([
+      'react/no-direct-mutation-state',
+    ]);
+    expect(messages['example.test.js']).toEqual(['jest/no-focused-tests']);
+  });
+
+  it('maps equivalent rules and enables the full recommended rule set', () => {
     const [recommended, typescript, jest] = getUtooLintConfig();
 
     expect(recommended.rules).toMatchObject({
       'no-global-assign': 2,
       'no-var': 2,
+      'react/no-direct-mutation-state': 2,
     });
     expect(recommended.rules).not.toHaveProperty('no-native-reassign');
-    expect(recommended.rules).not.toHaveProperty(
-      'react/no-direct-mutation-state',
-    );
+    expect(typescript.rules).toMatchObject({
+      'no-invalid-this': 2,
+      '@typescript-eslint/no-unused-vars': 2,
+    });
     expect(typescript.rules).not.toHaveProperty(
       '@typescript-eslint/no-invalid-this',
     );
-    expect(jest.rules).not.toHaveProperty('jest/no-focused-tests');
+    expect(jest.rules).toMatchObject({
+      'jest/no-conditional-expect': 2,
+      'jest/no-focused-tests': 2,
+      'jest/valid-expect': 2,
+      'jest/valid-title': 2,
+    });
+    expect(Object.keys(jest.rules!)).toHaveLength(
+      Object.keys(jestRules).length,
+    );
   });
 
   it('allows project config to override the built-in rules', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: workspace:*
         version: link:packages/utils
       '@utoo/lint':
-        specifier: 0.2.9
-        version: 0.2.9
+        specifier: 0.3.4
+        version: 0.3.4
       '@vercel/ncc':
         specifier: 0.44.1
         version: 0.44.1
@@ -2374,8 +2374,8 @@ importers:
         specifier: workspace:*
         version: link:../babel-preset-umi
       '@utoo/lint':
-        specifier: 0.2.9
-        version: 0.2.9
+        specifier: 0.3.4
+        version: 0.3.4
       eslint-plugin-jest:
         specifier: 27.2.3
         version: 27.2.3(@typescript-eslint/eslint-plugin@5.62.0)(@typescript/typescript6@6.0.2)(jest@29.7.0)
@@ -14229,8 +14229,28 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@eslint/eslintrc@2.1.4:
+    resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.3.4(supports-color@8.1.1)
+      espree: 9.6.1
+      globals: 13.19.0
+      ignore: 5.2.4
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   /@eslint/js@8.35.0:
     resolution: {integrity: sha512-JXdzbRiWclLVoD8sNUjR443VVlYqiYmDVT6rGUEIEHU5YJW0gaVZwV2xgM7D4arkvASqD0IlLUVjHiFuxaftRw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  /@eslint/js@8.57.1:
+    resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   /@exodus/schemasafe@1.0.0-rc.9:
@@ -21940,53 +21960,57 @@ packages:
       react: 18.3.1
     dev: false
 
-  /@utoo/lint-darwin-arm64@0.2.9:
-    resolution: {integrity: sha512-IPVStMvHRj7xDfTgH4E030Ody5y82fGI6v+4AszTxov261tjZLKBBprdbQB6H3JljB+aLAobVRIzqM9DhWdjVw==}
+  /@utoo/lint-darwin-arm64@0.3.4:
+    resolution: {integrity: sha512-s4o88c0IJBMNABgTRvz9nanR8xJUJldwZnbgdupIrn1pBeu+im0k9npdsTYrbsMJKYYFbaKpmCOGNReLG12dMw==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     optional: true
 
-  /@utoo/lint-darwin-x64@0.2.9:
-    resolution: {integrity: sha512-9kK6TTdFsygkSI/laszkEjjbJsHWphEkB5Q7fG8Yz6ts2jyNhen+vuVhpXlDov9TKO5bbK+CHbsRes6xtQjk0A==}
+  /@utoo/lint-darwin-x64@0.3.4:
+    resolution: {integrity: sha512-xZ9Xxi1PuffvKkVhRvtZGAP8FM4Phk9O8rRF1Ai4CWZPpH8FKjhsp0O78LB68pjQgPVzjBNmcPGIOlkcIP37qQ==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     optional: true
 
-  /@utoo/lint-linux-arm64@0.2.9:
-    resolution: {integrity: sha512-LjG7LNQf7VVXIhleiWKt/tNn9Y7fxVjdQy9HtG8ng9bV6AjHQWe0HXmNPWPQCAc7CC06LLC0tlXRSHutDslF2g==}
+  /@utoo/lint-linux-arm64@0.3.4:
+    resolution: {integrity: sha512-ATmEjnKyuDAj1Lc3E6YdZGuUmrV6ucCZhPf5UOdffrESNqtj9lOVJAg8tN6/CDf+fWkAt6mudCRi0Ocp71P8vw==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@utoo/lint-linux-x64@0.2.9:
-    resolution: {integrity: sha512-oS9Yz38rEFJw2sVYSFPkHT32SEjNm0cPgw0W8SeA/Pn1Rw269PpRJONBX1kR3HwmlOrN6STt+5zi9YWLyNoPsA==}
+  /@utoo/lint-linux-x64@0.3.4:
+    resolution: {integrity: sha512-2QHT/k8pDK9qRG+r2JRDiZfi3iL61CeS10CptqVZZs38bY2hNfcDp19jA5rTIlOJGeufqhz9djKbntq68nGM3g==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@utoo/lint-win32-x64@0.2.9:
-    resolution: {integrity: sha512-arTovHURrmyQE9zV2XX8b2nn6NZ/ASTKJPEFRG6eOFZZwk05J9eVtYlvjUDI8uHPefOrlFyg+UElft5fEc71uQ==}
+  /@utoo/lint-win32-x64@0.3.4:
+    resolution: {integrity: sha512-gGpWBwghGYQsGKAKUjZVF2gDxG7A1n5EMuf7x6dc3HEMISCq1X4MhsnNzzrZwBZ3Sud2D/kDbSfIIgqHg7cWkg==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     optional: true
 
-  /@utoo/lint@0.2.9:
-    resolution: {integrity: sha512-NsIAHxSxev4ASKn0fecz3oFNKvH5ic/ZvnkgzWEmYfL31290uVwoW48TvvrQ09McJ4NTAPE/hI2qKfb62yYmMQ==}
+  /@utoo/lint@0.3.4:
+    resolution: {integrity: sha512-56aj4u+ESKxGFoHUhEKQNjr59s0U5R+qEMkV/MjsI8gz64I9ieDObJ9FLWVAii/8YTNE1fC/h5yjqKKhR4aVOA==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     dependencies:
+      '@eslint/eslintrc': 2.1.4
+      '@eslint/js': 8.57.1
       jiti: 2.7.0
     optionalDependencies:
-      '@utoo/lint-darwin-arm64': 0.2.9
-      '@utoo/lint-darwin-x64': 0.2.9
-      '@utoo/lint-linux-arm64': 0.2.9
-      '@utoo/lint-linux-x64': 0.2.9
-      '@utoo/lint-win32-x64': 0.2.9
+      '@utoo/lint-darwin-arm64': 0.3.4
+      '@utoo/lint-darwin-x64': 0.3.4
+      '@utoo/lint-linux-arm64': 0.3.4
+      '@utoo/lint-linux-x64': 0.3.4
+      '@utoo/lint-win32-x64': 0.3.4
+    transitivePeerDependencies:
+      - supports-color
 
   /@utoo/pack-darwin-arm64@1.4.22:
     resolution: {integrity: sha512-DJCCx/tekQ0dKxTJhIf5BY7l9uR6cuPqHB8RpulEEPWgvWUX7SpY472QlK7Y4uz8J7HqcvZ2eNRk156y737zyw==}
@@ -23115,6 +23139,13 @@ packages:
     dependencies:
       acorn: 8.11.2
     dev: true
+
+  /acorn-jsx@5.3.2(acorn@8.17.0):
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      acorn: 8.17.0
 
   /acorn-jsx@5.3.2(acorn@8.8.2):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -30202,6 +30233,14 @@ packages:
       acorn: 8.8.2
       acorn-jsx: 5.3.2(acorn@8.8.2)
       eslint-visitor-keys: 3.4.1
+
+  /espree@9.6.1:
+    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 3.4.3
 
   /esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}


### PR DESCRIPTION
## Summary

- upgrade @utoo/lint from 0.2.9 to 0.3.4 in the root workspace and @umijs/lint
- lock all five native platform packages and the new ESLint migration dependencies
- update Umi rule coverage assertions and add behavioral coverage for the newly supported React and Jest rules
- verify all 78 current Umi recommended rules are supported

Upstream release workflow: https://github.com/utooland/utoo-lint/actions/runs/33649145272

## Verification

- pnpm install --frozen-lockfile --prefer-offline
- pnpm --filter umi... build
- pnpm jest packages/lint/src/config/utoo/index.test.ts packages/lint/src/linter/eslint.test.ts --runInBand
- pnpm lint (0 errors; 9 existing warnings)