### PR TITLE
fix(bundler-webpack): keep unused import warnings non-fatal

### DIFF
--- a/packages/bundler-webpack/src/config/harmonyLinkingErrorPlugin.ts
+++ b/packages/bundler-webpack/src/config/harmonyLinkingErrorPlugin.ts
@@ -1,6 +1,6 @@
 import type {
-  Compiler,
   Compilation,
+  Compiler,
   NormalModule,
 } from '@umijs/bundler-webpack/compiled/webpack';
 import Config from '@umijs/bundler-webpack/compiled/webpack-5-chain';
@@ -13,6 +13,21 @@ interface IOpts {
 const LINKING_ERROR_TAG = 'was not found in';
 // build 时会出现 css modules 的引用警告，但这应该是需要忽略的
 const CSS_NO_EXPORTS = /\.(css|sass|scss|styl|less)' \(module has no exports\)/;
+
+// webpack >= 5.110.2 checks missing specifiers even when their bindings are
+// never read. Keep those as warnings because they do not affect emitted code.
+function isUnusedSpecifierWarning(
+  warning: Compilation['warnings'][number],
+): boolean {
+  const warningModule = warning.module as NormalModule;
+  return warningModule.dependencies.some((dependency) => {
+    return (
+      dependency.loc === warning.loc &&
+      'unusedSpecifiers' in dependency &&
+      dependency.unusedSpecifiers !== undefined
+    );
+  });
+}
 
 class HarmonyLinkingErrorPlugin {
   apply(compiler: Compiler) {
@@ -27,7 +42,8 @@ class HarmonyLinkingErrorPlugin {
             w.name === 'ModuleDependencyWarning' &&
             !(w.module as NormalModule).resource.includes('node_modules') &&
             w.message.includes(LINKING_ERROR_TAG) &&
-            !CSS_NO_EXPORTS.test(w.message)
+            !CSS_NO_EXPORTS.test(w.message) &&
+            !isUnusedSpecifierWarning(w)
           );
         });
         if (!harmonyLinkingErrors.length) {


### PR DESCRIPTION
## Summary

- keep Webpack 5.110.2+ unused missing-import diagnostics as warnings
- continue promoting genuinely referenced missing exports to build errors
- preserve the existing CSS modules exception

Webpack 5.110.2 started reporting missing import specifiers even when the binding is never referenced (webpack/webpack#21856). The emitted module graph and code are unchanged, but Umi's `HarmonyLinkingErrorPlugin` promoted the new warning to an error and broke previously buildable applications.

## Verification

- `pnpm --filter @umijs/bundler-webpack build`
- `pnpm jest packages/bundler-webpack/src/build.test.ts --runInBand`
- verified unchanged `oasecview` source builds with Webpack 5.110.3
- verified unchanged `juchuanwaitou` source builds with Webpack 5.110.3
- verified a referenced missing export remains a build error

Upstream change: https://github.com/webpack/webpack/pull/21856
