### PR TITLE
fix(bundler-webpack): disable CommonJS concatenation by default

### DIFF
--- a/packages/bundler-webpack/src/config/config.ts
+++ b/packages/bundler-webpack/src/config/config.ts
@@ -97,6 +97,12 @@ export async function getConfig(opts: IOpts): Promise<Configuration> {
   config.mode(opts.env);
   config.stats('none');
 
+  // Webpack 5.109+ may change the execution order of circular dependencies
+  // when concatenating CommonJS modules. Keep ESM concatenation enabled.
+  if (!isDev) {
+    config.optimization.concatenateModules({ commonjs: false });
+  }
+
   // entry
   Object.keys(opts.entry).forEach((key) => {
     const entry = config.entry(key);


### PR DESCRIPTION
## Summary

- disable Webpack CommonJS module concatenation for production builds
- keep ESM module concatenation enabled and leave development behavior unchanged
- apply the default before `chainWebpack` so projects can explicitly override it

## Background

Webpack 5.109+ enables concatenation for statically analyzable CommonJS modules. In circular dependency graphs this can change module initialization order and cause runtime failures such as `Super expression must either be null or a function`.

## Verification

- `pnpm --filter @umijs/bundler-webpack build`
- `pnpm exec prettier --check packages/bundler-webpack/src/config/config.ts`
- verified generated production config is `{ commonjs: false }` and development config remains unset
- verified the affected `bench-next` production bundle passes module initialization with this option

No new test fixture is included in this change.